### PR TITLE
Implement contextual upgrade prompts for plan-gated features

### DIFF
--- a/web/src/components/features/UpgradePrompt.tsx
+++ b/web/src/components/features/UpgradePrompt.tsx
@@ -1,0 +1,449 @@
+import { Link } from 'react-router-dom';
+import {
+	FEATURE_BENEFITS,
+	FEATURE_NAMES,
+	FEATURE_REQUIRED_PLAN,
+} from '../../hooks/usePlanLimits';
+import type { PlanType, UpgradeFeature } from '../../lib/types';
+import {
+	PLAN_NAMES,
+	PLAN_PRICING,
+	generateContactSalesLink,
+	generateUpgradeLink,
+	requiresSales,
+} from '../../lib/upgrade';
+
+export type UpgradePromptVariant = 'inline' | 'banner' | 'card' | 'modal';
+
+interface UpgradePromptProps {
+	feature: UpgradeFeature;
+	variant?: UpgradePromptVariant;
+	currentPlan?: PlanType;
+	source?: string;
+	onDismiss?: () => void;
+	showBenefits?: boolean;
+	className?: string;
+}
+
+function UpgradeIcon({ className }: { className?: string }) {
+	return (
+		<svg
+			aria-hidden="true"
+			className={className}
+			fill="none"
+			stroke="currentColor"
+			viewBox="0 0 24 24"
+		>
+			<path
+				strokeLinecap="round"
+				strokeLinejoin="round"
+				strokeWidth={2}
+				d="M5 10l7-7m0 0l7 7m-7-7v18"
+			/>
+		</svg>
+	);
+}
+
+function SparklesIcon({ className }: { className?: string }) {
+	return (
+		<svg
+			aria-hidden="true"
+			className={className}
+			fill="none"
+			stroke="currentColor"
+			viewBox="0 0 24 24"
+		>
+			<path
+				strokeLinecap="round"
+				strokeLinejoin="round"
+				strokeWidth={2}
+				d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"
+			/>
+		</svg>
+	);
+}
+
+function CloseIcon({ className }: { className?: string }) {
+	return (
+		<svg
+			aria-hidden="true"
+			className={className}
+			fill="currentColor"
+			viewBox="0 0 20 20"
+		>
+			<path
+				fillRule="evenodd"
+				d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+				clipRule="evenodd"
+			/>
+		</svg>
+	);
+}
+
+function UpgradeButton({
+	feature,
+	source,
+	targetPlan,
+	size = 'normal',
+}: {
+	feature: UpgradeFeature;
+	source?: string;
+	targetPlan: PlanType;
+	size?: 'small' | 'normal';
+}) {
+	const isSales = requiresSales(targetPlan);
+	const link = isSales
+		? generateContactSalesLink({ feature, source })
+		: generateUpgradeLink({ feature, source, targetPlan });
+
+	const sizeClasses =
+		size === 'small' ? 'px-3 py-1.5 text-sm' : 'px-4 py-2 text-sm font-medium';
+
+	return (
+		<Link
+			to={link}
+			className={`inline-flex items-center gap-2 ${sizeClasses} bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors`}
+		>
+			{isSales ? (
+				<>
+					<SparklesIcon className="w-4 h-4" />
+					Contact Sales
+				</>
+			) : (
+				<>
+					<UpgradeIcon className="w-4 h-4" />
+					Upgrade to {PLAN_NAMES[targetPlan]}
+				</>
+			)}
+		</Link>
+	);
+}
+
+export function UpgradePromptInline({
+	feature,
+	source,
+	className = '',
+}: Omit<UpgradePromptProps, 'variant'>) {
+	const targetPlan = FEATURE_REQUIRED_PLAN[feature];
+	const featureName = FEATURE_NAMES[feature];
+
+	return (
+		<span
+			className={`inline-flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400 ${className}`}
+		>
+			<SparklesIcon className="w-4 h-4 text-indigo-500" />
+			<span>
+				{featureName} requires{' '}
+				<Link
+					to={generateUpgradeLink({ feature, source, targetPlan })}
+					className="text-indigo-600 dark:text-indigo-400 hover:underline font-medium"
+				>
+					{PLAN_NAMES[targetPlan]}
+				</Link>
+			</span>
+		</span>
+	);
+}
+
+export function UpgradePromptBanner({
+	feature,
+	source,
+	onDismiss,
+	className = '',
+}: Omit<UpgradePromptProps, 'variant'>) {
+	const targetPlan = FEATURE_REQUIRED_PLAN[feature];
+	const featureName = FEATURE_NAMES[feature];
+
+	return (
+		<div
+			className={`flex items-center justify-between gap-4 px-4 py-3 bg-indigo-50 dark:bg-indigo-900/20 border border-indigo-200 dark:border-indigo-800 rounded-lg ${className}`}
+		>
+			<div className="flex items-center gap-3">
+				<div className="p-2 bg-indigo-100 dark:bg-indigo-800 rounded-full">
+					<SparklesIcon className="w-5 h-5 text-indigo-600 dark:text-indigo-400" />
+				</div>
+				<div>
+					<p className="text-sm font-medium text-gray-900 dark:text-white">
+						Unlock {featureName}
+					</p>
+					<p className="text-sm text-gray-600 dark:text-gray-400">
+						Upgrade to {PLAN_NAMES[targetPlan]} to access this feature
+					</p>
+				</div>
+			</div>
+			<div className="flex items-center gap-2">
+				<UpgradeButton
+					feature={feature}
+					source={source}
+					targetPlan={targetPlan}
+					size="small"
+				/>
+				{onDismiss && (
+					<button
+						type="button"
+						onClick={onDismiss}
+						className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 rounded-lg"
+						aria-label="Dismiss"
+					>
+						<CloseIcon className="w-5 h-5" />
+					</button>
+				)}
+			</div>
+		</div>
+	);
+}
+
+export function UpgradePromptCard({
+	feature,
+	source,
+	showBenefits = true,
+	className = '',
+}: Omit<UpgradePromptProps, 'variant'>) {
+	const targetPlan = FEATURE_REQUIRED_PLAN[feature];
+	const featureName = FEATURE_NAMES[feature];
+	const benefits = FEATURE_BENEFITS[feature];
+	const isSales = requiresSales(targetPlan);
+
+	return (
+		<div
+			className={`bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm overflow-hidden ${className}`}
+		>
+			<div className="p-6">
+				<div className="flex items-start gap-4">
+					<div className="p-3 bg-gradient-to-br from-indigo-500 to-purple-500 rounded-lg">
+						<SparklesIcon className="w-6 h-6 text-white" />
+					</div>
+					<div className="flex-1">
+						<h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+							{featureName}
+						</h3>
+						<p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+							Available on {PLAN_NAMES[targetPlan]}
+							{!isSales && ` (${PLAN_PRICING[targetPlan]})`}
+						</p>
+					</div>
+				</div>
+
+				{showBenefits && benefits.length > 0 && (
+					<ul className="mt-4 space-y-2">
+						{benefits.map((benefit) => (
+							<li
+								key={benefit}
+								className="flex items-start gap-2 text-sm text-gray-600 dark:text-gray-400"
+							>
+								<svg
+									aria-hidden="true"
+									className="w-5 h-5 text-green-500 flex-shrink-0 mt-0.5"
+									fill="currentColor"
+									viewBox="0 0 20 20"
+								>
+									<path
+										fillRule="evenodd"
+										d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+										clipRule="evenodd"
+									/>
+								</svg>
+								{benefit}
+							</li>
+						))}
+					</ul>
+				)}
+
+				<div className="mt-6">
+					<UpgradeButton
+						feature={feature}
+						source={source}
+						targetPlan={targetPlan}
+					/>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+export function UpgradePromptModal({
+	feature,
+	source,
+	onDismiss,
+	showBenefits = true,
+}: Omit<UpgradePromptProps, 'variant'>) {
+	const targetPlan = FEATURE_REQUIRED_PLAN[feature];
+	const featureName = FEATURE_NAMES[feature];
+	const benefits = FEATURE_BENEFITS[feature];
+	const isSales = requiresSales(targetPlan);
+
+	return (
+		<div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+			<div className="bg-white dark:bg-gray-800 rounded-lg p-6 max-w-md w-full mx-4">
+				<div className="flex items-start justify-between gap-4 mb-4">
+					<div className="flex items-center gap-3">
+						<div className="p-3 bg-gradient-to-br from-indigo-500 to-purple-500 rounded-lg">
+							<SparklesIcon className="w-6 h-6 text-white" />
+						</div>
+						<div>
+							<h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+								Unlock {featureName}
+							</h3>
+							<p className="text-sm text-gray-600 dark:text-gray-400">
+								{PLAN_NAMES[targetPlan]} Plan
+								{!isSales && ` - ${PLAN_PRICING[targetPlan]}`}
+							</p>
+						</div>
+					</div>
+					{onDismiss && (
+						<button
+							type="button"
+							onClick={onDismiss}
+							className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+							aria-label="Close"
+						>
+							<CloseIcon className="w-5 h-5" />
+						</button>
+					)}
+				</div>
+
+				<p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+					This feature is not available on your current plan. Upgrade to access{' '}
+					{featureName.toLowerCase()} and other premium features.
+				</p>
+
+				{showBenefits && benefits.length > 0 && (
+					<ul className="space-y-2 mb-6">
+						{benefits.map((benefit) => (
+							<li
+								key={benefit}
+								className="flex items-start gap-2 text-sm text-gray-600 dark:text-gray-400"
+							>
+								<svg
+									aria-hidden="true"
+									className="w-5 h-5 text-green-500 flex-shrink-0 mt-0.5"
+									fill="currentColor"
+									viewBox="0 0 20 20"
+								>
+									<path
+										fillRule="evenodd"
+										d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+										clipRule="evenodd"
+									/>
+								</svg>
+								{benefit}
+							</li>
+						))}
+					</ul>
+				)}
+
+				<div className="flex justify-end gap-3">
+					{onDismiss && (
+						<button
+							type="button"
+							onClick={onDismiss}
+							className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
+						>
+							Maybe Later
+						</button>
+					)}
+					<UpgradeButton
+						feature={feature}
+						source={source}
+						targetPlan={targetPlan}
+					/>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+export function UpgradeLimitWarning({
+	type,
+	current,
+	limit,
+	source,
+	className = '',
+}: {
+	type: 'agents' | 'storage';
+	current: number;
+	limit: number;
+	source?: string;
+	className?: string;
+}) {
+	const percentage = Math.round((current / limit) * 100);
+	const isNearLimit = percentage >= 80;
+	const isAtLimit = percentage >= 100;
+
+	if (!isNearLimit) return null;
+
+	const formatValue = (value: number) => {
+		if (type === 'storage') {
+			const gb = value / (1024 * 1024 * 1024);
+			return gb >= 1024
+				? `${(gb / 1024).toFixed(1)} TB`
+				: `${gb.toFixed(1)} GB`;
+		}
+		return value.toString();
+	};
+
+	return (
+		<div
+			className={`flex items-center justify-between gap-4 px-4 py-3 rounded-lg ${
+				isAtLimit
+					? 'bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800'
+					: 'bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800'
+			} ${className}`}
+		>
+			<div className="flex items-center gap-3">
+				<svg
+					aria-hidden="true"
+					className={`w-5 h-5 ${isAtLimit ? 'text-red-500' : 'text-amber-500'}`}
+					fill="none"
+					stroke="currentColor"
+					viewBox="0 0 24 24"
+				>
+					<path
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						strokeWidth={2}
+						d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+					/>
+				</svg>
+				<div>
+					<p
+						className={`text-sm font-medium ${isAtLimit ? 'text-red-800 dark:text-red-200' : 'text-amber-800 dark:text-amber-200'}`}
+					>
+						{isAtLimit
+							? `${type === 'agents' ? 'Agent' : 'Storage'} limit reached`
+							: `Approaching ${type === 'agents' ? 'agent' : 'storage'} limit`}
+					</p>
+					<p
+						className={`text-sm ${isAtLimit ? 'text-red-600 dark:text-red-400' : 'text-amber-600 dark:text-amber-400'}`}
+					>
+						{formatValue(current)} / {formatValue(limit)} ({percentage}% used)
+					</p>
+				</div>
+			</div>
+			<UpgradeButton
+				feature={type}
+				source={source}
+				targetPlan="starter"
+				size="small"
+			/>
+		</div>
+	);
+}
+
+export function UpgradePrompt({
+	variant = 'banner',
+	...props
+}: UpgradePromptProps) {
+	switch (variant) {
+		case 'inline':
+			return <UpgradePromptInline {...props} />;
+		case 'banner':
+			return <UpgradePromptBanner {...props} />;
+		case 'card':
+			return <UpgradePromptCard {...props} />;
+		case 'modal':
+			return <UpgradePromptModal {...props} />;
+		default:
+			return <UpgradePromptBanner {...props} />;
+	}
+}

--- a/web/src/hooks/usePlanLimits.ts
+++ b/web/src/hooks/usePlanLimits.ts
@@ -1,0 +1,274 @@
+import { useMemo } from 'react';
+import type {
+	PlanFeatures,
+	PlanLimits,
+	PlanType,
+	UpgradeFeature,
+} from '../lib/types';
+import { useMe } from './useAuth';
+import { useCurrentOrganization } from './useOrganizations';
+
+// Default plan configurations
+const PLAN_LIMITS: Record<PlanType, PlanLimits> = {
+	free: {
+		agent_limit: 3,
+		storage_quota_bytes: 10 * 1024 * 1024 * 1024, // 10 GB
+		backup_retention_days: 30,
+		concurrent_backups: 1,
+	},
+	starter: {
+		agent_limit: 10,
+		storage_quota_bytes: 100 * 1024 * 1024 * 1024, // 100 GB
+		backup_retention_days: 90,
+		concurrent_backups: 3,
+	},
+	professional: {
+		agent_limit: 50,
+		storage_quota_bytes: 1024 * 1024 * 1024 * 1024, // 1 TB
+		backup_retention_days: 365,
+		concurrent_backups: 10,
+	},
+	enterprise: {
+		agent_limit: undefined, // Unlimited
+		storage_quota_bytes: undefined, // Unlimited
+		backup_retention_days: undefined, // Unlimited
+		concurrent_backups: undefined, // Unlimited
+	},
+};
+
+const PLAN_FEATURES: Record<PlanType, PlanFeatures> = {
+	free: {
+		sso_enabled: false,
+		api_access: false,
+		advanced_reporting: false,
+		audit_logs: false,
+		custom_branding: false,
+		priority_support: false,
+		geo_replication: false,
+		lifecycle_policies: false,
+		legal_holds: false,
+	},
+	starter: {
+		sso_enabled: false,
+		api_access: true,
+		advanced_reporting: false,
+		audit_logs: false,
+		custom_branding: false,
+		priority_support: false,
+		geo_replication: false,
+		lifecycle_policies: false,
+		legal_holds: false,
+	},
+	professional: {
+		sso_enabled: true,
+		api_access: true,
+		advanced_reporting: true,
+		audit_logs: true,
+		custom_branding: true,
+		priority_support: false,
+		geo_replication: false,
+		lifecycle_policies: true,
+		legal_holds: false,
+	},
+	enterprise: {
+		sso_enabled: true,
+		api_access: true,
+		advanced_reporting: true,
+		audit_logs: true,
+		custom_branding: true,
+		priority_support: true,
+		geo_replication: true,
+		lifecycle_policies: true,
+		legal_holds: true,
+	},
+};
+
+// Feature names for display
+export const FEATURE_NAMES: Record<UpgradeFeature, string> = {
+	agents: 'More Agents',
+	storage: 'More Storage',
+	sso: 'Single Sign-On (SSO)',
+	api_access: 'API Access',
+	advanced_reporting: 'Advanced Reporting',
+	audit_logs: 'Audit Logs',
+	custom_branding: 'Custom Branding',
+	priority_support: 'Priority Support',
+	geo_replication: 'Geo-Replication',
+	lifecycle_policies: 'Lifecycle Policies',
+	legal_holds: 'Legal Holds',
+};
+
+// Features benefits for upgrade prompts
+export const FEATURE_BENEFITS: Record<UpgradeFeature, string[]> = {
+	agents: [
+		'Connect more backup agents',
+		'Scale your backup infrastructure',
+		'Manage distributed systems',
+	],
+	storage: [
+		'Store more backup data',
+		'Longer retention periods',
+		'Archive more versions',
+	],
+	sso: [
+		'Centralized authentication',
+		'Automatic user provisioning',
+		'Enhanced security compliance',
+	],
+	api_access: [
+		'Automate backup operations',
+		'Build custom integrations',
+		'Programmatic access to data',
+	],
+	advanced_reporting: [
+		'Detailed backup analytics',
+		'Custom report generation',
+		'Trend analysis and insights',
+	],
+	audit_logs: [
+		'Track all user actions',
+		'Compliance reporting',
+		'Security monitoring',
+	],
+	custom_branding: [
+		'White-label the interface',
+		'Custom logo and colors',
+		'Professional appearance',
+	],
+	priority_support: [
+		'24/7 dedicated support',
+		'Faster response times',
+		'Direct access to engineers',
+	],
+	geo_replication: [
+		'Cross-region redundancy',
+		'Disaster recovery',
+		'Lower latency worldwide',
+	],
+	lifecycle_policies: [
+		'Automated retention rules',
+		'Cost optimization',
+		'Storage tier management',
+	],
+	legal_holds: [
+		'Preserve data for litigation',
+		'Compliance requirements',
+		'Prevent accidental deletion',
+	],
+};
+
+// Plan that unlocks each feature
+export const FEATURE_REQUIRED_PLAN: Record<UpgradeFeature, PlanType> = {
+	agents: 'starter',
+	storage: 'starter',
+	sso: 'professional',
+	api_access: 'starter',
+	advanced_reporting: 'professional',
+	audit_logs: 'professional',
+	custom_branding: 'professional',
+	priority_support: 'enterprise',
+	geo_replication: 'enterprise',
+	lifecycle_policies: 'professional',
+	legal_holds: 'enterprise',
+};
+
+export interface UsePlanLimitsResult {
+	isLoading: boolean;
+	planType: PlanType;
+	limits: PlanLimits;
+	features: PlanFeatures;
+	usage: {
+		agentCount: number;
+		storageUsedBytes: number;
+	};
+	hasFeature: (feature: keyof PlanFeatures) => boolean;
+	canAddAgents: (count?: number) => boolean;
+	canAddStorage: (bytes: number) => boolean;
+	getAgentLimitRemaining: () => number | undefined;
+	getStorageLimitRemaining: () => number | undefined;
+	isAtAgentLimit: () => boolean;
+	isAtStorageLimit: () => boolean;
+	getUpgradePlanFor: (feature: UpgradeFeature) => PlanType;
+}
+
+export function usePlanLimits(): UsePlanLimitsResult {
+	const { isLoading: orgLoading } = useCurrentOrganization();
+	const { isLoading: userLoading } = useMe();
+
+	const isLoading = orgLoading || userLoading;
+
+	// Default to free plan if no data is available
+	// In a real implementation, this would come from the organization data
+	// via an API call that returns the plan info
+	const planType: PlanType = useMemo(() => {
+		// This would typically come from org.organization.plan_type
+		// For now, return 'free' as default
+		return 'free';
+	}, []);
+
+	const limits = useMemo(() => PLAN_LIMITS[planType], [planType]);
+	const features = useMemo(() => PLAN_FEATURES[planType], [planType]);
+
+	// Mock usage data - in reality this would come from the API
+	const usage = useMemo(
+		() => ({
+			agentCount: 0,
+			storageUsedBytes: 0,
+		}),
+		[],
+	);
+
+	const hasFeature = (feature: keyof PlanFeatures): boolean => {
+		return features[feature];
+	};
+
+	const canAddAgents = (count = 1): boolean => {
+		if (limits.agent_limit === undefined) return true; // Unlimited
+		return usage.agentCount + count <= limits.agent_limit;
+	};
+
+	const canAddStorage = (bytes: number): boolean => {
+		if (limits.storage_quota_bytes === undefined) return true; // Unlimited
+		return usage.storageUsedBytes + bytes <= limits.storage_quota_bytes;
+	};
+
+	const getAgentLimitRemaining = (): number | undefined => {
+		if (limits.agent_limit === undefined) return undefined;
+		return Math.max(0, limits.agent_limit - usage.agentCount);
+	};
+
+	const getStorageLimitRemaining = (): number | undefined => {
+		if (limits.storage_quota_bytes === undefined) return undefined;
+		return Math.max(0, limits.storage_quota_bytes - usage.storageUsedBytes);
+	};
+
+	const isAtAgentLimit = (): boolean => {
+		if (limits.agent_limit === undefined) return false;
+		return usage.agentCount >= limits.agent_limit;
+	};
+
+	const isAtStorageLimit = (): boolean => {
+		if (limits.storage_quota_bytes === undefined) return false;
+		return usage.storageUsedBytes >= limits.storage_quota_bytes;
+	};
+
+	const getUpgradePlanFor = (feature: UpgradeFeature): PlanType => {
+		return FEATURE_REQUIRED_PLAN[feature];
+	};
+
+	return {
+		isLoading,
+		planType,
+		limits,
+		features,
+		usage,
+		hasFeature,
+		canAddAgents,
+		canAddStorage,
+		getAgentLimitRemaining,
+		getStorageLimitRemaining,
+		isAtAgentLimit,
+		isAtStorageLimit,
+		getUpgradePlanFor,
+	};
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1146,13 +1146,57 @@ export interface TransferOwnershipRequest {
 	new_owner_user_id: string;
 }
 
+export type PlanType = 'free' | 'starter' | 'professional' | 'enterprise';
+
 export interface BillingSettings {
-	plan_type: 'free' | 'starter' | 'professional' | 'enterprise';
+	plan_type: PlanType;
 	billing_email?: string;
 	billing_cycle?: 'monthly' | 'annual';
 	next_billing_date?: string;
 	payment_method_last4?: string;
 }
+
+export interface PlanLimits {
+	agent_limit?: number;
+	storage_quota_bytes?: number;
+	backup_retention_days?: number;
+	concurrent_backups?: number;
+}
+
+export interface PlanFeatures {
+	sso_enabled: boolean;
+	api_access: boolean;
+	advanced_reporting: boolean;
+	audit_logs: boolean;
+	custom_branding: boolean;
+	priority_support: boolean;
+	geo_replication: boolean;
+	lifecycle_policies: boolean;
+	legal_holds: boolean;
+}
+
+export interface OrganizationPlanInfo {
+	plan_type: PlanType;
+	limits: PlanLimits;
+	features: PlanFeatures;
+	usage: {
+		agent_count: number;
+		storage_used_bytes: number;
+	};
+}
+
+export type UpgradeFeature =
+	| 'agents'
+	| 'storage'
+	| 'sso'
+	| 'api_access'
+	| 'advanced_reporting'
+	| 'audit_logs'
+	| 'custom_branding'
+	| 'priority_support'
+	| 'geo_replication'
+	| 'lifecycle_policies'
+	| 'legal_holds';
 
 // API response wrappers
 export interface AgentsResponse {

--- a/web/src/lib/upgrade.ts
+++ b/web/src/lib/upgrade.ts
@@ -1,0 +1,123 @@
+import type { PlanType, UpgradeFeature } from './types';
+
+export interface UpgradeLinkOptions {
+	feature?: UpgradeFeature;
+	source?: string;
+	targetPlan?: PlanType;
+}
+
+/**
+ * Generates an upgrade link with optional feature and source tracking
+ */
+export function generateUpgradeLink(options: UpgradeLinkOptions = {}): string {
+	const { feature, source, targetPlan } = options;
+	const params = new URLSearchParams();
+
+	if (feature) {
+		params.set('feature', feature);
+	}
+
+	if (source) {
+		params.set('source', source);
+	}
+
+	if (targetPlan) {
+		params.set('plan', targetPlan);
+	}
+
+	const queryString = params.toString();
+	return `/organization/billing${queryString ? `?${queryString}` : ''}`;
+}
+
+/**
+ * Generates a contact sales link for enterprise features
+ */
+export function generateContactSalesLink(
+	options: UpgradeLinkOptions = {},
+): string {
+	const { feature, source } = options;
+	const params = new URLSearchParams();
+
+	if (feature) {
+		params.set('interest', feature);
+	}
+
+	if (source) {
+		params.set('source', source);
+	}
+
+	const queryString = params.toString();
+	return `/organization/contact-sales${queryString ? `?${queryString}` : ''}`;
+}
+
+/**
+ * Plan display names
+ */
+export const PLAN_NAMES: Record<PlanType, string> = {
+	free: 'Free',
+	starter: 'Starter',
+	professional: 'Professional',
+	enterprise: 'Enterprise',
+};
+
+/**
+ * Plan descriptions
+ */
+export const PLAN_DESCRIPTIONS: Record<PlanType, string> = {
+	free: 'For individuals and small projects',
+	starter: 'For growing teams with basic needs',
+	professional: 'For organizations needing advanced features',
+	enterprise: 'For large organizations with custom requirements',
+};
+
+/**
+ * Plan pricing (display strings)
+ */
+export const PLAN_PRICING: Record<PlanType, string> = {
+	free: 'Free',
+	starter: '$29/month',
+	professional: '$99/month',
+	enterprise: 'Contact Sales',
+};
+
+/**
+ * Check if upgrade is needed to get a plan
+ */
+export function needsUpgrade(
+	currentPlan: PlanType,
+	targetPlan: PlanType,
+): boolean {
+	const planOrder: PlanType[] = [
+		'free',
+		'starter',
+		'professional',
+		'enterprise',
+	];
+	const currentIndex = planOrder.indexOf(currentPlan);
+	const targetIndex = planOrder.indexOf(targetPlan);
+	return targetIndex > currentIndex;
+}
+
+/**
+ * Get the next plan upgrade from current
+ */
+export function getNextPlan(currentPlan: PlanType): PlanType | null {
+	const planOrder: PlanType[] = [
+		'free',
+		'starter',
+		'professional',
+		'enterprise',
+	];
+	const currentIndex = planOrder.indexOf(currentPlan);
+	if (currentIndex === -1 || currentIndex >= planOrder.length - 1) {
+		return null;
+	}
+	return planOrder[currentIndex + 1];
+}
+
+/**
+ * Check if a plan requires contacting sales
+ */
+export function requiresSales(plan: PlanType): boolean {
+	return plan === 'enterprise';
+}

--- a/web/src/pages/Agents.tsx
+++ b/web/src/pages/Agents.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { AgentDownloads } from '../components/features/AgentDownloads';
 import { ExportImportModal } from '../components/features/ExportImportModal';
 import { ImportAgentsWizard } from '../components/features/ImportAgentsWizard';
+import { UpgradeLimitWarning } from '../components/features/UpgradePrompt';
 import { type BulkAction, BulkActions } from '../components/ui/BulkActions';
 import {
 	BulkOperationProgress,
@@ -30,6 +31,7 @@ import {
 import { useBulkSelect } from '../hooks/useBulkSelect';
 import { useFavoriteIds } from '../hooks/useFavorites';
 import { useLocale } from '../hooks/useLocale';
+import { usePlanLimits } from '../hooks/usePlanLimits';
 import { useRunSchedule, useSchedules } from '../hooks/useSchedules';
 import { statusHelp } from '../lib/help-content';
 import type { Agent, AgentStatus, PendingRegistration } from '../lib/types';
@@ -671,6 +673,7 @@ export function Agents() {
 	const { data: agentGroups } = useAgentGroups();
 	const { data: schedules } = useSchedules();
 	const favoriteIds = useFavoriteIds('agent');
+	const { limits, usage } = usePlanLimits();
 	const deleteAgent = useDeleteAgent();
 	const rotateApiKey = useRotateAgentApiKey();
 	const revokeApiKey = useRevokeAgentApiKey();
@@ -864,6 +867,14 @@ export function Agents() {
 
 	return (
 		<div className="space-y-6">
+			{limits.agent_limit && (
+				<UpgradeLimitWarning
+					type="agents"
+					current={agents?.length ?? usage.agentCount}
+					limit={limits.agent_limit}
+					source="agents-page"
+				/>
+			)}
 			<div className="flex items-center justify-between">
 				<div>
 					<h1 className="text-2xl font-bold text-gray-900">

--- a/web/src/pages/AuditLogs.tsx
+++ b/web/src/pages/AuditLogs.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react';
+import { UpgradePrompt } from '../components/features/UpgradePrompt';
 import {
 	useAuditLogs,
 	useExportAuditLogsCsv,
 	useExportAuditLogsJson,
 } from '../hooks/useAuditLogs';
+import { usePlanLimits } from '../hooks/usePlanLimits';
 import type { AuditLogFilter } from '../lib/types';
 import {
 	formatAuditAction,
@@ -48,6 +50,8 @@ export function AuditLogs() {
 	const { data, isLoading, isError } = useAuditLogs(filter);
 	const exportCsv = useExportAuditLogsCsv();
 	const exportJson = useExportAuditLogsJson();
+	const { hasFeature } = usePlanLimits();
+	const hasAuditLogs = hasFeature('audit_logs');
 
 	const handleSearch = () => {
 		setFilter((prev) => ({
@@ -95,6 +99,27 @@ export function AuditLogs() {
 	const currentPage = data
 		? Math.floor((filter.offset || 0) / (filter.limit || 50)) + 1
 		: 1;
+
+	if (!hasAuditLogs) {
+		return (
+			<div className="space-y-6">
+				<div>
+					<h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+						Audit Logs
+					</h1>
+					<p className="text-gray-600 dark:text-gray-400 mt-1">
+						Track all user and system actions for compliance
+					</p>
+				</div>
+				<UpgradePrompt
+					feature="audit_logs"
+					variant="card"
+					source="audit-logs-page"
+					showBenefits={true}
+				/>
+			</div>
+		);
+	}
 
 	return (
 		<div className="space-y-6">

--- a/web/src/pages/LegalHolds.tsx
+++ b/web/src/pages/LegalHolds.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
+import { UpgradePrompt } from '../components/features/UpgradePrompt';
 import { useMe } from '../hooks/useAuth';
 import { useDeleteLegalHold, useLegalHolds } from '../hooks/useLegalHolds';
+import { usePlanLimits } from '../hooks/usePlanLimits';
 import { formatDateTime } from '../lib/utils';
 
 function LoadingRow() {
@@ -31,9 +33,33 @@ export function LegalHolds() {
 	const { data: holds, isLoading, isError, refetch } = useLegalHolds();
 	const deleteHold = useDeleteLegalHold();
 	const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null);
+	const { hasFeature } = usePlanLimits();
+	const hasLegalHolds = hasFeature('legal_holds');
 
 	const isAdmin =
 		user?.current_org_role === 'owner' || user?.current_org_role === 'admin';
+
+	// Feature gate check
+	if (!hasLegalHolds) {
+		return (
+			<div className="space-y-6">
+				<div>
+					<h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+						Legal Holds
+					</h1>
+					<p className="text-gray-600 dark:text-gray-400 mt-1">
+						Preserve snapshots for litigation or compliance purposes
+					</p>
+				</div>
+				<UpgradePrompt
+					feature="legal_holds"
+					variant="card"
+					source="legal-holds-page"
+					showBenefits={true}
+				/>
+			</div>
+		);
+	}
 
 	// Non-admins should not see this page
 	if (!isAdmin) {

--- a/web/src/pages/LifecyclePolicies.tsx
+++ b/web/src/pages/LifecyclePolicies.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { UpgradePrompt } from '../components/features/UpgradePrompt';
 import { useMe } from '../hooks/useAuth';
 import {
 	useCreateLifecyclePolicy,
@@ -8,6 +9,7 @@ import {
 	useOrgLifecycleDeletions,
 	useUpdateLifecyclePolicy,
 } from '../hooks/useLifecyclePolicies';
+import { usePlanLimits } from '../hooks/usePlanLimits';
 import type {
 	ClassificationLevel,
 	ClassificationRetention,
@@ -539,6 +541,8 @@ export function LifecyclePolicies() {
 	const { data: deletions } = useOrgLifecycleDeletions(10);
 	const deletePolicy = useDeleteLifecyclePolicy();
 	const updatePolicy = useUpdateLifecyclePolicy();
+	const { hasFeature } = usePlanLimits();
+	const hasLifecyclePolicies = hasFeature('lifecycle_policies');
 
 	const [showCreateModal, setShowCreateModal] = useState(false);
 	const [dryRunPolicy, setDryRunPolicy] = useState<LifecyclePolicy | null>(
@@ -548,6 +552,27 @@ export function LifecyclePolicies() {
 
 	const isAdmin =
 		user?.current_org_role === 'owner' || user?.current_org_role === 'admin';
+
+	if (!hasLifecyclePolicies) {
+		return (
+			<div className="space-y-6">
+				<div>
+					<h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+						Lifecycle Policies
+					</h1>
+					<p className="text-gray-600 dark:text-gray-400 mt-1">
+						Automate snapshot retention and cleanup based on custom rules
+					</p>
+				</div>
+				<UpgradePrompt
+					feature="lifecycle_policies"
+					variant="card"
+					source="lifecycle-policies-page"
+					showBenefits={true}
+				/>
+			</div>
+		);
+	}
 
 	if (!isAdmin) {
 		return (

--- a/web/src/pages/OrganizationSSOSettings.tsx
+++ b/web/src/pages/OrganizationSSOSettings.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
+import { UpgradePrompt } from '../components/features/UpgradePrompt';
 import { useMe } from '../hooks/useAuth';
+import { usePlanLimits } from '../hooks/usePlanLimits';
 import {
 	useCreateSSOGroupMapping,
 	useDeleteSSOGroupMapping,
@@ -17,6 +19,8 @@ export function OrganizationSSOSettings() {
 	const orgId = user?.current_org_id ?? '';
 	const currentUserRole = (user?.current_org_role ?? 'member') as OrgRole;
 	const canEdit = currentUserRole === 'owner' || currentUserRole === 'admin';
+	const { hasFeature } = usePlanLimits();
+	const hasSSO = hasFeature('sso_enabled');
 
 	const { data: mappings, isLoading: mappingsLoading } =
 		useSSOGroupMappings(orgId);
@@ -112,6 +116,28 @@ export function OrganizationSSOSettings() {
 		setAutoCreateOrgs(settings?.auto_create_orgs ?? false);
 		setSettingsEditing(true);
 	};
+
+	if (!hasSSO) {
+		return (
+			<div className="space-y-6">
+				<div>
+					<h1 className="text-2xl font-bold text-gray-900">
+						SSO Group Sync Settings
+					</h1>
+					<p className="text-gray-600 mt-1">
+						Map OIDC groups from your identity provider to Keldris organization
+						roles
+					</p>
+				</div>
+				<UpgradePrompt
+					feature="sso"
+					variant="card"
+					source="sso-settings-page"
+					showBenefits={true}
+				/>
+			</div>
+		);
+	}
 
 	if (mappingsLoading || settingsLoading) {
 		return (

--- a/web/src/pages/Reports.tsx
+++ b/web/src/pages/Reports.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
+import { UpgradePrompt } from '../components/features/UpgradePrompt';
 import { useNotificationChannels } from '../hooks/useNotifications';
+import { usePlanLimits } from '../hooks/usePlanLimits';
 import {
 	useCreateReportSchedule,
 	useDeleteReportSchedule,
@@ -634,9 +636,30 @@ export default function Reports() {
 		'schedules',
 	);
 	const [showAddModal, setShowAddModal] = useState(false);
+	const { hasFeature } = usePlanLimits();
+	const hasAdvancedReporting = hasFeature('advanced_reporting');
 
 	const { data: schedules, isLoading: schedulesLoading } = useReportSchedules();
 	const { data: history, isLoading: historyLoading } = useReportHistory();
+
+	if (!hasAdvancedReporting) {
+		return (
+			<div className="p-6 space-y-6">
+				<div>
+					<h1 className="text-2xl font-bold text-gray-900">Email Reports</h1>
+					<p className="text-sm text-gray-500 mt-1">
+						Schedule automated backup summary reports
+					</p>
+				</div>
+				<UpgradePrompt
+					feature="advanced_reporting"
+					variant="card"
+					source="reports-page"
+					showBenefits={true}
+				/>
+			</div>
+		);
+	}
 
 	return (
 		<div className="p-6">


### PR DESCRIPTION
Implement a comprehensive upgrade prompt system to guide users toward higher plans when accessing premium features or hitting plan limits.

## Key Features
- Flexible UpgradePrompt component with inline, banner, card, and modal variants
- usePlanLimits hook for checking feature availability and usage limits
- Plan limit warnings when approaching agent or storage quotas
- Integrated prompts throughout premium feature pages (Audit Logs, SSO, Legal Holds, Lifecycle Policies, Reports)

## Test Plan
- Verify upgrade banners appear on Agents page when near limit
- Confirm feature-gated pages show upgrade prompts on free plan
- Check that all upgrade links include proper tracking context
- Verify components render correctly in different variants