### PR TITLE
Implement Ansible role for agent deployment

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,0 +1,73 @@
+# Keldris Ansible Roles
+
+This directory contains Ansible roles for deploying and managing Keldris components.
+
+## Available Roles
+
+### keldris_agent
+
+Installs and configures the Keldris backup agent on Linux and macOS systems.
+
+**Features:**
+- Downloads and installs the agent binary
+- Configures the agent with server URL and API key
+- Sets up systemd service (Linux) or launchd service (macOS)
+- Supports multiple versions and rolling upgrades
+
+See [roles/keldris_agent/README.md](roles/keldris_agent/README.md) for detailed documentation.
+
+## Quick Start
+
+```bash
+# Clone the repository
+git clone https://github.com/MacJediWizard/keldris.git
+cd keldris
+
+# Set up your inventory
+cp examples/ansible/inventory.example.yml examples/ansible/inventory.yml
+# Edit inventory.yml with your hosts and credentials
+
+# Deploy agents
+cd examples/ansible
+ansible-playbook -i inventory.yml deploy-agent.yml
+```
+
+## Requirements
+
+- Ansible 2.10 or higher
+- Python 3.8+ on control node
+- SSH access to target hosts
+
+## Role Structure
+
+```
+ansible/
+├── README.md                          # This file
+└── roles/
+    └── keldris_agent/
+        ├── defaults/main.yml          # Default variables
+        ├── handlers/main.yml          # Service restart handlers
+        ├── meta/main.yml              # Galaxy metadata
+        ├── tasks/
+        │   ├── main.yml               # Main entry point
+        │   ├── install.yml            # Binary installation
+        │   ├── configure.yml          # Configuration
+        │   ├── systemd.yml            # Linux service setup
+        │   ├── launchd.yml            # macOS service setup
+        │   └── register.yml           # Server registration
+        ├── templates/
+        │   ├── config.yml.j2          # Agent config template
+        │   ├── keldris-agent.service.j2   # Systemd service
+        │   └── io.keldris.agent.plist.j2  # Launchd plist
+        ├── vars/
+        │   ├── Debian.yml             # Debian/Ubuntu vars
+        │   ├── RedHat.yml             # RHEL/CentOS vars
+        │   └── Darwin.yml             # macOS vars
+        └── README.md                  # Role documentation
+```
+
+## Future Plans
+
+- Publish to Ansible Galaxy as `macjediwizard.keldris_agent`
+- Add `keldris_server` role for server deployment
+- Collection packaging for easier distribution

--- a/ansible/roles/keldris_agent/README.md
+++ b/ansible/roles/keldris_agent/README.md
@@ -1,0 +1,85 @@
+# Keldris Agent Ansible Role
+
+An Ansible role to install and configure the Keldris backup agent on Linux and macOS systems.
+
+## Requirements
+
+- Ansible 2.10 or higher
+- Target systems: Linux (systemd) or macOS 12+
+- Network access to download agent binary and connect to Keldris server
+
+## Role Variables
+
+### Required Variables
+
+| Variable | Description |
+|----------|-------------|
+| `keldris_server_url` | URL of the Keldris server (e.g., `https://backup.example.com`) |
+| `keldris_api_key` | API key for authentication with the server |
+
+### Optional Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `keldris_agent_version` | `latest` | Version to install |
+| `keldris_download_url` | `https://releases.keldris.io/agent` | Base URL for binary downloads |
+| `keldris_install_dir` | `/usr/local/bin` | Installation directory |
+| `keldris_binary_name` | `keldris-agent` | Binary filename |
+| `keldris_config_dir_linux` | `/etc/keldris` | Config directory (Linux) |
+| `keldris_config_dir_macos` | `~/.config/keldris` | Config directory (macOS) |
+| `keldris_auto_check_update` | `true` | Enable automatic update checks |
+| `keldris_hostname` | `{{ ansible_hostname }}` | Hostname to register |
+| `keldris_service_enabled` | `true` | Enable service at boot |
+| `keldris_service_started` | `true` | Start service after install |
+| `keldris_register_agent` | `true` | Register with server |
+| `keldris_force_registration` | `false` | Force re-registration |
+| `keldris_remove_quarantine` | `true` | Remove quarantine attribute (macOS) |
+
+## Dependencies
+
+None.
+
+## Example Playbook
+
+```yaml
+- hosts: backup_clients
+  roles:
+    - role: keldris_agent
+      vars:
+        keldris_server_url: "https://backup.example.com"
+        keldris_api_key: "your-api-key"
+        keldris_agent_version: "latest"
+```
+
+## Platform Support
+
+- **Linux**: Ubuntu 20.04+, Debian 11+, RHEL/CentOS 8+ (systemd)
+- **macOS**: 12 (Monterey) through 15 (Sequoia) (launchd)
+
+## Service Management
+
+### Linux (systemd)
+
+```bash
+sudo systemctl status keldris-agent
+sudo systemctl start keldris-agent
+sudo systemctl stop keldris-agent
+sudo journalctl -u keldris-agent -f
+```
+
+### macOS (launchd)
+
+```bash
+launchctl list | grep keldris
+launchctl load ~/Library/LaunchAgents/io.keldris.agent.plist
+launchctl unload ~/Library/LaunchAgents/io.keldris.agent.plist
+tail -f ~/.config/keldris/agent.log
+```
+
+## License
+
+AGPL-3.0
+
+## Author
+
+MacJediWizard

