### PR TITLE
Add multi-channel notifications (Slack, Teams, Discord, PagerDuty, Webhooks)

### DIFF
--- a/internal/api/handlers/notifications.go
+++ b/internal/api/handlers/notifications.go
@@ -30,8 +30,9 @@ type NotificationStore interface {
 
 // NotificationsHandler handles notification-related HTTP endpoints.
 type NotificationsHandler struct {
-	store  NotificationStore
-	logger zerolog.Logger
+	store   NotificationStore
+	service NotificationService
+	logger  zerolog.Logger
 }
 
 // NewNotificationsHandler creates a new NotificationsHandler.
@@ -40,6 +41,16 @@ func NewNotificationsHandler(store NotificationStore, logger zerolog.Logger) *No
 		store:  store,
 		logger: logger.With().Str("component", "notifications_handler").Logger(),
 	}
+}
+
+// SetNotificationService sets the notification service for testing channels.
+func (h *NotificationsHandler) SetNotificationService(service NotificationService) {
+	h.service = service
+}
+
+// NotificationService defines the interface for testing notification channels.
+type NotificationService interface {
+	TestChannel(channel *models.NotificationChannel) error
 }
 
 // RegisterRoutes registers notification routes on the given router group.
@@ -52,6 +63,10 @@ func (h *NotificationsHandler) RegisterRoutes(r *gin.RouterGroup) {
 		notifications.GET("/channels/:id", h.GetChannel)
 		notifications.PUT("/channels/:id", h.UpdateChannel)
 		notifications.DELETE("/channels/:id", h.DeleteChannel)
+		notifications.POST("/channels/:id/test", h.TestChannel)
+
+		// Channel types info
+		notifications.GET("/channel-types", h.ListChannelTypes)
 
 		// Preferences
 		notifications.GET("/preferences", h.ListPreferences)
@@ -537,10 +552,166 @@ func (h *NotificationsHandler) ListLogs(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"logs": logs})
 }
 
