### PR TITLE
Implement navigation breadcrumbs throughout UI

### DIFF
--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -23,6 +23,7 @@ import { LanguageSelector } from './features/LanguageSelector';
 import { MaintenanceCountdown } from './features/MaintenanceCountdown';
 import { ShortcutHelpModal } from './features/ShortcutHelpModal';
 import { WhatsNewModal } from './features/WhatsNewModal';
+import { Breadcrumbs } from './ui/Breadcrumbs';
 
 interface NavItem {
 	path: string;
@@ -964,6 +965,7 @@ export function Layout() {
 					<div className="flex-1 flex flex-col">
 						<Header />
 						<main className="flex-1 p-6">
+							<Breadcrumbs />
 							<Outlet />
 						</main>
 					</div>

--- a/web/src/components/ui/Breadcrumbs.tsx
+++ b/web/src/components/ui/Breadcrumbs.tsx
@@ -1,0 +1,161 @@
+import { Link } from 'react-router-dom';
+import type { BreadcrumbItem } from '../../hooks/useBreadcrumbs';
+import { useBreadcrumbs } from '../../hooks/useBreadcrumbs';
+
+interface BreadcrumbsProps {
+	items?: BreadcrumbItem[];
+	className?: string;
+}
+
+export function Breadcrumbs({ items, className = '' }: BreadcrumbsProps) {
+	const { breadcrumbs: autoBreadcrumbs, isLoading } = useBreadcrumbs();
+	const breadcrumbs = items ?? autoBreadcrumbs;
+
+	// Don't render if only Dashboard (home page)
+	if (breadcrumbs.length <= 1) {
+		return null;
+	}
+
+	return (
+		<nav aria-label="Breadcrumb" className={`mb-4 ${className}`}>
+			<ol className="flex items-center space-x-2 text-sm">
+				{breadcrumbs.map((item, index) => (
+					<li key={item.path} className="flex items-center">
+						{index > 0 && (
+							<svg
+								aria-hidden="true"
+								className="w-4 h-4 text-gray-400 dark:text-gray-500 mx-2"
+								fill="none"
+								stroke="currentColor"
+								viewBox="0 0 24 24"
+							>
+								<path
+									strokeLinecap="round"
+									strokeLinejoin="round"
+									strokeWidth={2}
+									d="M9 5l7 7-7 7"
+								/>
+							</svg>
+						)}
+						{item.isCurrentPage ? (
+							<span
+								className="text-gray-900 dark:text-white font-medium"
+								aria-current="page"
+							>
+								{isLoading && index === breadcrumbs.length - 1 ? (
+									<span className="inline-block w-20 h-4 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
+								) : (
+									item.label
+								)}
+							</span>
+						) : (
+							<Link
+								to={item.path}
+								className="text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 transition-colors"
+							>
+								{index === 0 ? (
+									<span className="flex items-center gap-1">
+										<svg
+											aria-hidden="true"
+											className="w-4 h-4"
+											fill="none"
+											stroke="currentColor"
+											viewBox="0 0 24 24"
+										>
+											<path
+												strokeLinecap="round"
+												strokeLinejoin="round"
+												strokeWidth={2}
+												d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"
+											/>
+										</svg>
+										<span className="sr-only">{item.label}</span>
+									</span>
+								) : (
+									item.label
+								)}
+							</Link>
+						)}
+					</li>
+				))}
+			</ol>
+		</nav>
+	);
+}
+
+interface BreadcrumbsWithItemsProps {
+	items: BreadcrumbItem[];
+	className?: string;
+}
+
+export function BreadcrumbsWithItems({
+	items,
+	className = '',
+}: BreadcrumbsWithItemsProps) {
+	// Don't render if only one item
+	if (items.length <= 1) {
+		return null;
+	}
+
+	return (
+		<nav aria-label="Breadcrumb" className={`mb-4 ${className}`}>
+			<ol className="flex items-center space-x-2 text-sm">
+				{items.map((item, index) => (
+					<li key={item.path} className="flex items-center">
+						{index > 0 && (
+							<svg
+								aria-hidden="true"
+								className="w-4 h-4 text-gray-400 dark:text-gray-500 mx-2"
+								fill="none"
+								stroke="currentColor"
+								viewBox="0 0 24 24"
+							>
+								<path
+									strokeLinecap="round"
+									strokeLinejoin="round"
+									strokeWidth={2}
+									d="M9 5l7 7-7 7"
+								/>
+							</svg>
+						)}
+						{item.isCurrentPage ? (
+							<span
+								className="text-gray-900 dark:text-white font-medium"
+								aria-current="page"
+							>
+								{item.label}
+							</span>
+						) : (
+							<Link
+								to={item.path}
+								className="text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 transition-colors"
+							>
+								{index === 0 ? (
+									<span className="flex items-center gap-1">
+										<svg
+											aria-hidden="true"
+											className="w-4 h-4"
+											fill="none"
+											stroke="currentColor"
+											viewBox="0 0 24 24"
+										>
+											<path
+												strokeLinecap="round"
+												strokeLinejoin="round"
+												strokeWidth={2}
+												d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"
+											/>
+										</svg>
+										<span className="sr-only">{item.label}</span>
+									</span>
+								) : (
+									item.label
+								)}
+							</Link>
+						)}
+					</li>
+				))}
+			</ol>
+		</nav>
+	);
+}

--- a/web/src/hooks/useBreadcrumbs.ts
+++ b/web/src/hooks/useBreadcrumbs.ts
@@ -1,0 +1,210 @@
+import { useMemo } from 'react';
+import { useLocation, useParams } from 'react-router-dom';
+import { useAgent } from './useAgents';
+import { useRepositoryStats } from './useStorageStats';
+
+export interface BreadcrumbItem {
+	label: string;
+	path: string;
+	isCurrentPage: boolean;
+}
+
+// Static route labels mapping
+const routeLabels: Record<string, string> = {
+	'': 'Dashboard',
+	agents: 'Agents',
+	'agent-groups': 'Agent Groups',
+	repositories: 'Repositories',
+	schedules: 'Schedules',
+	policies: 'Policies',
+	templates: 'Templates',
+	backups: 'Backups',
+	'dr-runbooks': 'DR Runbooks',
+	restore: 'Restore',
+	'file-history': 'File History',
+	'file-search': 'File Search',
+	snapshots: 'Snapshots',
+	compare: 'Compare',
+	'file-diff': 'File Diff',
+	alerts: 'Alerts',
+	downtime: 'Downtime History',
+	notifications: 'Notifications',
+	'notification-rules': 'Notification Rules',
+	reports: 'Reports',
+	'audit-logs': 'Audit Logs',
+	'legal-holds': 'Legal Holds',
+	'lifecycle-policies': 'Lifecycle Policies',
+	stats: 'Storage Stats',
+	tags: 'Tags',
+	classifications: 'Classifications',
+	costs: 'Cost Estimation',
+	sla: 'SLA',
+	organization: 'Organization',
+	members: 'Members',
+	settings: 'Settings',
+	sso: 'SSO Group Sync',
+	maintenance: 'Maintenance',
+	announcements: 'Announcements',
+	'ip-allowlist': 'IP Allowlist',
+	'password-policies': 'Password Policy',
+	new: 'Create New',
+	admin: 'Admin',
+	logs: 'Server Logs',
+	'rate-limits': 'Rate Limits',
+	'rate-limit-configs': 'Rate Limit Configs',
+	account: 'Account',
+	sessions: 'Sessions',
+	onboarding: 'Onboarding',
+	changelog: 'Changelog',
+};
+
+function isUuid(str: string): boolean {
+	return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+		str,
+	);
+}
+
+interface UseBreadcrumbsOptions {
+	agentHostname?: string;
+	repositoryName?: string;
+}
+
+export function useBreadcrumbs(options?: UseBreadcrumbsOptions): {
+	breadcrumbs: BreadcrumbItem[];
+	isLoading: boolean;
+} {
+	const location = useLocation();
+	const params = useParams();
+
+	// Check if we're on a dynamic route that needs name resolution
+	const agentId =
+		location.pathname.startsWith('/agents/') && params.id ? params.id : null;
+	const repoId =
+		location.pathname.startsWith('/stats/') && params.id ? params.id : null;
+
+	// Fetch agent name if on agent details page
+	const { data: agent, isLoading: agentLoading } = useAgent(agentId ?? '');
+
+	// Fetch repository name if on stats detail page
+	const { data: repoStats, isLoading: repoLoading } = useRepositoryStats(
+		repoId ?? '',
+	);
+
+	const isLoading =
+		(agentId !== null && agentLoading) || (repoId !== null && repoLoading);
+
+	const breadcrumbs = useMemo(() => {
+		const pathSegments = location.pathname.split('/').filter(Boolean);
+		const items: BreadcrumbItem[] = [];
+
+		// Always add Home/Dashboard
+		items.push({
+			label: 'Dashboard',
+			path: '/',
+			isCurrentPage: pathSegments.length === 0,
+		});
+
+		// Build breadcrumb items for each segment
+		let currentPath = '';
+		pathSegments.forEach((segment, index) => {
+			currentPath += `/${segment}`;
+			const isLastSegment = index === pathSegments.length - 1;
+
+			// Check if this segment is a dynamic ID
+			if (isUuid(segment)) {
+				// Use provided name or fetched name, or fallback to truncated ID
+				let label = `${segment.substring(0, 8)}...`;
+
+				if (
+					agentId === segment &&
+					(options?.agentHostname || agent?.hostname)
+				) {
+					label = options?.agentHostname || agent?.hostname || label;
+				} else if (
+					repoId === segment &&
+					(options?.repositoryName || repoStats?.repository_name)
+				) {
+					label =
+						options?.repositoryName || repoStats?.repository_name || label;
+				}
+
+				items.push({
+					label,
+					path: currentPath,
+					isCurrentPage: isLastSegment,
+				});
+			} else {
+				// Use static label from mapping
+				const label = routeLabels[segment] || segment;
+				items.push({
+					label,
+					path: currentPath,
+					isCurrentPage: isLastSegment,
+				});
+			}
+		});
+
+		return items;
+	}, [
+		location.pathname,
+		agentId,
+		repoId,
+		agent?.hostname,
+		repoStats?.repository_name,
+		options?.agentHostname,
+		options?.repositoryName,
+	]);
+
+	return { breadcrumbs, isLoading };
+}
+
+// Hook for pages that want to provide their own dynamic name
+export function useBreadcrumbsWithName(name?: string): {
+	breadcrumbs: BreadcrumbItem[];
+	isLoading: boolean;
+} {
+	const location = useLocation();
+
+	const breadcrumbs = useMemo(() => {
+		const pathSegments = location.pathname.split('/').filter(Boolean);
+		const items: BreadcrumbItem[] = [];
+
+		// Always add Home/Dashboard
+		items.push({
+			label: 'Dashboard',
+			path: '/',
+			isCurrentPage: pathSegments.length === 0,
+		});
+
+		// Build breadcrumb items for each segment
+		let currentPath = '';
+		pathSegments.forEach((segment, index) => {
+			currentPath += `/${segment}`;
+			const isLastSegment = index === pathSegments.length - 1;
+
+			// Check if this segment is a dynamic ID
+			if (isUuid(segment)) {
+				// Use provided name for the last segment if it's a UUID
+				const label =
+					isLastSegment && name ? name : `${segment.substring(0, 8)}...`;
+				items.push({
+					label,
+					path: currentPath,
+					isCurrentPage: isLastSegment,
+				});
+			} else {
+				// Use static label from mapping
+				const label = routeLabels[segment] || segment;
+				items.push({
+					label,
+					path: currentPath,
+					isCurrentPage: isLastSegment,
+				});
+			}
+		});
+
+		return items;
+	}, [location.pathname, name]);
+
+	return { breadcrumbs, isLoading: false };
+}


### PR DESCRIPTION
## Summary
- Add dynamic breadcrumb component that displays the current navigation path with clickable segments
- Breadcrumbs automatically resolve dynamic IDs (agents, repositories) to their friendly names
- Component integrates seamlessly with the layout and supports dark mode

## Test plan
- Navigate to various pages and verify breadcrumbs display correctly
- Click breadcrumb segments and verify navigation works
- Test dynamic ID resolution on agent details and repository stats pages
- Verify dark mode styling on breadcrumbs

🤖 Generated with [Claude Code](https://claude.com/claude-code)