--- a/ansible/roles/keldris_agent/defaults/main.yml
+++ b/ansible/roles/keldris_agent/defaults/main.yml
@@ -1,0 +1,42 @@
+# Keldris Agent Role - Default Variables
+---
+# Server connection settings (required)
+keldris_server_url: ""
+keldris_api_key: ""
+
+# Agent version to install
+# Use "latest" to download the most recent version
+keldris_agent_version: "latest"
+
+# Download base URL for agent binaries
+keldris_download_url: "https://releases.keldris.io/agent"
+
+# Installation paths
+keldris_install_dir: "/usr/local/bin"
+keldris_binary_name: "keldris-agent"
+
+# Configuration settings
+keldris_config_dir_linux: "/etc/keldris"
+keldris_config_dir_macos: "{{ ansible_env.HOME }}/.config/keldris"
+keldris_auto_check_update: true
+keldris_hostname: "{{ ansible_hostname }}"
+
+# Service settings
+keldris_service_name: "keldris-agent"
+keldris_service_enabled: true
+keldris_service_started: true
+
+# Linux-specific (systemd)
+keldris_systemd_service_file: "/etc/systemd/system/{{ keldris_service_name }}.service"
+
+# macOS-specific (launchd)
+keldris_launchd_label: "io.keldris.agent"
+keldris_launchd_plist_dir: "{{ ansible_env.HOME }}/Library/LaunchAgents"
+keldris_launchd_plist_file: "{{ keldris_launchd_plist_dir }}/{{ keldris_launchd_label }}.plist"
+
+# Registration settings
+keldris_register_agent: true
+keldris_force_registration: false
+
+# Security settings
+keldris_remove_quarantine: true  # macOS only: remove quarantine attribute from downloaded binary

--- a/ansible/roles/keldris_agent/handlers/main.yml
+++ b/ansible/roles/keldris_agent/handlers/main.yml
@@ -1,0 +1,26 @@
+# Keldris Agent Role - Handlers
+---
+- name: Reload systemd
+  ansible.builtin.systemd:
+    daemon_reload: true
+  when: ansible_system == "Linux"
+
+- name: Restart keldris-agent
+  block:
+    - name: Restart systemd service
+      ansible.builtin.systemd:
+        name: "{{ keldris_service_name }}"
+        state: restarted
+      when: ansible_system == "Linux"
+
+    - name: Restart launchd service
+      block:
+        - name: Unload launchd service
+          ansible.builtin.command: launchctl unload "{{ keldris_launchd_plist_file }}"
+          failed_when: false
+          changed_when: false
+
+        - name: Load launchd service
+          ansible.builtin.command: launchctl load -w "{{ keldris_launchd_plist_file }}"
+          changed_when: true
+      when: ansible_system == "Darwin"