+// TestChannel sends a test notification to verify the channel configuration.
+// POST /api/v1/notifications/channels/:id/test
+func (h *NotificationsHandler) TestChannel(c *gin.Context) {
+	user := middleware.RequireUser(c)
+	if user == nil {
+		return
+	}
+
+	idParam := c.Param("id")
+	id, err := uuid.Parse(idParam)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid channel ID"})
+		return
+	}
+
+	channel, err := h.store.GetNotificationChannelByID(c.Request.Context(), id)
+	if err != nil {
+		h.logger.Error().Err(err).Str("channel_id", id.String()).Msg("failed to get notification channel")
+		c.JSON(http.StatusNotFound, gin.H{"error": "notification channel not found"})
+		return
+	}
+
+	dbUser, err := h.store.GetUserByID(c.Request.Context(), user.ID)
+	if err != nil {
+		h.logger.Error().Err(err).Str("user_id", user.ID.String()).Msg("failed to get user")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to verify access"})
+		return
+	}
+
+	if channel.OrgID != dbUser.OrgID {
+		c.JSON(http.StatusNotFound, gin.H{"error": "notification channel not found"})
+		return
+	}
+
+	if h.service == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "notification service not configured"})
+		return
+	}
+
+	if err := h.service.TestChannel(channel); err != nil {
+		h.logger.Error().Err(err).
+			Str("channel_id", id.String()).
+			Str("channel_type", string(channel.Type)).
+			Msg("test notification failed")
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":   "test notification failed",
+			"details": err.Error(),
+		})
+		return
+	}
+
+	h.logger.Info().
+		Str("channel_id", id.String()).
+		Str("channel_type", string(channel.Type)).
+		Msg("test notification sent successfully")
+
+	c.JSON(http.StatusOK, gin.H{
+		"message": "test notification sent successfully",
+	})
+}
+
+// ChannelTypeInfo represents information about a notification channel type.
+type ChannelTypeInfo struct {
+	Type        models.NotificationChannelType `json:"type"`
+	Name        string                         `json:"name"`
+	Description string                         `json:"description"`
+	ConfigFields []ChannelConfigField          `json:"config_fields"`
+}
+
+// ChannelConfigField represents a configuration field for a channel type.
+type ChannelConfigField struct {
+	Name        string `json:"name"`
+	Type        string `json:"type"`
+	Required    bool   `json:"required"`
+	Description string `json:"description"`
+	Placeholder string `json:"placeholder,omitempty"`
+}
+
+// ListChannelTypes returns information about available notification channel types.
+// GET /api/v1/notifications/channel-types
+func (h *NotificationsHandler) ListChannelTypes(c *gin.Context) {
+	channelTypes := []ChannelTypeInfo{
+		{
+			Type:        models.ChannelTypeEmail,
+			Name:        "Email (SMTP)",
+			Description: "Send notifications via email using SMTP",
+			ConfigFields: []ChannelConfigField{
+				{Name: "host", Type: "string", Required: true, Description: "SMTP server hostname", Placeholder: "smtp.example.com"},
+				{Name: "port", Type: "number", Required: true, Description: "SMTP server port", Placeholder: "587"},
+				{Name: "username", Type: "string", Required: false, Description: "SMTP username for authentication"},
+				{Name: "password", Type: "password", Required: false, Description: "SMTP password for authentication"},
+				{Name: "from", Type: "email", Required: true, Description: "From email address", Placeholder: "alerts@example.com"},
+				{Name: "tls", Type: "boolean", Required: false, Description: "Enable TLS encryption"},
+			},
+		},
+		{
+			Type:        models.ChannelTypeSlack,
+			Name:        "Slack",
+			Description: "Send notifications to Slack channels via webhooks",
+			ConfigFields: []ChannelConfigField{
+				{Name: "webhook_url", Type: "url", Required: true, Description: "Slack Incoming Webhook URL", Placeholder: "https://hooks.slack.com/services/..."},
+				{Name: "channel", Type: "string", Required: false, Description: "Override default channel (e.g., #alerts)"},
+				{Name: "username", Type: "string", Required: false, Description: "Bot username displayed in Slack", Placeholder: "Keldris Backup"},
+				{Name: "icon_emoji", Type: "string", Required: false, Description: "Emoji to use as icon (e.g., :shield:)"},
+			},
+		},
+		{
+			Type:        models.ChannelTypeTeams,
+			Name:        "Microsoft Teams",
+			Description: "Send notifications to Microsoft Teams channels via webhooks",
+			ConfigFields: []ChannelConfigField{
+				{Name: "webhook_url", Type: "url", Required: true, Description: "Teams Incoming Webhook URL", Placeholder: "https://outlook.office.com/webhook/..."},
+			},
+		},
+		{
+			Type:        models.ChannelTypeDiscord,
+			Name:        "Discord",
+			Description: "Send notifications to Discord channels via webhooks",
+			ConfigFields: []ChannelConfigField{
+				{Name: "webhook_url", Type: "url", Required: true, Description: "Discord Webhook URL", Placeholder: "https://discord.com/api/webhooks/..."},
+				{Name: "username", Type: "string", Required: false, Description: "Bot username displayed in Discord", Placeholder: "Keldris Backup"},
+				{Name: "avatar_url", Type: "url", Required: false, Description: "Avatar image URL for the bot"},
+			},
+		},
+		{
+			Type:        models.ChannelTypePagerDuty,
+			Name:        "PagerDuty",
+			Description: "Send alerts to PagerDuty for incident management",
+			ConfigFields: []ChannelConfigField{
+				{Name: "routing_key", Type: "string", Required: true, Description: "PagerDuty Events API v2 routing key (integration key)"},
+				{Name: "severity", Type: "select", Required: false, Description: "Default severity level (critical, error, warning, info)"},
+				{Name: "component", Type: "string", Required: false, Description: "Component name for the alert"},
+				{Name: "group", Type: "string", Required: false, Description: "Logical grouping of alerts"},
+				{Name: "class", Type: "string", Required: false, Description: "Class/type of alert"},
+			},
+		},
+		{
+			Type:        models.ChannelTypeWebhook,
+			Name:        "Generic Webhook",
+			Description: "Send notifications to any HTTP endpoint",
+			ConfigFields: []ChannelConfigField{
+				{Name: "url", Type: "url", Required: true, Description: "Webhook URL endpoint", Placeholder: "https://api.example.com/webhooks/..."},
+				{Name: "method", Type: "select", Required: false, Description: "HTTP method (default: POST)"},
+				{Name: "auth_type", Type: "select", Required: false, Description: "Authentication type (none, bearer, basic)"},
+				{Name: "auth_token", Type: "password", Required: false, Description: "Bearer token for authentication"},
+				{Name: "basic_user", Type: "string", Required: false, Description: "Username for basic authentication"},
+				{Name: "basic_pass", Type: "password", Required: false, Description: "Password for basic authentication"},
+				{Name: "content_type", Type: "string", Required: false, Description: "Content-Type header (default: application/json)"},
+				{Name: "template", Type: "textarea", Required: false, Description: "Custom payload template (Go template syntax)"},
+			},
+		},
+	}
+
+	c.JSON(http.StatusOK, gin.H{"channel_types": channelTypes})
+}
+
 // isValidChannelType checks if a channel type is valid.
 func isValidChannelType(t models.NotificationChannelType) bool {
 	switch t {
-	case models.ChannelTypeEmail, models.ChannelTypeSlack, models.ChannelTypeWebhook, models.ChannelTypePagerDuty:
+	case models.ChannelTypeEmail, models.ChannelTypeSlack, models.ChannelTypeTeams, models.ChannelTypeDiscord, models.ChannelTypeWebhook, models.ChannelTypePagerDuty:
 		return true
 	default:
 		return false

--- a/internal/models/notification.go
+++ b/internal/models/notification.go
@@ -12,6 +12,8 @@ type NotificationChannelType string
 const (
 	ChannelTypeEmail     NotificationChannelType = "email"
 	ChannelTypeSlack     NotificationChannelType = "slack"
+	ChannelTypeTeams     NotificationChannelType = "teams"
+	ChannelTypeDiscord   NotificationChannelType = "discord"
 	ChannelTypeWebhook   NotificationChannelType = "webhook"
 	ChannelTypePagerDuty NotificationChannelType = "pagerduty"
 )
@@ -136,6 +138,50 @@ type EmailChannelConfig struct {
 	Password string `json:"password"`
 	From     string `json:"from"`
 	TLS      bool   `json:"tls"`
+}
+
+// SlackChannelConfig represents Slack webhook configuration
+type SlackChannelConfig struct {
+	WebhookURL string `json:"webhook_url"`
+	Channel    string `json:"channel,omitempty"`
+	Username   string `json:"username,omitempty"`
+	IconEmoji  string `json:"icon_emoji,omitempty"`
+}
+
+// TeamsChannelConfig represents Microsoft Teams webhook configuration
+type TeamsChannelConfig struct {
+	WebhookURL string `json:"webhook_url"`
+}
+
+// DiscordChannelConfig represents Discord webhook configuration
+type DiscordChannelConfig struct {
+	WebhookURL string `json:"webhook_url"`
+	Username   string `json:"username,omitempty"`
+	AvatarURL  string `json:"avatar_url,omitempty"`
+}
+
+// PagerDutyChannelConfig represents PagerDuty integration configuration
+type PagerDutyChannelConfig struct {
+	RoutingKey   string `json:"routing_key"`
+	ServiceKey   string `json:"service_key,omitempty"`
+	Severity     string `json:"severity,omitempty"`
+	Component    string `json:"component,omitempty"`
+	Group        string `json:"group,omitempty"`
+	Class        string `json:"class,omitempty"`
+	CustomFields map[string]string `json:"custom_fields,omitempty"`
+}
+
+// WebhookChannelConfig represents generic webhook configuration
+type WebhookChannelConfig struct {
+	URL         string            `json:"url"`
+	Method      string            `json:"method,omitempty"`
+	Headers     map[string]string `json:"headers,omitempty"`
+	AuthType    string            `json:"auth_type,omitempty"`
+	AuthToken   string            `json:"auth_token,omitempty"`
+	BasicUser   string            `json:"basic_user,omitempty"`
+	BasicPass   string            `json:"basic_pass,omitempty"`
+	ContentType string            `json:"content_type,omitempty"`
+	Template    string            `json:"template,omitempty"`
 }
 
 // CreateNotificationChannelRequest represents a request to create a notification channel

--- a/internal/notifications/discord.go
+++ b/internal/notifications/discord.go
@@ -1,0 +1,260 @@
+package notifications
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/MacJediWizard/keldris/internal/models"
+	"github.com/rs/zerolog"
+)
+
+// DiscordService handles sending notifications via Discord webhooks.
+type DiscordService struct {
+	config models.DiscordChannelConfig
+	client *http.Client
+	logger zerolog.Logger
+}
+
+// NewDiscordService creates a new Discord notification service.
+func NewDiscordService(config models.DiscordChannelConfig, logger zerolog.Logger) (*DiscordService, error) {
+	if err := ValidateDiscordConfig(&config); err != nil {
+		return nil, err
+	}
+
+	return &DiscordService{
+		config: config,
+		client: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		logger: logger.With().Str("component", "discord_service").Logger(),
+	}, nil
+}
+
+// ValidateDiscordConfig validates the Discord configuration.
+func ValidateDiscordConfig(config *models.DiscordChannelConfig) error {
+	if config.WebhookURL == "" {
+		return fmt.Errorf("discord webhook URL is required")
+	}
+	return nil
+}
+
+// DiscordMessage represents a Discord webhook message.
+type DiscordMessage struct {
+	Content   string         `json:"content,omitempty"`
+	Username  string         `json:"username,omitempty"`
+	AvatarURL string         `json:"avatar_url,omitempty"`
+	Embeds    []DiscordEmbed `json:"embeds,omitempty"`
+}
+
+// DiscordEmbed represents a Discord embed object.
+type DiscordEmbed struct {
+	Title       string              `json:"title,omitempty"`
+	Description string              `json:"description,omitempty"`
+	URL         string              `json:"url,omitempty"`
+	Color       int                 `json:"color,omitempty"`
+	Fields      []DiscordEmbedField `json:"fields,omitempty"`
+	Footer      *DiscordEmbedFooter `json:"footer,omitempty"`
+	Timestamp   string              `json:"timestamp,omitempty"`
+}
+
+// DiscordEmbedField represents a field in a Discord embed.
+type DiscordEmbedField struct {
+	Name   string `json:"name"`
+	Value  string `json:"value"`
+	Inline bool   `json:"inline,omitempty"`
+}
+
+// DiscordEmbedFooter represents a footer in a Discord embed.
+type DiscordEmbedFooter struct {
+	Text    string `json:"text,omitempty"`
+	IconURL string `json:"icon_url,omitempty"`
+}
+
+// Discord embed colors (decimal values)
+const (
+	DiscordColorGreen  = 3066993  // #2ECC71
+	DiscordColorRed    = 15158332 // #E74C3C
+	DiscordColorYellow = 16776960 // #FFFF00
+	DiscordColorBlue   = 3447003  // #3498DB
+)
+
+// Send sends a message to Discord.
+func (s *DiscordService) Send(msg *DiscordMessage) error {
+	if msg.Username == "" && s.config.Username != "" {
+		msg.Username = s.config.Username
+	}
+	if msg.AvatarURL == "" && s.config.AvatarURL != "" {
+		msg.AvatarURL = s.config.AvatarURL
+	}
+
+	payload, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("marshal discord message: %w", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, s.config.WebhookURL, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("create discord request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("send discord request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Discord webhooks return 204 No Content on success
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("discord API error: status %d, body: %s", resp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
+// SendBackupSuccess sends a backup success notification to Discord.
+func (s *DiscordService) SendBackupSuccess(data BackupSuccessData) error {
+	msg := &DiscordMessage{
+		Embeds: []DiscordEmbed{
+			{
+				Title:       fmt.Sprintf("Backup Successful: %s", data.Hostname),
+				Description: fmt.Sprintf("Backup completed successfully for schedule **%s**", data.ScheduleName),
+				Color:       DiscordColorGreen,
+				Fields: []DiscordEmbedField{
+					{Name: "Host", Value: data.Hostname, Inline: true},
+					{Name: "Schedule", Value: data.ScheduleName, Inline: true},
+					{Name: "Snapshot ID", Value: fmt.Sprintf("`%s`", data.SnapshotID), Inline: false},
+					{Name: "Duration", Value: data.Duration, Inline: true},
+					{Name: "Files New", Value: fmt.Sprintf("%d", data.FilesNew), Inline: true},
+					{Name: "Files Changed", Value: fmt.Sprintf("%d", data.FilesChanged), Inline: true},
+					{Name: "Size", Value: FormatBytes(data.SizeBytes), Inline: true},
+				},
+				Footer: &DiscordEmbedFooter{
+					Text: "Keldris Backup",
+				},
+				Timestamp: time.Now().UTC().Format(time.RFC3339),
+			},
+		},
+	}
+
+	s.logger.Debug().
+		Str("hostname", data.Hostname).
+		Str("schedule", data.ScheduleName).
+		Msg("sending backup success notification to Discord")
+
+	return s.Send(msg)
+}
+
+// SendBackupFailed sends a backup failed notification to Discord.
+func (s *DiscordService) SendBackupFailed(data BackupFailedData) error {
+	msg := &DiscordMessage{
+		Embeds: []DiscordEmbed{
+			{
+				Title:       fmt.Sprintf("Backup Failed: %s", data.Hostname),
+				Description: fmt.Sprintf("Backup failed for schedule **%s**", data.ScheduleName),
+				Color:       DiscordColorRed,
+				Fields: []DiscordEmbedField{
+					{Name: "Host", Value: data.Hostname, Inline: true},
+					{Name: "Schedule", Value: data.ScheduleName, Inline: true},
+					{Name: "Started At", Value: data.StartedAt.Format(time.RFC822), Inline: true},
+					{Name: "Failed At", Value: data.FailedAt.Format(time.RFC822), Inline: true},
+					{Name: "Error", Value: fmt.Sprintf("```\n%s\n```", data.ErrorMessage), Inline: false},
+				},
+				Footer: &DiscordEmbedFooter{
+					Text: "Keldris Backup",
+				},
+				Timestamp: time.Now().UTC().Format(time.RFC3339),
+			},
+		},
+	}
+
+	s.logger.Debug().
+		Str("hostname", data.Hostname).
+		Str("schedule", data.ScheduleName).
+		Str("error", data.ErrorMessage).
+		Msg("sending backup failed notification to Discord")
+
+	return s.Send(msg)
+}
+
+// SendAgentOffline sends an agent offline notification to Discord.
+func (s *DiscordService) SendAgentOffline(data AgentOfflineData) error {
+	msg := &DiscordMessage{
+		Embeds: []DiscordEmbed{
+			{
+				Title:       fmt.Sprintf("Agent Offline: %s", data.Hostname),
+				Description: fmt.Sprintf("Agent has been offline for **%s**", data.OfflineSince),
+				Color:       DiscordColorYellow,
+				Fields: []DiscordEmbedField{
+					{Name: "Host", Value: data.Hostname, Inline: true},
+					{Name: "Agent ID", Value: fmt.Sprintf("`%s`", data.AgentID), Inline: true},
+					{Name: "Last Seen", Value: data.LastSeen.Format(time.RFC822), Inline: true},
+					{Name: "Offline Duration", Value: data.OfflineSince, Inline: true},
+				},
+				Footer: &DiscordEmbedFooter{
+					Text: "Keldris Backup",
+				},
+				Timestamp: time.Now().UTC().Format(time.RFC3339),
+			},
+		},
+	}
+
+	s.logger.Debug().
+		Str("hostname", data.Hostname).
+		Str("agent_id", data.AgentID).
+		Msg("sending agent offline notification to Discord")
+
+	return s.Send(msg)
+}
+
+// SendMaintenanceScheduled sends a maintenance scheduled notification to Discord.
+func (s *DiscordService) SendMaintenanceScheduled(data MaintenanceScheduledData) error {
+	msg := &DiscordMessage{
+		Embeds: []DiscordEmbed{
+			{
+				Title:       fmt.Sprintf("Scheduled Maintenance: %s", data.Title),
+				Description: data.Message,
+				Color:       DiscordColorBlue,
+				Fields: []DiscordEmbedField{
+					{Name: "Starts At", Value: data.StartsAt.Format(time.RFC822), Inline: true},
+					{Name: "Ends At", Value: data.EndsAt.Format(time.RFC822), Inline: true},
+					{Name: "Duration", Value: data.Duration, Inline: true},
+				},
+				Footer: &DiscordEmbedFooter{
+					Text: "Keldris Backup",
+				},
+				Timestamp: time.Now().UTC().Format(time.RFC3339),
+			},
+		},
+	}
+
+	s.logger.Debug().
+		Str("title", data.Title).
+		Time("starts_at", data.StartsAt).
+		Msg("sending maintenance scheduled notification to Discord")
+
+	return s.Send(msg)
+}
+
+// TestConnection sends a test message to verify the Discord webhook is working.
+func (s *DiscordService) TestConnection() error {
+	msg := &DiscordMessage{
+		Embeds: []DiscordEmbed{
+			{
+				Title:       "Keldris Backup - Test Notification",
+				Description: "Your Discord integration is working correctly!",
+				Color:       DiscordColorGreen,
+				Footer: &DiscordEmbedFooter{
+					Text: "Keldris Backup",
+				},
+				Timestamp: time.Now().UTC().Format(time.RFC3339),
+			},
+		},
+	}
+	return s.Send(msg)
+}

--- a/internal/notifications/pagerduty.go
+++ b/internal/notifications/pagerduty.go
@@ -1,0 +1,338 @@
+package notifications
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/MacJediWizard/keldris/internal/models"
+	"github.com/rs/zerolog"
+)
+
+const (
+	// PagerDuty Events API v2 endpoint
+	pagerDutyEventsAPIURL = "https://events.pagerduty.com/v2/enqueue"
+)
+
+// PagerDutyService handles sending notifications via PagerDuty Events API v2.
+type PagerDutyService struct {
+	config models.PagerDutyChannelConfig
+	client *http.Client
+	logger zerolog.Logger
+}
+
+// NewPagerDutyService creates a new PagerDuty notification service.
+func NewPagerDutyService(config models.PagerDutyChannelConfig, logger zerolog.Logger) (*PagerDutyService, error) {
+	if err := ValidatePagerDutyConfig(&config); err != nil {
+		return nil, err
+	}
+
+	// Set default severity if not specified
+	if config.Severity == "" {
+		config.Severity = "warning"
+	}
+
+	return &PagerDutyService{
+		config: config,
+		client: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		logger: logger.With().Str("component", "pagerduty_service").Logger(),
+	}, nil
+}
+
+// ValidatePagerDutyConfig validates the PagerDuty configuration.
+func ValidatePagerDutyConfig(config *models.PagerDutyChannelConfig) error {
+	if config.RoutingKey == "" {
+		return fmt.Errorf("pagerduty routing key is required")
+	}
+	return nil
+}
+
+// PagerDutyEventAction represents the action to take on an event.
+type PagerDutyEventAction string
+
+const (
+	PagerDutyEventTrigger     PagerDutyEventAction = "trigger"
+	PagerDutyEventAcknowledge PagerDutyEventAction = "acknowledge"
+	PagerDutyEventResolve     PagerDutyEventAction = "resolve"
+)
+
+// PagerDutySeverity represents the severity of an event.
+type PagerDutySeverity string
+
+const (
+	PagerDutySeverityCritical PagerDutySeverity = "critical"
+	PagerDutySeverityError    PagerDutySeverity = "error"
+	PagerDutySeverityWarning  PagerDutySeverity = "warning"
+	PagerDutySeverityInfo     PagerDutySeverity = "info"
+)
+
+// PagerDutyEvent represents a PagerDuty Events API v2 event.
+type PagerDutyEvent struct {
+	RoutingKey  string              `json:"routing_key"`
+	EventAction PagerDutyEventAction `json:"event_action"`
+	DedupKey    string              `json:"dedup_key,omitempty"`
+	Payload     PagerDutyPayload    `json:"payload"`
+	Images      []PagerDutyImage    `json:"images,omitempty"`
+	Links       []PagerDutyLink     `json:"links,omitempty"`
+}
+
+// PagerDutyPayload represents the payload of a PagerDuty event.
+type PagerDutyPayload struct {
+	Summary       string                 `json:"summary"`
+	Source        string                 `json:"source"`
+	Severity      PagerDutySeverity      `json:"severity"`
+	Timestamp     string                 `json:"timestamp,omitempty"`
+	Component     string                 `json:"component,omitempty"`
+	Group         string                 `json:"group,omitempty"`
+	Class         string                 `json:"class,omitempty"`
+	CustomDetails map[string]interface{} `json:"custom_details,omitempty"`
+}
+
+// PagerDutyImage represents an image attachment.
+type PagerDutyImage struct {
+	Src  string `json:"src"`
+	Href string `json:"href,omitempty"`
+	Alt  string `json:"alt,omitempty"`
+}
+
+// PagerDutyLink represents a link attachment.
+type PagerDutyLink struct {
+	Href string `json:"href"`
+	Text string `json:"text,omitempty"`
+}
+
+// PagerDutyResponse represents the response from PagerDuty Events API.
+type PagerDutyResponse struct {
+	Status   string `json:"status"`
+	Message  string `json:"message"`
+	DedupKey string `json:"dedup_key,omitempty"`
+}
+
+// Send sends an event to PagerDuty.
+func (s *PagerDutyService) Send(event *PagerDutyEvent) error {
+	event.RoutingKey = s.config.RoutingKey
+
+	// Apply config defaults
+	if event.Payload.Component == "" && s.config.Component != "" {
+		event.Payload.Component = s.config.Component
+	}
+	if event.Payload.Group == "" && s.config.Group != "" {
+		event.Payload.Group = s.config.Group
+	}
+	if event.Payload.Class == "" && s.config.Class != "" {
+		event.Payload.Class = s.config.Class
+	}
+
+	// Merge custom fields from config
+	if len(s.config.CustomFields) > 0 {
+		if event.Payload.CustomDetails == nil {
+			event.Payload.CustomDetails = make(map[string]interface{})
+		}
+		for k, v := range s.config.CustomFields {
+			if _, exists := event.Payload.CustomDetails[k]; !exists {
+				event.Payload.CustomDetails[k] = v
+			}
+		}
+	}
+
+	payload, err := json.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("marshal pagerduty event: %w", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, pagerDutyEventsAPIURL, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("create pagerduty request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("send pagerduty request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("pagerduty API error: status %d, body: %s", resp.StatusCode, string(body))
+	}
+
+	var pdResp PagerDutyResponse
+	if err := json.Unmarshal(body, &pdResp); err == nil {
+		s.logger.Debug().
+			Str("status", pdResp.Status).
+			Str("dedup_key", pdResp.DedupKey).
+			Msg("pagerduty event sent")
+	}
+
+	return nil
+}
+
+// getSeverity returns the appropriate PagerDuty severity.
+func (s *PagerDutyService) getSeverity(defaultSeverity PagerDutySeverity) PagerDutySeverity {
+	if s.config.Severity != "" {
+		return PagerDutySeverity(s.config.Severity)
+	}
+	return defaultSeverity
+}
+
+// SendBackupSuccess sends a backup success notification to PagerDuty.
+// Note: Backup success typically resolves any previous backup failure alerts.
+func (s *PagerDutyService) SendBackupSuccess(data BackupSuccessData) error {
+	event := &PagerDutyEvent{
+		EventAction: PagerDutyEventResolve,
+		DedupKey:    fmt.Sprintf("backup-%s-%s", data.Hostname, data.ScheduleName),
+		Payload: PagerDutyPayload{
+			Summary:   fmt.Sprintf("Backup Successful: %s - %s", data.Hostname, data.ScheduleName),
+			Source:    data.Hostname,
+			Severity:  PagerDutySeverityInfo,
+			Timestamp: time.Now().UTC().Format(time.RFC3339),
+			CustomDetails: map[string]interface{}{
+				"hostname":      data.Hostname,
+				"schedule":      data.ScheduleName,
+				"snapshot_id":   data.SnapshotID,
+				"duration":      data.Duration,
+				"files_new":     data.FilesNew,
+				"files_changed": data.FilesChanged,
+				"size_bytes":    data.SizeBytes,
+			},
+		},
+	}
+
+	s.logger.Debug().
+		Str("hostname", data.Hostname).
+		Str("schedule", data.ScheduleName).
+		Msg("sending backup success (resolve) to PagerDuty")
+
+	return s.Send(event)
+}
+
+// SendBackupFailed sends a backup failed notification to PagerDuty.
+func (s *PagerDutyService) SendBackupFailed(data BackupFailedData) error {
+	event := &PagerDutyEvent{
+		EventAction: PagerDutyEventTrigger,
+		DedupKey:    fmt.Sprintf("backup-%s-%s", data.Hostname, data.ScheduleName),
+		Payload: PagerDutyPayload{
+			Summary:   fmt.Sprintf("Backup Failed: %s - %s: %s", data.Hostname, data.ScheduleName, data.ErrorMessage),
+			Source:    data.Hostname,
+			Severity:  s.getSeverity(PagerDutySeverityError),
+			Timestamp: time.Now().UTC().Format(time.RFC3339),
+			CustomDetails: map[string]interface{}{
+				"hostname":      data.Hostname,
+				"schedule":      data.ScheduleName,
+				"started_at":    data.StartedAt.Format(time.RFC3339),
+				"failed_at":     data.FailedAt.Format(time.RFC3339),
+				"error_message": data.ErrorMessage,
+			},
+		},
+	}
+
+	s.logger.Debug().
+		Str("hostname", data.Hostname).
+		Str("schedule", data.ScheduleName).
+		Str("error", data.ErrorMessage).
+		Msg("sending backup failed notification to PagerDuty")
+
+	return s.Send(event)
+}
+
+// SendAgentOffline sends an agent offline notification to PagerDuty.
+func (s *PagerDutyService) SendAgentOffline(data AgentOfflineData) error {
+	event := &PagerDutyEvent{
+		EventAction: PagerDutyEventTrigger,
+		DedupKey:    fmt.Sprintf("agent-offline-%s", data.AgentID),
+		Payload: PagerDutyPayload{
+			Summary:   fmt.Sprintf("Agent Offline: %s (offline for %s)", data.Hostname, data.OfflineSince),
+			Source:    data.Hostname,
+			Severity:  s.getSeverity(PagerDutySeverityWarning),
+			Timestamp: time.Now().UTC().Format(time.RFC3339),
+			CustomDetails: map[string]interface{}{
+				"hostname":       data.Hostname,
+				"agent_id":       data.AgentID,
+				"last_seen":      data.LastSeen.Format(time.RFC3339),
+				"offline_since":  data.OfflineSince,
+			},
+		},
+	}
+
+	s.logger.Debug().
+		Str("hostname", data.Hostname).
+		Str("agent_id", data.AgentID).
+		Msg("sending agent offline notification to PagerDuty")
+
+	return s.Send(event)
+}
+
+// SendMaintenanceScheduled sends a maintenance scheduled notification to PagerDuty.
+func (s *PagerDutyService) SendMaintenanceScheduled(data MaintenanceScheduledData) error {
+	event := &PagerDutyEvent{
+		EventAction: PagerDutyEventTrigger,
+		DedupKey:    fmt.Sprintf("maintenance-%s-%d", data.Title, data.StartsAt.Unix()),
+		Payload: PagerDutyPayload{
+			Summary:   fmt.Sprintf("Scheduled Maintenance: %s", data.Title),
+			Source:    "keldris-backup",
+			Severity:  PagerDutySeverityInfo,
+			Timestamp: time.Now().UTC().Format(time.RFC3339),
+			CustomDetails: map[string]interface{}{
+				"title":     data.Title,
+				"message":   data.Message,
+				"starts_at": data.StartsAt.Format(time.RFC3339),
+				"ends_at":   data.EndsAt.Format(time.RFC3339),
+				"duration":  data.Duration,
+			},
+		},
+	}
+
+	s.logger.Debug().
+		Str("title", data.Title).
+		Time("starts_at", data.StartsAt).
+		Msg("sending maintenance scheduled notification to PagerDuty")
+
+	return s.Send(event)
+}
+
+// TestConnection sends a test event to verify the PagerDuty integration is working.
+func (s *PagerDutyService) TestConnection() error {
+	event := &PagerDutyEvent{
+		EventAction: PagerDutyEventTrigger,
+		DedupKey:    fmt.Sprintf("keldris-test-%d", time.Now().Unix()),
+		Payload: PagerDutyPayload{
+			Summary:   "Keldris Backup - Test Notification",
+			Source:    "keldris-backup",
+			Severity:  PagerDutySeverityInfo,
+			Timestamp: time.Now().UTC().Format(time.RFC3339),
+			CustomDetails: map[string]interface{}{
+				"message": "Your PagerDuty integration is working correctly!",
+				"test":    true,
+			},
+		},
+	}
+	return s.Send(event)
+}
+
+// ResolveAgent sends a resolve event for an agent that has come back online.
+func (s *PagerDutyService) ResolveAgent(agentID, hostname string) error {
+	event := &PagerDutyEvent{
+		EventAction: PagerDutyEventResolve,
+		DedupKey:    fmt.Sprintf("agent-offline-%s", agentID),
+		Payload: PagerDutyPayload{
+			Summary:   fmt.Sprintf("Agent Online: %s", hostname),
+			Source:    hostname,
+			Severity:  PagerDutySeverityInfo,
+			Timestamp: time.Now().UTC().Format(time.RFC3339),
+		},
+	}
+
+	s.logger.Debug().
+		Str("hostname", hostname).
+		Str("agent_id", agentID).
+		Msg("resolving agent offline alert in PagerDuty")
+
+	return s.Send(event)
+}

--- a/internal/notifications/service.go
+++ b/internal/notifications/service.go
@@ -126,24 +126,127 @@ func (s *Service) sendNotification(ctx context.Context, pref *models.Notificatio
 		return
 	}
 
-	// Only handle email channels for now
-	if channel.Type != models.ChannelTypeEmail {
-		s.logger.Debug().
+	// Build notification data
+	duration := result.CompletedAt.Sub(result.StartedAt)
+	successData := BackupSuccessData{
+		Hostname:     result.Hostname,
+		ScheduleName: result.ScheduleName,
+		SnapshotID:   result.SnapshotID,
+		StartedAt:    result.StartedAt,
+		CompletedAt:  result.CompletedAt,
+		Duration:     formatDuration(duration),
+		SizeBytes:    result.SizeBytes,
+		FilesNew:     result.FilesNew,
+		FilesChanged: result.FilesChanged,
+	}
+	failedData := BackupFailedData{
+		Hostname:     result.Hostname,
+		ScheduleName: result.ScheduleName,
+		StartedAt:    result.StartedAt,
+		FailedAt:     result.CompletedAt,
+		ErrorMessage: result.ErrorMessage,
+	}
+
+	// Create log entry
+	var subject string
+	var recipient string
+	if result.Success {
+		subject = fmt.Sprintf("Backup Successful: %s - %s", result.Hostname, result.ScheduleName)
+	} else {
+		subject = fmt.Sprintf("Backup Failed: %s - %s", result.Hostname, result.ScheduleName)
+	}
+
+	// Determine recipient based on channel type
+	switch channel.Type {
+	case models.ChannelTypeEmail:
+		var config models.EmailChannelConfig
+		if err := json.Unmarshal(channel.ConfigEncrypted, &config); err == nil {
+			recipient = config.From
+		}
+	case models.ChannelTypeSlack:
+		var config models.SlackChannelConfig
+		if err := json.Unmarshal(channel.ConfigEncrypted, &config); err == nil {
+			recipient = config.WebhookURL
+		}
+	case models.ChannelTypeTeams:
+		var config models.TeamsChannelConfig
+		if err := json.Unmarshal(channel.ConfigEncrypted, &config); err == nil {
+			recipient = config.WebhookURL
+		}
+	case models.ChannelTypeDiscord:
+		var config models.DiscordChannelConfig
+		if err := json.Unmarshal(channel.ConfigEncrypted, &config); err == nil {
+			recipient = config.WebhookURL
+		}
+	case models.ChannelTypePagerDuty:
+		var config models.PagerDutyChannelConfig
+		if err := json.Unmarshal(channel.ConfigEncrypted, &config); err == nil {
+			recipient = "pagerduty:" + config.RoutingKey[:8] + "..."
+		}
+	case models.ChannelTypeWebhook:
+		var config models.WebhookChannelConfig
+		if err := json.Unmarshal(channel.ConfigEncrypted, &config); err == nil {
+			recipient = config.URL
+		}
+	default:
+		recipient = string(channel.Type)
+	}
+
+	log := models.NewNotificationLog(result.OrgID, &channel.ID, string(pref.EventType), recipient, subject)
+	if err := s.store.CreateNotificationLog(ctx, log); err != nil {
+		s.logger.Error().Err(err).Msg("failed to create notification log")
+	}
+
+	// Send notification based on channel type
+	var sendErr error
+	switch channel.Type {
+	case models.ChannelTypeEmail:
+		sendErr = s.sendEmailBackup(channel, result.Success, successData, failedData)
+	case models.ChannelTypeSlack:
+		sendErr = s.sendSlackBackup(channel, result.Success, successData, failedData)
+	case models.ChannelTypeTeams:
+		sendErr = s.sendTeamsBackup(channel, result.Success, successData, failedData)
+	case models.ChannelTypeDiscord:
+		sendErr = s.sendDiscordBackup(channel, result.Success, successData, failedData)
+	case models.ChannelTypePagerDuty:
+		sendErr = s.sendPagerDutyBackup(channel, result.Success, successData, failedData)
+	case models.ChannelTypeWebhook:
+		sendErr = s.sendWebhookBackup(channel, result.Success, successData, failedData)
+	default:
+		s.logger.Warn().
 			Str("channel_type", string(channel.Type)).
-			Msg("skipping non-email channel")
+			Msg("unsupported notification channel type")
 		return
 	}
 
-	// Parse email config
+	// Update log with result
+	if sendErr != nil {
+		log.MarkFailed(sendErr.Error())
+		s.logger.Error().Err(sendErr).
+			Str("channel_id", channel.ID.String()).
+			Str("channel_type", string(channel.Type)).
+			Msg("failed to send notification")
+	} else {
+		log.MarkSent()
+		s.logger.Info().
+			Str("channel_id", channel.ID.String()).
+			Str("channel_type", string(channel.Type)).
+			Str("event_type", string(pref.EventType)).
+			Msg("notification sent")
+	}
+
+	if err := s.store.UpdateNotificationLog(ctx, log); err != nil {
+		s.logger.Error().Err(err).Msg("failed to update notification log")
+	}
+}
+
+// sendEmailBackup sends a backup notification via email.
+func (s *Service) sendEmailBackup(channel *models.NotificationChannel, success bool, successData BackupSuccessData, failedData BackupFailedData) error {
 	var emailConfig models.EmailChannelConfig
 	if err := json.Unmarshal(channel.ConfigEncrypted, &emailConfig); err != nil {
-		s.logger.Error().Err(err).
-			Str("channel_id", channel.ID.String()).
-			Msg("failed to parse email config")
-		return
+		return fmt.Errorf("parse email config: %w", err)
 	}
 
-	// Create email service
 	smtpConfig := SMTPConfig{
 		Host:     emailConfig.Host,
 		Port:     emailConfig.Port,
@@ -155,72 +258,104 @@ func (s *Service) sendNotification(ctx context.Context, pref *models.Notificatio
 
 	emailService, err := NewEmailService(smtpConfig, s.logger)
 	if err != nil {
-		s.logger.Error().Err(err).Msg("failed to create email service")
-		return
+		return fmt.Errorf("create email service: %w", err)
 	}
 
-	// Get recipient from config (use the from address as default recipient)
 	recipients := []string{emailConfig.From}
+	if success {
+		return emailService.SendBackupSuccess(recipients, successData)
+	}
+	return emailService.SendBackupFailed(recipients, failedData)
+}
 
-	// Create log entry
-	var subject string
-	if result.Success {
-		subject = fmt.Sprintf("Backup Successful: %s - %s", result.Hostname, result.ScheduleName)
-	} else {
-		subject = fmt.Sprintf("Backup Failed: %s - %s", result.Hostname, result.ScheduleName)
+// sendSlackBackup sends a backup notification via Slack.
+func (s *Service) sendSlackBackup(channel *models.NotificationChannel, success bool, successData BackupSuccessData, failedData BackupFailedData) error {
+	var config models.SlackChannelConfig
+	if err := json.Unmarshal(channel.ConfigEncrypted, &config); err != nil {
+		return fmt.Errorf("parse slack config: %w", err)
 	}
 
-	log := models.NewNotificationLog(result.OrgID, &channel.ID, string(pref.EventType), recipients[0], subject)
-	if err := s.store.CreateNotificationLog(ctx, log); err != nil {
-		s.logger.Error().Err(err).Msg("failed to create notification log")
+	slackService, err := NewSlackService(config, s.logger)
+	if err != nil {
+		return fmt.Errorf("create slack service: %w", err)
 	}
 
-	// Send the email
-	var sendErr error
-	if result.Success {
-		duration := result.CompletedAt.Sub(result.StartedAt)
-		data := BackupSuccessData{
-			Hostname:     result.Hostname,
-			ScheduleName: result.ScheduleName,
-			SnapshotID:   result.SnapshotID,
-			StartedAt:    result.StartedAt,
-			CompletedAt:  result.CompletedAt,
-			Duration:     formatDuration(duration),
-			SizeBytes:    result.SizeBytes,
-			FilesNew:     result.FilesNew,
-			FilesChanged: result.FilesChanged,
-		}
-		sendErr = emailService.SendBackupSuccess(recipients, data)
-	} else {
-		data := BackupFailedData{
-			Hostname:     result.Hostname,
-			ScheduleName: result.ScheduleName,
-			StartedAt:    result.StartedAt,
-			FailedAt:     result.CompletedAt,
-			ErrorMessage: result.ErrorMessage,
-		}
-		sendErr = emailService.SendBackupFailed(recipients, data)
+	if success {
+		return slackService.SendBackupSuccess(successData)
+	}
+	return slackService.SendBackupFailed(failedData)
+}
+
+// sendTeamsBackup sends a backup notification via Microsoft Teams.
+func (s *Service) sendTeamsBackup(channel *models.NotificationChannel, success bool, successData BackupSuccessData, failedData BackupFailedData) error {
+	var config models.TeamsChannelConfig
+	if err := json.Unmarshal(channel.ConfigEncrypted, &config); err != nil {
+		return fmt.Errorf("parse teams config: %w", err)
 	}
 
-	// Update log with result
-	if sendErr != nil {
-		log.MarkFailed(sendErr.Error())
-		s.logger.Error().Err(sendErr).
-			Str("channel_id", channel.ID.String()).
-			Str("recipient", recipients[0]).
-			Msg("failed to send email notification")
-	} else {
-		log.MarkSent()
-		s.logger.Info().
-			Str("channel_id", channel.ID.String()).
-			Str("recipient", recipients[0]).
-			Str("event_type", string(pref.EventType)).
-			Msg("email notification sent")
+	teamsService, err := NewTeamsService(config, s.logger)
+	if err != nil {
+		return fmt.Errorf("create teams service: %w", err)
 	}
 
-	if err := s.store.UpdateNotificationLog(ctx, log); err != nil {
-		s.logger.Error().Err(err).Msg("failed to update notification log")
+	if success {
+		return teamsService.SendBackupSuccess(successData)
 	}
+	return teamsService.SendBackupFailed(failedData)
+}
+
+// sendDiscordBackup sends a backup notification via Discord.
+func (s *Service) sendDiscordBackup(channel *models.NotificationChannel, success bool, successData BackupSuccessData, failedData BackupFailedData) error {
+	var config models.DiscordChannelConfig
+	if err := json.Unmarshal(channel.ConfigEncrypted, &config); err != nil {
+		return fmt.Errorf("parse discord config: %w", err)
+	}
+
+	discordService, err := NewDiscordService(config, s.logger)
+	if err != nil {
+		return fmt.Errorf("create discord service: %w", err)
+	}
+
+	if success {
+		return discordService.SendBackupSuccess(successData)
+	}
+	return discordService.SendBackupFailed(failedData)
+}
+
+// sendPagerDutyBackup sends a backup notification via PagerDuty.
+func (s *Service) sendPagerDutyBackup(channel *models.NotificationChannel, success bool, successData BackupSuccessData, failedData BackupFailedData) error {
+	var config models.PagerDutyChannelConfig
+	if err := json.Unmarshal(channel.ConfigEncrypted, &config); err != nil {
+		return fmt.Errorf("parse pagerduty config: %w", err)
+	}
+
+	pdService, err := NewPagerDutyService(config, s.logger)
+	if err != nil {
+		return fmt.Errorf("create pagerduty service: %w", err)
+	}
+
+	if success {
+		return pdService.SendBackupSuccess(successData)
+	}
+	return pdService.SendBackupFailed(failedData)
+}
+
+// sendWebhookBackup sends a backup notification via generic webhook.
+func (s *Service) sendWebhookBackup(channel *models.NotificationChannel, success bool, successData BackupSuccessData, failedData BackupFailedData) error {
+	var config models.WebhookChannelConfig
+	if err := json.Unmarshal(channel.ConfigEncrypted, &config); err != nil {
+		return fmt.Errorf("parse webhook config: %w", err)
+	}
+
+	webhookService, err := NewWebhookService(config, s.logger)
+	if err != nil {
+		return fmt.Errorf("create webhook service: %w", err)
+	}
+
+	if success {
+		return webhookService.SendBackupSuccess(successData)
+	}
+	return webhookService.SendBackupFailed(failedData)
 }
 
 // sendAgentOfflineNotification sends an agent offline notification.
@@ -233,24 +368,97 @@ func (s *Service) sendAgentOfflineNotification(ctx context.Context, pref *models
 		return
 	}
 
-	// Only handle email channels for now
-	if channel.Type != models.ChannelTypeEmail {
-		s.logger.Debug().
+	subject := fmt.Sprintf("Agent Offline: %s", data.Hostname)
+	recipient := s.getChannelRecipient(channel)
+
+	log := models.NewNotificationLog(orgID, &channel.ID, string(models.EventAgentOffline), recipient, subject)
+	if err := s.store.CreateNotificationLog(ctx, log); err != nil {
+		s.logger.Error().Err(err).Msg("failed to create notification log")
+	}
+
+	var sendErr error
+	switch channel.Type {
+	case models.ChannelTypeEmail:
+		sendErr = s.sendEmailAgentOffline(channel, data)
+	case models.ChannelTypeSlack:
+		sendErr = s.sendSlackAgentOffline(channel, data)
+	case models.ChannelTypeTeams:
+		sendErr = s.sendTeamsAgentOffline(channel, data)
+	case models.ChannelTypeDiscord:
+		sendErr = s.sendDiscordAgentOffline(channel, data)
+	case models.ChannelTypePagerDuty:
+		sendErr = s.sendPagerDutyAgentOffline(channel, data)
+	case models.ChannelTypeWebhook:
+		sendErr = s.sendWebhookAgentOffline(channel, data)
+	default:
+		s.logger.Warn().
 			Str("channel_type", string(channel.Type)).
-			Msg("skipping non-email channel")
+			Msg("unsupported notification channel type")
 		return
 	}
 
-	// Parse email config
+	if sendErr != nil {
+		log.MarkFailed(sendErr.Error())
+		s.logger.Error().Err(sendErr).
+			Str("channel_id", channel.ID.String()).
+			Str("channel_type", string(channel.Type)).
+			Msg("failed to send agent offline notification")
+	} else {
+		log.MarkSent()
+		s.logger.Info().
+			Str("channel_id", channel.ID.String()).
+			Str("channel_type", string(channel.Type)).
+			Str("agent_id", data.AgentID).
+			Msg("agent offline notification sent")
+	}
+
+	if err := s.store.UpdateNotificationLog(ctx, log); err != nil {
+		s.logger.Error().Err(err).Msg("failed to update notification log")
+	}
+}
+
+// getChannelRecipient returns a display-friendly recipient string for logging.
+func (s *Service) getChannelRecipient(channel *models.NotificationChannel) string {
+	switch channel.Type {
+	case models.ChannelTypeEmail:
+		var config models.EmailChannelConfig
+		if err := json.Unmarshal(channel.ConfigEncrypted, &config); err == nil {
+			return config.From
+		}
+	case models.ChannelTypeSlack:
+		var config models.SlackChannelConfig
+		if err := json.Unmarshal(channel.ConfigEncrypted, &config); err == nil {
+			if config.Channel != "" {
+				return config.Channel
+			}
+			return "slack-webhook"
+		}
+	case models.ChannelTypeTeams:
+		return "teams-webhook"
+	case models.ChannelTypeDiscord:
+		return "discord-webhook"
+	case models.ChannelTypePagerDuty:
+		var config models.PagerDutyChannelConfig
+		if err := json.Unmarshal(channel.ConfigEncrypted, &config); err == nil && len(config.RoutingKey) > 8 {
+			return "pagerduty:" + config.RoutingKey[:8] + "..."
+		}
+		return "pagerduty"
+	case models.ChannelTypeWebhook:
+		var config models.WebhookChannelConfig
+		if err := json.Unmarshal(channel.ConfigEncrypted, &config); err == nil {
+			return config.URL
+		}
+	}
+	return string(channel.Type)
+}
+
+// sendEmailAgentOffline sends an agent offline notification via email.
+func (s *Service) sendEmailAgentOffline(channel *models.NotificationChannel, data AgentOfflineData) error {
 	var emailConfig models.EmailChannelConfig
 	if err := json.Unmarshal(channel.ConfigEncrypted, &emailConfig); err != nil {
-		s.logger.Error().Err(err).
-			Str("channel_id", channel.ID.String()).
-			Msg("failed to parse email config")
-		return
+		return fmt.Errorf("parse email config: %w", err)
 	}
 
-	// Create email service
 	smtpConfig := SMTPConfig{
 		Host:     emailConfig.Host,
 		Port:     emailConfig.Port,
@@ -262,38 +470,85 @@ func (s *Service) sendAgentOfflineNotification(ctx context.Context, pref *models
 
 	emailService, err := NewEmailService(smtpConfig, s.logger)
 	if err != nil {
-		s.logger.Error().Err(err).Msg("failed to create email service")
-		return
+		return fmt.Errorf("create email service: %w", err)
 	}
 
-	recipients := []string{emailConfig.From}
-	subject := fmt.Sprintf("Agent Offline: %s", data.Hostname)
+	return emailService.SendAgentOffline([]string{emailConfig.From}, data)
+}
 
-	log := models.NewNotificationLog(orgID, &channel.ID, string(models.EventAgentOffline), recipients[0], subject)
-	if err := s.store.CreateNotificationLog(ctx, log); err != nil {
-		s.logger.Error().Err(err).Msg("failed to create notification log")
+// sendSlackAgentOffline sends an agent offline notification via Slack.
+func (s *Service) sendSlackAgentOffline(channel *models.NotificationChannel, data AgentOfflineData) error {
+	var config models.SlackChannelConfig
+	if err := json.Unmarshal(channel.ConfigEncrypted, &config); err != nil {
+		return fmt.Errorf("parse slack config: %w", err)
 	}
 
-	sendErr := emailService.SendAgentOffline(recipients, data)
-
-	if sendErr != nil {
-		log.MarkFailed(sendErr.Error())
-		s.logger.Error().Err(sendErr).
-			Str("channel_id", channel.ID.String()).
-			Str("recipient", recipients[0]).
-			Msg("failed to send agent offline notification")
-	} else {
-		log.MarkSent()
-		s.logger.Info().
-			Str("channel_id", channel.ID.String()).
-			Str("recipient", recipients[0]).
-			Str("agent_id", data.AgentID).
-			Msg("agent offline notification sent")
+	slackService, err := NewSlackService(config, s.logger)
+	if err != nil {
+		return fmt.Errorf("create slack service: %w", err)
 	}
 
-	if err := s.store.UpdateNotificationLog(ctx, log); err != nil {
-		s.logger.Error().Err(err).Msg("failed to update notification log")
+	return slackService.SendAgentOffline(data)
+}
+
+// sendTeamsAgentOffline sends an agent offline notification via Microsoft Teams.
+func (s *Service) sendTeamsAgentOffline(channel *models.NotificationChannel, data AgentOfflineData) error {
+	var config models.TeamsChannelConfig
+	if err := json.Unmarshal(channel.ConfigEncrypted, &config); err != nil {
+		return fmt.Errorf("parse teams config: %w", err)
 	}
+
+	teamsService, err := NewTeamsService(config, s.logger)
+	if err != nil {
+		return fmt.Errorf("create teams service: %w", err)
+	}
+
+	return teamsService.SendAgentOffline(data)
+}
+
+// sendDiscordAgentOffline sends an agent offline notification via Discord.
+func (s *Service) sendDiscordAgentOffline(channel *models.NotificationChannel, data AgentOfflineData) error {
+	var config models.DiscordChannelConfig
+	if err := json.Unmarshal(channel.ConfigEncrypted, &config); err != nil {
+		return fmt.Errorf("parse discord config: %w", err)
+	}
+
+	discordService, err := NewDiscordService(config, s.logger)
+	if err != nil {
+		return fmt.Errorf("create discord service: %w", err)
+	}
+
+	return discordService.SendAgentOffline(data)
+}
+
+// sendPagerDutyAgentOffline sends an agent offline notification via PagerDuty.
+func (s *Service) sendPagerDutyAgentOffline(channel *models.NotificationChannel, data AgentOfflineData) error {
+	var config models.PagerDutyChannelConfig
+	if err := json.Unmarshal(channel.ConfigEncrypted, &config); err != nil {
+		return fmt.Errorf("parse pagerduty config: %w", err)
+	}
+
+	pdService, err := NewPagerDutyService(config, s.logger)
+	if err != nil {
+		return fmt.Errorf("create pagerduty service: %w", err)
+	}
+
+	return pdService.SendAgentOffline(data)
+}
+
+// sendWebhookAgentOffline sends an agent offline notification via generic webhook.
+func (s *Service) sendWebhookAgentOffline(channel *models.NotificationChannel, data AgentOfflineData) error {
+	var config models.WebhookChannelConfig
+	if err := json.Unmarshal(channel.ConfigEncrypted, &config); err != nil {
+		return fmt.Errorf("parse webhook config: %w", err)
+	}
+
+	webhookService, err := NewWebhookService(config, s.logger)
+	if err != nil {
+		return fmt.Errorf("create webhook service: %w", err)
+	}
+
+	return webhookService.SendAgentOffline(data)
 }
 
 // NotifyMaintenanceScheduled sends notifications for an upcoming maintenance window.
@@ -338,24 +593,62 @@ func (s *Service) sendMaintenanceNotification(ctx context.Context, pref *models.
 		return
 	}
 
-	// Only handle email channels for now
-	if channel.Type != models.ChannelTypeEmail {
-		s.logger.Debug().
+	subject := fmt.Sprintf("Scheduled Maintenance: %s", data.Title)
+	recipient := s.getChannelRecipient(channel)
+
+	log := models.NewNotificationLog(orgID, &channel.ID, string(pref.EventType), recipient, subject)
+	if err := s.store.CreateNotificationLog(ctx, log); err != nil {
+		s.logger.Error().Err(err).Msg("failed to create notification log")
+	}
+
+	var sendErr error
+	switch channel.Type {
+	case models.ChannelTypeEmail:
+		sendErr = s.sendEmailMaintenance(channel, data)
+	case models.ChannelTypeSlack:
+		sendErr = s.sendSlackMaintenance(channel, data)
+	case models.ChannelTypeTeams:
+		sendErr = s.sendTeamsMaintenance(channel, data)
+	case models.ChannelTypeDiscord:
+		sendErr = s.sendDiscordMaintenance(channel, data)
+	case models.ChannelTypePagerDuty:
+		sendErr = s.sendPagerDutyMaintenance(channel, data)
+	case models.ChannelTypeWebhook:
+		sendErr = s.sendWebhookMaintenance(channel, data)
+	default:
+		s.logger.Warn().
 			Str("channel_type", string(channel.Type)).
-			Msg("skipping non-email channel")
+			Msg("unsupported notification channel type")
 		return
 	}
 
-	// Parse email config
+	if sendErr != nil {
+		log.MarkFailed(sendErr.Error())
+		s.logger.Error().Err(sendErr).
+			Str("channel_id", channel.ID.String()).
+			Str("channel_type", string(channel.Type)).
+			Msg("failed to send maintenance notification")
+	} else {
+		log.MarkSent()
+		s.logger.Info().
+			Str("channel_id", channel.ID.String()).
+			Str("channel_type", string(channel.Type)).
+			Str("title", data.Title).
+			Msg("maintenance notification sent")
+	}
+
+	if err := s.store.UpdateNotificationLog(ctx, log); err != nil {
+		s.logger.Error().Err(err).Msg("failed to update notification log")
+	}
+}
+
+// sendEmailMaintenance sends a maintenance notification via email.
+func (s *Service) sendEmailMaintenance(channel *models.NotificationChannel, data MaintenanceScheduledData) error {
 	var emailConfig models.EmailChannelConfig
 	if err := json.Unmarshal(channel.ConfigEncrypted, &emailConfig); err != nil {
-		s.logger.Error().Err(err).
-			Str("channel_id", channel.ID.String()).
-			Msg("failed to parse email config")
-		return
+		return fmt.Errorf("parse email config: %w", err)
 	}
 
-	// Create email service
 	smtpConfig := SMTPConfig{
 		Host:     emailConfig.Host,
 		Port:     emailConfig.Port,
@@ -367,41 +660,177 @@ func (s *Service) sendMaintenanceNotification(ctx context.Context, pref *models.
 
 	emailService, err := NewEmailService(smtpConfig, s.logger)
 	if err != nil {
-		s.logger.Error().Err(err).Msg("failed to create email service")
-		return
+		return fmt.Errorf("create email service: %w", err)
 	}
 
-	// Get recipient from config
-	recipients := []string{emailConfig.From}
+	return emailService.SendMaintenanceScheduled([]string{emailConfig.From}, data)
+}
 
-	// Create log entry
-	subject := fmt.Sprintf("Scheduled Maintenance: %s", data.Title)
-	log := models.NewNotificationLog(orgID, &channel.ID, string(pref.EventType), recipients[0], subject)
-	if err := s.store.CreateNotificationLog(ctx, log); err != nil {
-		s.logger.Error().Err(err).Msg("failed to create notification log")
+// sendSlackMaintenance sends a maintenance notification via Slack.
+func (s *Service) sendSlackMaintenance(channel *models.NotificationChannel, data MaintenanceScheduledData) error {
+	var config models.SlackChannelConfig
+	if err := json.Unmarshal(channel.ConfigEncrypted, &config); err != nil {
+		return fmt.Errorf("parse slack config: %w", err)
 	}
 
-	// Send the email
-	sendErr := emailService.SendMaintenanceScheduled(recipients, data)
-
-	// Update log with result
-	if sendErr != nil {
-		log.MarkFailed(sendErr.Error())
-		s.logger.Error().Err(sendErr).
-			Str("channel_id", channel.ID.String()).
-			Str("recipient", recipients[0]).
-			Msg("failed to send maintenance notification")
-	} else {
-		log.MarkSent()
-		s.logger.Info().
-			Str("channel_id", channel.ID.String()).
-			Str("recipient", recipients[0]).
-			Str("title", data.Title).
-			Msg("maintenance notification sent")
+	slackService, err := NewSlackService(config, s.logger)
+	if err != nil {
+		return fmt.Errorf("create slack service: %w", err)
 	}
 
-	if err := s.store.UpdateNotificationLog(ctx, log); err != nil {
-		s.logger.Error().Err(err).Msg("failed to update notification log")
+	return slackService.SendMaintenanceScheduled(data)
+}
+
+// sendTeamsMaintenance sends a maintenance notification via Microsoft Teams.
+func (s *Service) sendTeamsMaintenance(channel *models.NotificationChannel, data MaintenanceScheduledData) error {
+	var config models.TeamsChannelConfig
+	if err := json.Unmarshal(channel.ConfigEncrypted, &config); err != nil {
+		return fmt.Errorf("parse teams config: %w", err)
+	}
+
+	teamsService, err := NewTeamsService(config, s.logger)
+	if err != nil {
+		return fmt.Errorf("create teams service: %w", err)
+	}
+
+	return teamsService.SendMaintenanceScheduled(data)
+}
+
+// sendDiscordMaintenance sends a maintenance notification via Discord.
+func (s *Service) sendDiscordMaintenance(channel *models.NotificationChannel, data MaintenanceScheduledData) error {
+	var config models.DiscordChannelConfig
+	if err := json.Unmarshal(channel.ConfigEncrypted, &config); err != nil {
+		return fmt.Errorf("parse discord config: %w", err)
+	}
+
+	discordService, err := NewDiscordService(config, s.logger)
+	if err != nil {
+		return fmt.Errorf("create discord service: %w", err)
+	}
+
+	return discordService.SendMaintenanceScheduled(data)
+}
+
+// sendPagerDutyMaintenance sends a maintenance notification via PagerDuty.
+func (s *Service) sendPagerDutyMaintenance(channel *models.NotificationChannel, data MaintenanceScheduledData) error {
+	var config models.PagerDutyChannelConfig
+	if err := json.Unmarshal(channel.ConfigEncrypted, &config); err != nil {
+		return fmt.Errorf("parse pagerduty config: %w", err)
+	}
+
+	pdService, err := NewPagerDutyService(config, s.logger)
+	if err != nil {
+		return fmt.Errorf("create pagerduty service: %w", err)
+	}
+
+	return pdService.SendMaintenanceScheduled(data)
+}
+
+// sendWebhookMaintenance sends a maintenance notification via generic webhook.
+func (s *Service) sendWebhookMaintenance(channel *models.NotificationChannel, data MaintenanceScheduledData) error {
+	var config models.WebhookChannelConfig
+	if err := json.Unmarshal(channel.ConfigEncrypted, &config); err != nil {
+		return fmt.Errorf("parse webhook config: %w", err)
+	}
+
+	webhookService, err := NewWebhookService(config, s.logger)
+	if err != nil {
+		return fmt.Errorf("create webhook service: %w", err)
+	}
+
+	return webhookService.SendMaintenanceScheduled(data)
+}
+
+// TestChannel sends a test notification to verify the channel configuration is working.
+func (s *Service) TestChannel(channel *models.NotificationChannel) error {
+	switch channel.Type {
+	case models.ChannelTypeEmail:
+		var config models.EmailChannelConfig
+		if err := json.Unmarshal(channel.ConfigEncrypted, &config); err != nil {
+			return fmt.Errorf("parse email config: %w", err)
+		}
+		smtpConfig := SMTPConfig{
+			Host:     config.Host,
+			Port:     config.Port,
+			Username: config.Username,
+			Password: config.Password,
+			From:     config.From,
+			TLS:      config.TLS,
+		}
+		emailService, err := NewEmailService(smtpConfig, s.logger)
+		if err != nil {
+			return fmt.Errorf("create email service: %w", err)
+		}
+		testData := BackupSuccessData{
+			Hostname:     "test-host",
+			ScheduleName: "Test Schedule",
+			SnapshotID:   "test-snapshot-123",
+			StartedAt:    time.Now().Add(-5 * time.Minute),
+			CompletedAt:  time.Now(),
+			Duration:     "5 minutes",
+			SizeBytes:    1024 * 1024 * 100,
+			FilesNew:     10,
+			FilesChanged: 5,
+		}
+		return emailService.SendBackupSuccess([]string{config.From}, testData)
+
+	case models.ChannelTypeSlack:
+		var config models.SlackChannelConfig
+		if err := json.Unmarshal(channel.ConfigEncrypted, &config); err != nil {
+			return fmt.Errorf("parse slack config: %w", err)
+		}
+		slackService, err := NewSlackService(config, s.logger)
+		if err != nil {
+			return fmt.Errorf("create slack service: %w", err)
+		}
+		return slackService.TestConnection()
+
+	case models.ChannelTypeTeams:
+		var config models.TeamsChannelConfig
+		if err := json.Unmarshal(channel.ConfigEncrypted, &config); err != nil {
+			return fmt.Errorf("parse teams config: %w", err)
+		}
+		teamsService, err := NewTeamsService(config, s.logger)
+		if err != nil {
+			return fmt.Errorf("create teams service: %w", err)
+		}
+		return teamsService.TestConnection()
+
+	case models.ChannelTypeDiscord:
+		var config models.DiscordChannelConfig
+		if err := json.Unmarshal(channel.ConfigEncrypted, &config); err != nil {
+			return fmt.Errorf("parse discord config: %w", err)
+		}
+		discordService, err := NewDiscordService(config, s.logger)
+		if err != nil {
+			return fmt.Errorf("create discord service: %w", err)
+		}
+		return discordService.TestConnection()
+
+	case models.ChannelTypePagerDuty:
+		var config models.PagerDutyChannelConfig
+		if err := json.Unmarshal(channel.ConfigEncrypted, &config); err != nil {
+			return fmt.Errorf("parse pagerduty config: %w", err)
+		}
+		pdService, err := NewPagerDutyService(config, s.logger)
+		if err != nil {
+			return fmt.Errorf("create pagerduty service: %w", err)
+		}
+		return pdService.TestConnection()
+
+	case models.ChannelTypeWebhook:
+		var config models.WebhookChannelConfig
+		if err := json.Unmarshal(channel.ConfigEncrypted, &config); err != nil {
+			return fmt.Errorf("parse webhook config: %w", err)
+		}
+		webhookService, err := NewWebhookService(config, s.logger)
+		if err != nil {
+			return fmt.Errorf("create webhook service: %w", err)
+		}
+		return webhookService.TestConnection()
+
+	default:
+		return fmt.Errorf("unsupported channel type: %s", channel.Type)
 	}
 }
 

--- a/internal/notifications/slack.go
+++ b/internal/notifications/slack.go
@@ -1,0 +1,249 @@
+package notifications
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/MacJediWizard/keldris/internal/models"
+	"github.com/rs/zerolog"
+)
+
+// SlackService handles sending notifications via Slack webhooks.
+type SlackService struct {
+	config models.SlackChannelConfig
+	client *http.Client
+	logger zerolog.Logger
+}
+
+// NewSlackService creates a new Slack notification service.
+func NewSlackService(config models.SlackChannelConfig, logger zerolog.Logger) (*SlackService, error) {
+	if err := ValidateSlackConfig(&config); err != nil {
+		return nil, err
+	}
+
+	return &SlackService{
+		config: config,
+		client: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		logger: logger.With().Str("component", "slack_service").Logger(),
+	}, nil
+}
+
+// ValidateSlackConfig validates the Slack configuration.
+func ValidateSlackConfig(config *models.SlackChannelConfig) error {
+	if config.WebhookURL == "" {
+		return fmt.Errorf("slack webhook URL is required")
+	}
+	return nil
+}
+
+// SlackMessage represents a Slack message payload.
+type SlackMessage struct {
+	Text        string            `json:"text,omitempty"`
+	Channel     string            `json:"channel,omitempty"`
+	Username    string            `json:"username,omitempty"`
+	IconEmoji   string            `json:"icon_emoji,omitempty"`
+	Attachments []SlackAttachment `json:"attachments,omitempty"`
+	Blocks      []SlackBlock      `json:"blocks,omitempty"`
+}
+
+// SlackAttachment represents a Slack message attachment.
+type SlackAttachment struct {
+	Color      string       `json:"color,omitempty"`
+	Title      string       `json:"title,omitempty"`
+	TitleLink  string       `json:"title_link,omitempty"`
+	Text       string       `json:"text,omitempty"`
+	Fallback   string       `json:"fallback,omitempty"`
+	Fields     []SlackField `json:"fields,omitempty"`
+	Footer     string       `json:"footer,omitempty"`
+	FooterIcon string       `json:"footer_icon,omitempty"`
+	Timestamp  int64        `json:"ts,omitempty"`
+}
+
+// SlackField represents a field in a Slack attachment.
+type SlackField struct {
+	Title string `json:"title"`
+	Value string `json:"value"`
+	Short bool   `json:"short,omitempty"`
+}
+
+// SlackBlock represents a Slack Block Kit element.
+type SlackBlock struct {
+	Type     string      `json:"type"`
+	Text     *SlackText  `json:"text,omitempty"`
+	Elements interface{} `json:"elements,omitempty"`
+}
+
+// SlackText represents text in a Slack block.
+type SlackText struct {
+	Type  string `json:"type"`
+	Text  string `json:"text"`
+	Emoji bool   `json:"emoji,omitempty"`
+}
+
+// Send sends a message to Slack.
+func (s *SlackService) Send(msg *SlackMessage) error {
+	if msg.Channel == "" && s.config.Channel != "" {
+		msg.Channel = s.config.Channel
+	}
+	if msg.Username == "" && s.config.Username != "" {
+		msg.Username = s.config.Username
+	}
+	if msg.IconEmoji == "" && s.config.IconEmoji != "" {
+		msg.IconEmoji = s.config.IconEmoji
+	}
+
+	payload, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("marshal slack message: %w", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, s.config.WebhookURL, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("create slack request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("send slack request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("slack API error: status %d, body: %s", resp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
+// SendBackupSuccess sends a backup success notification to Slack.
+func (s *SlackService) SendBackupSuccess(data BackupSuccessData) error {
+	msg := &SlackMessage{
+		Attachments: []SlackAttachment{
+			{
+				Color:    "#36a64f", // Green
+				Title:    fmt.Sprintf("Backup Successful: %s", data.Hostname),
+				Fallback: fmt.Sprintf("Backup completed successfully for %s - %s", data.Hostname, data.ScheduleName),
+				Fields: []SlackField{
+					{Title: "Host", Value: data.Hostname, Short: true},
+					{Title: "Schedule", Value: data.ScheduleName, Short: true},
+					{Title: "Snapshot ID", Value: data.SnapshotID, Short: true},
+					{Title: "Duration", Value: data.Duration, Short: true},
+					{Title: "Files New", Value: fmt.Sprintf("%d", data.FilesNew), Short: true},
+					{Title: "Files Changed", Value: fmt.Sprintf("%d", data.FilesChanged), Short: true},
+					{Title: "Size", Value: FormatBytes(data.SizeBytes), Short: true},
+				},
+				Footer:    "Keldris Backup",
+				Timestamp: time.Now().Unix(),
+			},
+		},
+	}
+
+	s.logger.Debug().
+		Str("hostname", data.Hostname).
+		Str("schedule", data.ScheduleName).
+		Msg("sending backup success notification to Slack")
+
+	return s.Send(msg)
+}
+
+// SendBackupFailed sends a backup failed notification to Slack.
+func (s *SlackService) SendBackupFailed(data BackupFailedData) error {
+	msg := &SlackMessage{
+		Attachments: []SlackAttachment{
+			{
+				Color:    "#dc3545", // Red
+				Title:    fmt.Sprintf("Backup Failed: %s", data.Hostname),
+				Fallback: fmt.Sprintf("Backup failed for %s - %s: %s", data.Hostname, data.ScheduleName, data.ErrorMessage),
+				Fields: []SlackField{
+					{Title: "Host", Value: data.Hostname, Short: true},
+					{Title: "Schedule", Value: data.ScheduleName, Short: true},
+					{Title: "Started At", Value: data.StartedAt.Format(time.RFC822), Short: true},
+					{Title: "Failed At", Value: data.FailedAt.Format(time.RFC822), Short: true},
+					{Title: "Error", Value: data.ErrorMessage, Short: false},
+				},
+				Footer:    "Keldris Backup",
+				Timestamp: time.Now().Unix(),
+			},
+		},
+	}
+
+	s.logger.Debug().
+		Str("hostname", data.Hostname).
+		Str("schedule", data.ScheduleName).
+		Str("error", data.ErrorMessage).
+		Msg("sending backup failed notification to Slack")
+
+	return s.Send(msg)
+}
+
+// SendAgentOffline sends an agent offline notification to Slack.
+func (s *SlackService) SendAgentOffline(data AgentOfflineData) error {
+	msg := &SlackMessage{
+		Attachments: []SlackAttachment{
+			{
+				Color:    "#ffc107", // Yellow/Warning
+				Title:    fmt.Sprintf("Agent Offline: %s", data.Hostname),
+				Fallback: fmt.Sprintf("Agent %s has been offline for %s", data.Hostname, data.OfflineSince),
+				Fields: []SlackField{
+					{Title: "Host", Value: data.Hostname, Short: true},
+					{Title: "Agent ID", Value: data.AgentID, Short: true},
+					{Title: "Last Seen", Value: data.LastSeen.Format(time.RFC822), Short: true},
+					{Title: "Offline Duration", Value: data.OfflineSince, Short: true},
+				},
+				Footer:    "Keldris Backup",
+				Timestamp: time.Now().Unix(),
+			},
+		},
+	}
+
+	s.logger.Debug().
+		Str("hostname", data.Hostname).
+		Str("agent_id", data.AgentID).
+		Msg("sending agent offline notification to Slack")
+
+	return s.Send(msg)
+}
+
+// SendMaintenanceScheduled sends a maintenance scheduled notification to Slack.
+func (s *SlackService) SendMaintenanceScheduled(data MaintenanceScheduledData) error {
+	msg := &SlackMessage{
+		Attachments: []SlackAttachment{
+			{
+				Color:    "#17a2b8", // Blue/Info
+				Title:    fmt.Sprintf("Scheduled Maintenance: %s", data.Title),
+				Fallback: fmt.Sprintf("Scheduled maintenance: %s from %s to %s", data.Title, data.StartsAt.Format(time.RFC822), data.EndsAt.Format(time.RFC822)),
+				Text:     data.Message,
+				Fields: []SlackField{
+					{Title: "Starts At", Value: data.StartsAt.Format(time.RFC822), Short: true},
+					{Title: "Ends At", Value: data.EndsAt.Format(time.RFC822), Short: true},
+					{Title: "Duration", Value: data.Duration, Short: true},
+				},
+				Footer:    "Keldris Backup",
+				Timestamp: time.Now().Unix(),
+			},
+		},
+	}
+
+	s.logger.Debug().
+		Str("title", data.Title).
+		Time("starts_at", data.StartsAt).
+		Msg("sending maintenance scheduled notification to Slack")
+
+	return s.Send(msg)
+}
+
+// TestConnection sends a test message to verify the Slack webhook is working.
+func (s *SlackService) TestConnection() error {
+	msg := &SlackMessage{
+		Text: "Test notification from Keldris Backup - your Slack integration is working!",
+	}
+	return s.Send(msg)
+}

--- a/internal/notifications/teams.go
+++ b/internal/notifications/teams.go
@@ -1,0 +1,268 @@
+package notifications
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/MacJediWizard/keldris/internal/models"
+	"github.com/rs/zerolog"
+)
+
+// TeamsService handles sending notifications via Microsoft Teams webhooks.
+type TeamsService struct {
+	config models.TeamsChannelConfig
+	client *http.Client
+	logger zerolog.Logger
+}
+
+// NewTeamsService creates a new Microsoft Teams notification service.
+func NewTeamsService(config models.TeamsChannelConfig, logger zerolog.Logger) (*TeamsService, error) {
+	if err := ValidateTeamsConfig(&config); err != nil {
+		return nil, err
+	}
+
+	return &TeamsService{
+		config: config,
+		client: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		logger: logger.With().Str("component", "teams_service").Logger(),
+	}, nil
+}
+
+// ValidateTeamsConfig validates the Teams configuration.
+func ValidateTeamsConfig(config *models.TeamsChannelConfig) error {
+	if config.WebhookURL == "" {
+		return fmt.Errorf("teams webhook URL is required")
+	}
+	return nil
+}
+
+// TeamsMessage represents a Microsoft Teams Adaptive Card message.
+type TeamsMessage struct {
+	Type        string            `json:"type"`
+	Attachments []TeamsAttachment `json:"attachments"`
+}
+
+// TeamsAttachment represents an Adaptive Card attachment.
+type TeamsAttachment struct {
+	ContentType string      `json:"contentType"`
+	ContentURL  interface{} `json:"contentUrl"`
+	Content     TeamsCard   `json:"content"`
+}
+
+// TeamsCard represents an Adaptive Card structure.
+type TeamsCard struct {
+	Schema  string             `json:"$schema"`
+	Type    string             `json:"type"`
+	Version string             `json:"version"`
+	Body    []TeamsCardElement `json:"body"`
+}
+
+// TeamsCardElement represents an element in an Adaptive Card body.
+type TeamsCardElement struct {
+	Type      string             `json:"type"`
+	Text      string             `json:"text,omitempty"`
+	Weight    string             `json:"weight,omitempty"`
+	Size      string             `json:"size,omitempty"`
+	Color     string             `json:"color,omitempty"`
+	Wrap      bool               `json:"wrap,omitempty"`
+	Spacing   string             `json:"spacing,omitempty"`
+	Separator bool               `json:"separator,omitempty"`
+	Facts     []TeamsCardFact    `json:"facts,omitempty"`
+	Columns   []TeamsCardColumn  `json:"columns,omitempty"`
+	Items     []TeamsCardElement `json:"items,omitempty"`
+}
+
+// TeamsCardFact represents a fact in a FactSet.
+type TeamsCardFact struct {
+	Title string `json:"title"`
+	Value string `json:"value"`
+}
+
+// TeamsCardColumn represents a column in a ColumnSet.
+type TeamsCardColumn struct {
+	Type  string             `json:"type"`
+	Width string             `json:"width,omitempty"`
+	Items []TeamsCardElement `json:"items,omitempty"`
+}
+
+// NewTeamsMessage creates a new Teams message with the adaptive card format.
+func NewTeamsMessage() *TeamsMessage {
+	return &TeamsMessage{
+		Type: "message",
+		Attachments: []TeamsAttachment{
+			{
+				ContentType: "application/vnd.microsoft.card.adaptive",
+				ContentURL:  nil,
+				Content: TeamsCard{
+					Schema:  "http://adaptivecards.io/schemas/adaptive-card.json",
+					Type:    "AdaptiveCard",
+					Version: "1.4",
+					Body:    []TeamsCardElement{},
+				},
+			},
+		},
+	}
+}
+
+// AddHeader adds a header element to the card.
+func (m *TeamsMessage) AddHeader(text string, color string) {
+	if len(m.Attachments) == 0 {
+		return
+	}
+	element := TeamsCardElement{
+		Type:   "TextBlock",
+		Text:   text,
+		Weight: "Bolder",
+		Size:   "Medium",
+		Color:  color,
+	}
+	m.Attachments[0].Content.Body = append(m.Attachments[0].Content.Body, element)
+}
+
+// AddText adds a text block to the card.
+func (m *TeamsMessage) AddText(text string, wrap bool) {
+	if len(m.Attachments) == 0 {
+		return
+	}
+	element := TeamsCardElement{
+		Type: "TextBlock",
+		Text: text,
+		Wrap: wrap,
+	}
+	m.Attachments[0].Content.Body = append(m.Attachments[0].Content.Body, element)
+}
+
+// AddFactSet adds a FactSet element to the card.
+func (m *TeamsMessage) AddFactSet(facts []TeamsCardFact) {
+	if len(m.Attachments) == 0 {
+		return
+	}
+	element := TeamsCardElement{
+		Type:  "FactSet",
+		Facts: facts,
+	}
+	m.Attachments[0].Content.Body = append(m.Attachments[0].Content.Body, element)
+}
+
+// Send sends a message to Microsoft Teams.
+func (s *TeamsService) Send(msg *TeamsMessage) error {
+	payload, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("marshal teams message: %w", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, s.config.WebhookURL, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("create teams request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("send teams request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("teams API error: status %d, body: %s", resp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
+// SendBackupSuccess sends a backup success notification to Teams.
+func (s *TeamsService) SendBackupSuccess(data BackupSuccessData) error {
+	msg := NewTeamsMessage()
+	msg.AddHeader(fmt.Sprintf("Backup Successful: %s", data.Hostname), "Good")
+	msg.AddFactSet([]TeamsCardFact{
+		{Title: "Host", Value: data.Hostname},
+		{Title: "Schedule", Value: data.ScheduleName},
+		{Title: "Snapshot ID", Value: data.SnapshotID},
+		{Title: "Duration", Value: data.Duration},
+		{Title: "Files New", Value: fmt.Sprintf("%d", data.FilesNew)},
+		{Title: "Files Changed", Value: fmt.Sprintf("%d", data.FilesChanged)},
+		{Title: "Size", Value: FormatBytes(data.SizeBytes)},
+		{Title: "Completed At", Value: data.CompletedAt.Format(time.RFC822)},
+	})
+
+	s.logger.Debug().
+		Str("hostname", data.Hostname).
+		Str("schedule", data.ScheduleName).
+		Msg("sending backup success notification to Teams")
+
+	return s.Send(msg)
+}
+
+// SendBackupFailed sends a backup failed notification to Teams.
+func (s *TeamsService) SendBackupFailed(data BackupFailedData) error {
+	msg := NewTeamsMessage()
+	msg.AddHeader(fmt.Sprintf("Backup Failed: %s", data.Hostname), "Attention")
+	msg.AddFactSet([]TeamsCardFact{
+		{Title: "Host", Value: data.Hostname},
+		{Title: "Schedule", Value: data.ScheduleName},
+		{Title: "Started At", Value: data.StartedAt.Format(time.RFC822)},
+		{Title: "Failed At", Value: data.FailedAt.Format(time.RFC822)},
+	})
+	msg.AddText(fmt.Sprintf("**Error:** %s", data.ErrorMessage), true)
+
+	s.logger.Debug().
+		Str("hostname", data.Hostname).
+		Str("schedule", data.ScheduleName).
+		Str("error", data.ErrorMessage).
+		Msg("sending backup failed notification to Teams")
+
+	return s.Send(msg)
+}
+
+// SendAgentOffline sends an agent offline notification to Teams.
+func (s *TeamsService) SendAgentOffline(data AgentOfflineData) error {
+	msg := NewTeamsMessage()
+	msg.AddHeader(fmt.Sprintf("Agent Offline: %s", data.Hostname), "Warning")
+	msg.AddFactSet([]TeamsCardFact{
+		{Title: "Host", Value: data.Hostname},
+		{Title: "Agent ID", Value: data.AgentID},
+		{Title: "Last Seen", Value: data.LastSeen.Format(time.RFC822)},
+		{Title: "Offline Duration", Value: data.OfflineSince},
+	})
+
+	s.logger.Debug().
+		Str("hostname", data.Hostname).
+		Str("agent_id", data.AgentID).
+		Msg("sending agent offline notification to Teams")
+
+	return s.Send(msg)
+}
+
+// SendMaintenanceScheduled sends a maintenance scheduled notification to Teams.
+func (s *TeamsService) SendMaintenanceScheduled(data MaintenanceScheduledData) error {
+	msg := NewTeamsMessage()
+	msg.AddHeader(fmt.Sprintf("Scheduled Maintenance: %s", data.Title), "Accent")
+	msg.AddText(data.Message, true)
+	msg.AddFactSet([]TeamsCardFact{
+		{Title: "Starts At", Value: data.StartsAt.Format(time.RFC822)},
+		{Title: "Ends At", Value: data.EndsAt.Format(time.RFC822)},
+		{Title: "Duration", Value: data.Duration},
+	})
+
+	s.logger.Debug().
+		Str("title", data.Title).
+		Time("starts_at", data.StartsAt).
+		Msg("sending maintenance scheduled notification to Teams")
+
+	return s.Send(msg)
+}
+
+// TestConnection sends a test message to verify the Teams webhook is working.
+func (s *TeamsService) TestConnection() error {
+	msg := NewTeamsMessage()
+	msg.AddHeader("Keldris Backup - Test Notification", "Good")
+	msg.AddText("Your Microsoft Teams integration is working correctly!", true)
+	return s.Send(msg)
+}

--- a/internal/notifications/webhook.go
+++ b/internal/notifications/webhook.go
@@ -1,0 +1,275 @@
+package notifications
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/MacJediWizard/keldris/internal/models"
+	"github.com/rs/zerolog"
+)
+
+// WebhookService handles sending notifications via generic webhooks.
+type WebhookService struct {
+	config models.WebhookChannelConfig
+	client *http.Client
+	logger zerolog.Logger
+}
+
+// NewWebhookService creates a new generic webhook notification service.
+func NewWebhookService(config models.WebhookChannelConfig, logger zerolog.Logger) (*WebhookService, error) {
+	if err := ValidateWebhookConfig(&config); err != nil {
+		return nil, err
+	}
+
+	// Set defaults
+	if config.Method == "" {
+		config.Method = http.MethodPost
+	}
+	if config.ContentType == "" {
+		config.ContentType = "application/json"
+	}
+
+	return &WebhookService{
+		config: config,
+		client: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		logger: logger.With().Str("component", "webhook_service").Logger(),
+	}, nil
+}
+
+// ValidateWebhookConfig validates the webhook configuration.
+func ValidateWebhookConfig(config *models.WebhookChannelConfig) error {
+	if config.URL == "" {
+		return fmt.Errorf("webhook URL is required")
+	}
+	return nil
+}
+
+// WebhookPayload represents the standard payload sent to webhooks.
+type WebhookPayload struct {
+	EventType   string                 `json:"event_type"`
+	EventTime   time.Time              `json:"event_time"`
+	Source      string                 `json:"source"`
+	Summary     string                 `json:"summary"`
+	Severity    string                 `json:"severity"`
+	Details     map[string]interface{} `json:"details,omitempty"`
+}
+
+// Send sends a payload to the configured webhook.
+func (s *WebhookService) Send(payload *WebhookPayload) error {
+	var body []byte
+	var err error
+
+	// If a custom template is configured, use it
+	if s.config.Template != "" {
+		body, err = s.renderTemplate(payload)
+		if err != nil {
+			return fmt.Errorf("render template: %w", err)
+		}
+	} else {
+		body, err = json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("marshal webhook payload: %w", err)
+		}
+	}
+
+	req, err := http.NewRequest(s.config.Method, s.config.URL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create webhook request: %w", err)
+	}
+
+	// Set content type
+	req.Header.Set("Content-Type", s.config.ContentType)
+
+	// Apply custom headers
+	for key, value := range s.config.Headers {
+		req.Header.Set(key, value)
+	}
+
+	// Apply authentication
+	if err := s.applyAuth(req); err != nil {
+		return fmt.Errorf("apply authentication: %w", err)
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("send webhook request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Accept 2xx status codes
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("webhook error: status %d, body: %s", resp.StatusCode, string(respBody))
+	}
+
+	return nil
+}
+
+// applyAuth applies authentication to the request based on config.
+func (s *WebhookService) applyAuth(req *http.Request) error {
+	switch strings.ToLower(s.config.AuthType) {
+	case "bearer", "token":
+		if s.config.AuthToken != "" {
+			req.Header.Set("Authorization", "Bearer "+s.config.AuthToken)
+		}
+	case "basic":
+		if s.config.BasicUser != "" {
+			auth := base64.StdEncoding.EncodeToString(
+				[]byte(s.config.BasicUser + ":" + s.config.BasicPass),
+			)
+			req.Header.Set("Authorization", "Basic "+auth)
+		}
+	case "header":
+		// Auth token is set as a custom header - already handled by custom headers
+	case "":
+		// No authentication
+	default:
+		return fmt.Errorf("unsupported auth type: %s", s.config.AuthType)
+	}
+	return nil
+}
+
+// renderTemplate renders the custom template with the payload data.
+func (s *WebhookService) renderTemplate(payload *WebhookPayload) ([]byte, error) {
+	tmpl, err := template.New("webhook").Parse(s.config.Template)
+	if err != nil {
+		return nil, fmt.Errorf("parse template: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, payload); err != nil {
+		return nil, fmt.Errorf("execute template: %w", err)
+	}
+
+	return buf.Bytes(), nil
+}
+
+// SendBackupSuccess sends a backup success notification via webhook.
+func (s *WebhookService) SendBackupSuccess(data BackupSuccessData) error {
+	payload := &WebhookPayload{
+		EventType: "backup_success",
+		EventTime: time.Now().UTC(),
+		Source:    "keldris-backup",
+		Summary:   fmt.Sprintf("Backup Successful: %s - %s", data.Hostname, data.ScheduleName),
+		Severity:  "info",
+		Details: map[string]interface{}{
+			"hostname":      data.Hostname,
+			"schedule":      data.ScheduleName,
+			"snapshot_id":   data.SnapshotID,
+			"started_at":    data.StartedAt.Format(time.RFC3339),
+			"completed_at":  data.CompletedAt.Format(time.RFC3339),
+			"duration":      data.Duration,
+			"files_new":     data.FilesNew,
+			"files_changed": data.FilesChanged,
+			"size_bytes":    data.SizeBytes,
+			"size_human":    FormatBytes(data.SizeBytes),
+		},
+	}
+
+	s.logger.Debug().
+		Str("hostname", data.Hostname).
+		Str("schedule", data.ScheduleName).
+		Msg("sending backup success notification via webhook")
+
+	return s.Send(payload)
+}
+
+// SendBackupFailed sends a backup failed notification via webhook.
+func (s *WebhookService) SendBackupFailed(data BackupFailedData) error {
+	payload := &WebhookPayload{
+		EventType: "backup_failed",
+		EventTime: time.Now().UTC(),
+		Source:    "keldris-backup",
+		Summary:   fmt.Sprintf("Backup Failed: %s - %s", data.Hostname, data.ScheduleName),
+		Severity:  "error",
+		Details: map[string]interface{}{
+			"hostname":      data.Hostname,
+			"schedule":      data.ScheduleName,
+			"started_at":    data.StartedAt.Format(time.RFC3339),
+			"failed_at":     data.FailedAt.Format(time.RFC3339),
+			"error_message": data.ErrorMessage,
+		},
+	}
+
+	s.logger.Debug().
+		Str("hostname", data.Hostname).
+		Str("schedule", data.ScheduleName).
+		Str("error", data.ErrorMessage).
+		Msg("sending backup failed notification via webhook")
+
+	return s.Send(payload)
+}
+
+// SendAgentOffline sends an agent offline notification via webhook.
+func (s *WebhookService) SendAgentOffline(data AgentOfflineData) error {
+	payload := &WebhookPayload{
+		EventType: "agent_offline",
+		EventTime: time.Now().UTC(),
+		Source:    "keldris-backup",
+		Summary:   fmt.Sprintf("Agent Offline: %s", data.Hostname),
+		Severity:  "warning",
+		Details: map[string]interface{}{
+			"hostname":       data.Hostname,
+			"agent_id":       data.AgentID,
+			"last_seen":      data.LastSeen.Format(time.RFC3339),
+			"offline_since":  data.OfflineSince,
+		},
+	}
+
+	s.logger.Debug().
+		Str("hostname", data.Hostname).
+		Str("agent_id", data.AgentID).
+		Msg("sending agent offline notification via webhook")
+
+	return s.Send(payload)
+}
+
+// SendMaintenanceScheduled sends a maintenance scheduled notification via webhook.
+func (s *WebhookService) SendMaintenanceScheduled(data MaintenanceScheduledData) error {
+	payload := &WebhookPayload{
+		EventType: "maintenance_scheduled",
+		EventTime: time.Now().UTC(),
+		Source:    "keldris-backup",
+		Summary:   fmt.Sprintf("Scheduled Maintenance: %s", data.Title),
+		Severity:  "info",
+		Details: map[string]interface{}{
+			"title":     data.Title,
+			"message":   data.Message,
+			"starts_at": data.StartsAt.Format(time.RFC3339),
+			"ends_at":   data.EndsAt.Format(time.RFC3339),
+			"duration":  data.Duration,
+		},
+	}
+
+	s.logger.Debug().
+		Str("title", data.Title).
+		Time("starts_at", data.StartsAt).
+		Msg("sending maintenance scheduled notification via webhook")
+
+	return s.Send(payload)
+}
+
+// TestConnection sends a test event to verify the webhook is working.
+func (s *WebhookService) TestConnection() error {
+	payload := &WebhookPayload{
+		EventType: "test",
+		EventTime: time.Now().UTC(),
+		Source:    "keldris-backup",
+		Summary:   "Keldris Backup - Test Notification",
+		Severity:  "info",
+		Details: map[string]interface{}{
+			"message": "Your webhook integration is working correctly!",
+			"test":    true,
+		},
+	}
+	return s.Send(payload)
+}


### PR DESCRIPTION
## Summary
Implements comprehensive multi-channel notification support for backup events. Adds handlers for Slack, Microsoft Teams, Discord, PagerDuty, and generic webhooks to complement existing email notifications. Includes config models, test endpoints, and unified service dispatching.

## Changes
- 5 new channel handlers with rich formatting per platform
- Config structs for each channel type
- Unified service dispatcher supporting all channels
- Test channel API endpoint for configuration verification
- Channel types metadata endpoint for UI setup wizards

🤖 Generated with [Claude Code](https://claude.com/claude-code)