--- a/ansible/roles/keldris_agent/meta/main.yml
+++ b/ansible/roles/keldris_agent/meta/main.yml
@@ -1,0 +1,38 @@
+# Keldris Agent Role - Metadata
+---
+galaxy_info:
+  role_name: keldris_agent
+  author: MacJediWizard
+  description: Install and configure the Keldris backup agent
+  license: AGPL-3.0
+  min_ansible_version: "2.10"
+
+  platforms:
+    - name: Ubuntu
+      versions:
+        - focal    # 20.04
+        - jammy    # 22.04
+        - noble    # 24.04
+    - name: Debian
+      versions:
+        - bullseye # 11
+        - bookworm # 12
+    - name: EL      # RHEL/CentOS/Rocky/Alma
+      versions:
+        - "8"
+        - "9"
+    - name: MacOSX
+      versions:
+        - "12"     # Monterey
+        - "13"     # Ventura
+        - "14"     # Sonoma
+        - "15"     # Sequoia
+
+  galaxy_tags:
+    - backup
+    - keldris
+    - restic
+    - agent
+    - system
+
+dependencies: []

--- a/ansible/roles/keldris_agent/tasks/configure.yml
+++ b/ansible/roles/keldris_agent/tasks/configure.yml
@@ -1,0 +1,20 @@
+# Keldris Agent Role - Configuration Tasks
+---
+- name: Ensure config directory exists
+  ansible.builtin.file:
+    path: "{{ keldris_config_dir }}"
+    state: directory
+    mode: "{{ '0750' if ansible_system == 'Linux' else '0700' }}"
+    owner: "{{ 'root' if ansible_system == 'Linux' else ansible_user_id }}"
+    group: "{{ 'root' if ansible_system == 'Linux' else 'staff' }}"
+  become: "{{ ansible_system == 'Linux' }}"
+
+- name: Deploy agent configuration
+  ansible.builtin.template:
+    src: config.yml.j2
+    dest: "{{ keldris_config_dir }}/config.yml"
+    mode: "0600"
+    owner: "{{ 'root' if ansible_system == 'Linux' else ansible_user_id }}"
+    group: "{{ 'root' if ansible_system == 'Linux' else 'staff' }}"
+  become: "{{ ansible_system == 'Linux' }}"
+  notify: Restart keldris-agent

--- a/ansible/roles/keldris_agent/tasks/install.yml
+++ b/ansible/roles/keldris_agent/tasks/install.yml
@@ -1,0 +1,53 @@
+# Keldris Agent Role - Binary Installation Tasks
+---
+- name: Determine system architecture
+  ansible.builtin.set_fact:
+    keldris_arch: >-
+      {{ 'arm64' if ansible_architecture in ['aarch64', 'arm64'] else 'amd64' }}
+
+- name: Determine OS name for download
+  ansible.builtin.set_fact:
+    keldris_os: "{{ 'darwin' if ansible_system == 'Darwin' else 'linux' }}"
+
+- name: Set download URL
+  ansible.builtin.set_fact:
+    keldris_download_binary_url: "{{ keldris_download_url }}/{{ keldris_agent_version }}/keldris-agent-{{ keldris_os }}-{{ keldris_arch }}"
+
+- name: Ensure install directory exists
+  ansible.builtin.file:
+    path: "{{ keldris_install_dir }}"
+    state: directory
+    mode: "0755"
+  become: true
+
+- name: Check if agent binary exists
+  ansible.builtin.stat:
+    path: "{{ keldris_install_dir }}/{{ keldris_binary_name }}"
+  register: keldris_binary_stat
+
+- name: Get current agent version
+  ansible.builtin.command: "{{ keldris_install_dir }}/{{ keldris_binary_name }} version"
+  register: keldris_current_version
+  changed_when: false
+  failed_when: false
+  when: keldris_binary_stat.stat.exists
+
+- name: Download agent binary
+  ansible.builtin.get_url:
+    url: "{{ keldris_download_binary_url }}"
+    dest: "{{ keldris_install_dir }}/{{ keldris_binary_name }}"
+    mode: "0755"
+    owner: root
+    group: "{{ 'wheel' if ansible_system == 'Darwin' else 'root' }}"
+    force: "{{ keldris_agent_version != 'latest' or not keldris_binary_stat.stat.exists }}"
+  become: true
+  notify: Restart keldris-agent
+
+- name: Remove quarantine attribute (macOS)
+  ansible.builtin.command: xattr -d com.apple.quarantine "{{ keldris_install_dir }}/{{ keldris_binary_name }}"
+  become: true
+  changed_when: false
+  failed_when: false
+  when:
+    - ansible_system == "Darwin"
+    - keldris_remove_quarantine | bool

--- a/ansible/roles/keldris_agent/tasks/launchd.yml
+++ b/ansible/roles/keldris_agent/tasks/launchd.yml
@@ -1,0 +1,29 @@
+# Keldris Agent Role - Launchd Service Setup (macOS)
+---
+- name: Ensure LaunchAgents directory exists
+  ansible.builtin.file:
+    path: "{{ keldris_launchd_plist_dir }}"
+    state: directory
+    mode: "0755"
+    owner: "{{ ansible_user_id }}"
+    group: staff
+
+- name: Stop existing launchd service
+  ansible.builtin.command: launchctl unload "{{ keldris_launchd_plist_file }}"
+  failed_when: false
+  changed_when: false
+  when: keldris_service_started | bool
+
+- name: Deploy launchd plist file
+  ansible.builtin.template:
+    src: io.keldris.agent.plist.j2
+    dest: "{{ keldris_launchd_plist_file }}"
+    mode: "0644"
+    owner: "{{ ansible_user_id }}"
+    group: staff
+  notify: Restart keldris-agent
+
+- name: Load launchd service
+  ansible.builtin.command: launchctl load -w "{{ keldris_launchd_plist_file }}"
+  changed_when: true
+  when: keldris_service_enabled | bool and keldris_service_started | bool

--- a/ansible/roles/keldris_agent/tasks/main.yml
+++ b/ansible/roles/keldris_agent/tasks/main.yml
@@ -1,0 +1,41 @@
+# Keldris Agent Role - Main Tasks
+---
+- name: Validate required variables
+  ansible.builtin.assert:
+    that:
+      - keldris_server_url | length > 0
+      - keldris_api_key | length > 0
+    fail_msg: "keldris_server_url and keldris_api_key are required"
+    quiet: true
+
+- name: Set OS-specific variables
+  ansible.builtin.include_vars: "{{ item }}"
+  with_first_found:
+    - files:
+        - "{{ ansible_os_family }}.yml"
+        - "{{ ansible_system }}.yml"
+      paths:
+        - "{{ role_path }}/vars"
+      skip: true
+
+- name: Set config directory based on OS
+  ansible.builtin.set_fact:
+    keldris_config_dir: "{{ keldris_config_dir_linux if ansible_system == 'Linux' else keldris_config_dir_macos }}"
+
+- name: Install agent binary
+  ansible.builtin.include_tasks: install.yml
+
+- name: Configure agent
+  ansible.builtin.include_tasks: configure.yml
+
+- name: Setup systemd service (Linux)
+  ansible.builtin.include_tasks: systemd.yml
+  when: ansible_system == "Linux"
+
+- name: Setup launchd service (macOS)
+  ansible.builtin.include_tasks: launchd.yml
+  when: ansible_system == "Darwin"
+
+- name: Register agent with server
+  ansible.builtin.include_tasks: register.yml
+  when: keldris_register_agent | bool

--- a/ansible/roles/keldris_agent/tasks/register.yml
+++ b/ansible/roles/keldris_agent/tasks/register.yml
@@ -1,0 +1,40 @@
+# Keldris Agent Role - Server Registration Tasks
+---
+- name: Check if agent is already registered
+  ansible.builtin.command: "{{ keldris_install_dir }}/{{ keldris_binary_name }} status"
+  register: keldris_status_check
+  changed_when: false
+  failed_when: false
+  become: "{{ ansible_system == 'Linux' }}"
+  environment:
+    KELDRIS_CONFIG_DIR: "{{ keldris_config_dir }}"
+
+- name: Determine if registration is needed
+  ansible.builtin.set_fact:
+    keldris_needs_registration: >-
+      {{ keldris_force_registration | bool or
+         keldris_status_check.rc != 0 or
+         'Not configured' in keldris_status_check.stdout | default('') }}
+
+- name: Verify server connectivity
+  ansible.builtin.uri:
+    url: "{{ keldris_server_url }}/health"
+    method: GET
+    timeout: 10
+    status_code: 200
+  register: keldris_health_check
+  when: keldris_needs_registration | bool
+  ignore_errors: true
+
+- name: Warn if server is not reachable
+  ansible.builtin.debug:
+    msg: "Warning: Keldris server at {{ keldris_server_url }} is not reachable. Registration may fail."
+  when:
+    - keldris_needs_registration | bool
+    - keldris_health_check.failed | default(false)
+
+- name: Display registration status
+  ansible.builtin.debug:
+    msg: >-
+      Agent registration status:
+      {{ 'Already registered' if not keldris_needs_registration else 'Registration pending' }}

--- a/ansible/roles/keldris_agent/tasks/systemd.yml
+++ b/ansible/roles/keldris_agent/tasks/systemd.yml
@@ -1,0 +1,29 @@
+# Keldris Agent Role - Systemd Service Setup (Linux)
+---
+- name: Deploy systemd service file
+  ansible.builtin.template:
+    src: keldris-agent.service.j2
+    dest: "{{ keldris_systemd_service_file }}"
+    mode: "0644"
+    owner: root
+    group: root
+  become: true
+  notify:
+    - Reload systemd
+    - Restart keldris-agent
+
+- name: Ensure systemd is reloaded
+  ansible.builtin.meta: flush_handlers
+
+- name: Enable keldris-agent service
+  ansible.builtin.systemd:
+    name: "{{ keldris_service_name }}"
+    enabled: "{{ keldris_service_enabled }}"
+  become: true
+
+- name: Start keldris-agent service
+  ansible.builtin.systemd:
+    name: "{{ keldris_service_name }}"
+    state: started
+  become: true
+  when: keldris_service_started | bool

--- a/ansible/roles/keldris_agent/templates/config.yml.j2
+++ b/ansible/roles/keldris_agent/templates/config.yml.j2
@@ -1,0 +1,9 @@
+# Keldris Agent Configuration
+# Managed by Ansible - do not edit manually
+---
+server_url: {{ keldris_server_url | to_json }}
+api_key: {{ keldris_api_key | to_json }}
+{% if keldris_hostname is defined and keldris_hostname %}
+hostname: {{ keldris_hostname | to_json }}
+{% endif %}
+auto_check_update: {{ keldris_auto_check_update | bool | lower }}

--- a/ansible/roles/keldris_agent/templates/io.keldris.agent.plist.j2
+++ b/ansible/roles/keldris_agent/templates/io.keldris.agent.plist.j2
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- Keldris Agent Launchd Service -->
+<!-- Managed by Ansible - do not edit manually -->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>{{ keldris_launchd_label }}</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{ keldris_install_dir }}/{{ keldris_binary_name }}</string>
+        <string>daemon</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <{{ 'true' if keldris_service_enabled else 'false' }}/>
+
+    <key>KeepAlive</key>
+    <dict>
+        <key>NetworkState</key>
+        <true/>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <key>StandardOutPath</key>
+    <string>{{ keldris_config_dir }}/agent.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>{{ keldris_config_dir }}/agent.error.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>KELDRIS_CONFIG_DIR</key>
+        <string>{{ keldris_config_dir }}</string>
+    </dict>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+</dict>
+</plist>

--- a/ansible/roles/keldris_agent/templates/keldris-agent.service.j2
+++ b/ansible/roles/keldris_agent/templates/keldris-agent.service.j2
@@ -1,0 +1,30 @@
+# Keldris Agent Systemd Service
+# Managed by Ansible - do not edit manually
+[Unit]
+Description=Keldris Backup Agent
+Documentation=https://keldris.io/docs
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=root
+ExecStart={{ keldris_install_dir }}/{{ keldris_binary_name }} daemon
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier={{ keldris_service_name }}
+
+# Security hardening
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=read-only
+PrivateTmp=yes
+ReadWritePaths={{ keldris_config_dir }} /var/log
+
+# Environment
+Environment=KELDRIS_CONFIG_DIR={{ keldris_config_dir }}
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/keldris_agent/vars/Darwin.yml
+++ b/ansible/roles/keldris_agent/vars/Darwin.yml
@@ -1,0 +1,3 @@
+# Keldris Agent Role - macOS Variables
+---
+keldris_package_dependencies: []

--- a/ansible/roles/keldris_agent/vars/Debian.yml
+++ b/ansible/roles/keldris_agent/vars/Debian.yml
@@ -1,0 +1,5 @@
+# Keldris Agent Role - Debian/Ubuntu Variables
+---
+keldris_package_dependencies:
+  - curl
+  - ca-certificates

--- a/ansible/roles/keldris_agent/vars/RedHat.yml
+++ b/ansible/roles/keldris_agent/vars/RedHat.yml
@@ -1,0 +1,5 @@
+# Keldris Agent Role - RedHat/CentOS Variables
+---
+keldris_package_dependencies:
+  - curl
+  - ca-certificates

--- a/examples/ansible/README.md
+++ b/examples/ansible/README.md
@@ -1,0 +1,99 @@
+# Keldris Agent Ansible Examples
+
+Example playbooks for deploying and managing Keldris backup agents.
+
+## Quick Start
+
+1. Copy the example inventory:
+   ```bash
+   cp inventory.example.yml inventory.yml
+   ```
+
+2. Edit `inventory.yml` with your hosts and credentials:
+   ```yaml
+   all:
+     vars:
+       keldris_server_url: "https://your-keldris-server.com"
+       keldris_api_key: "your-api-key"
+   ```
+
+3. Run the deployment playbook:
+   ```bash
+   ansible-playbook -i inventory.yml deploy-agent.yml
+   ```
+
+## Playbooks
+
+### deploy-agent.yml
+
+Deploys the Keldris agent to all hosts in the `backup_clients` group.
+
+```bash
+# Using environment variables
+export KELDRIS_SERVER_URL="https://backup.example.com"
+export KELDRIS_API_KEY="your-api-key"
+ansible-playbook -i inventory.yml deploy-agent.yml
+
+# Or pass variables directly
+ansible-playbook -i inventory.yml deploy-agent.yml \
+  -e keldris_server_url="https://backup.example.com" \
+  -e keldris_api_key="your-api-key"
+```
+
+### upgrade-agents.yml
+
+Performs a rolling upgrade of agents across all hosts.
+
+```bash
+# Upgrade to latest version
+ansible-playbook -i inventory.yml upgrade-agents.yml
+
+# Upgrade to specific version
+ansible-playbook -i inventory.yml upgrade-agents.yml -e target_version="v1.2.3"
+```
+
+## Directory Structure
+
+```
+examples/ansible/
+├── README.md                 # This file
+├── deploy-agent.yml          # Initial deployment playbook
+├── inventory.example.yml     # Example inventory
+└── upgrade-agents.yml        # Upgrade playbook
+```
+
+## Using with Ansible Galaxy
+
+Once the role is published to Ansible Galaxy, you can install it with:
+
+```bash
+ansible-galaxy install macjediwizard.keldris_agent
+```
+
+Then reference it in your playbooks:
+
+```yaml
+- hosts: backup_clients
+  roles:
+    - role: macjediwizard.keldris_agent
+```
+
+## Security Notes
+
+- Store API keys in Ansible Vault or use environment variables
+- Never commit `inventory.yml` with real credentials to version control
+- The agent config file (containing API key) is created with mode 0600
+
+Example using Ansible Vault:
+
+```bash
+# Create encrypted vars file
+ansible-vault create vault.yml
+
+# Add to playbook
+vars_files:
+  - vault.yml
+
+# Run with vault
+ansible-playbook -i inventory.yml deploy-agent.yml --ask-vault-pass
+```

--- a/examples/ansible/deploy-agent.yml
+++ b/examples/ansible/deploy-agent.yml
@@ -1,0 +1,18 @@
+# Keldris Agent Deployment Playbook
+# Deploys and configures the Keldris backup agent on target hosts
+---
+- name: Deploy Keldris Agent
+  hosts: backup_clients
+  gather_facts: true
+
+  vars:
+    # Override these in your inventory or pass via -e
+    keldris_server_url: "{{ lookup('env', 'KELDRIS_SERVER_URL') }}"
+    keldris_api_key: "{{ lookup('env', 'KELDRIS_API_KEY') }}"
+
+  roles:
+    - role: keldris_agent
+      vars:
+        keldris_agent_version: "latest"
+        keldris_auto_check_update: true
+        keldris_register_agent: true

--- a/examples/ansible/inventory.example.yml
+++ b/examples/ansible/inventory.example.yml
@@ -1,0 +1,45 @@
+# Keldris Agent Inventory Example
+# Copy this file to inventory.yml and customize for your environment
+---
+all:
+  vars:
+    # Global settings (can be overridden per host)
+    keldris_server_url: "https://backup.example.com"
+    keldris_api_key: "your-api-key-here"
+    keldris_agent_version: "latest"
+
+  children:
+    backup_clients:
+      hosts:
+        # Linux servers with systemd
+        linux-server-1:
+          ansible_host: 192.168.1.10
+          ansible_user: admin
+          ansible_become: true
+
+        linux-server-2:
+          ansible_host: 192.168.1.11
+          ansible_user: admin
+          ansible_become: true
+
+        # macOS workstations
+        macos-workstation-1:
+          ansible_host: 192.168.1.20
+          ansible_user: user
+          # macOS typically doesn't need become for user-level launchd
+
+      children:
+        linux_servers:
+          hosts:
+            linux-server-1:
+            linux-server-2:
+          vars:
+            # Linux-specific settings
+            keldris_config_dir_linux: "/etc/keldris"
+
+        macos_workstations:
+          hosts:
+            macos-workstation-1:
+          vars:
+            # macOS-specific settings
+            keldris_remove_quarantine: true

--- a/examples/ansible/upgrade-agents.yml
+++ b/examples/ansible/upgrade-agents.yml
@@ -1,0 +1,36 @@
+# Keldris Agent Upgrade Playbook
+# Upgrades the Keldris backup agent to a specific version on all hosts
+---
+- name: Upgrade Keldris Agents
+  hosts: backup_clients
+  gather_facts: true
+  serial: "25%"  # Rolling upgrade - 25% of hosts at a time
+
+  vars:
+    keldris_agent_version: "{{ target_version | default('latest') }}"
+
+  tasks:
+    - name: Get current agent version
+      ansible.builtin.command: "{{ keldris_install_dir | default('/usr/local/bin') }}/keldris-agent version"
+      register: current_version
+      changed_when: false
+      failed_when: false
+
+    - name: Display current version
+      ansible.builtin.debug:
+        msg: "Current version: {{ current_version.stdout | default('Not installed') }}"
+
+    - name: Include keldris_agent role for upgrade
+      ansible.builtin.include_role:
+        name: keldris_agent
+      vars:
+        keldris_register_agent: false  # Skip registration on upgrade
+
+    - name: Get new agent version
+      ansible.builtin.command: "{{ keldris_install_dir | default('/usr/local/bin') }}/keldris-agent version"
+      register: new_version
+      changed_when: false
+
+    - name: Display upgrade result
+      ansible.builtin.debug:
+        msg: "Upgraded from {{ current_version.stdout | default('unknown') }} to {{ new_version.stdout }}"


### PR DESCRIPTION
## Summary

Adds a complete Ansible role for deploying and managing Keldris backup agents across infrastructure. Supports both Linux (systemd) and macOS (launchd) with service setup, configuration management, and registration. Includes example playbooks for initial deployment and rolling upgrades.

## Test plan

- [ ] Deploy to Linux host with systemd
- [ ] Deploy to macOS host with launchd
- [ ] Verify agent registration with server
- [ ] Test rolling upgrade playbook
- [ ] Verify security settings (service hardening, config permissions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)