### PR TITLE
Implement agent diagnostics command

### DIFF
--- a/internal/diagnostics/diagnostics.go
+++ b/internal/diagnostics/diagnostics.go
@@ -1,0 +1,444 @@
+// Package diagnostics provides self-test functionality for the Keldris agent.
+package diagnostics
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/MacJediWizard/keldris/internal/config"
+)
+
+// CheckStatus represents the status of a diagnostic check.
+type CheckStatus string
+
+const (
+	// StatusPass indicates the check passed.
+	StatusPass CheckStatus = "pass"
+	// StatusFail indicates the check failed.
+	StatusFail CheckStatus = "fail"
+	// StatusWarn indicates the check passed with warnings.
+	StatusWarn CheckStatus = "warn"
+	// StatusSkip indicates the check was skipped.
+	StatusSkip CheckStatus = "skip"
+)
+
+// CheckResult represents the result of a single diagnostic check.
+type CheckResult struct {
+	Name    string      `json:"name"`
+	Status  CheckStatus `json:"status"`
+	Message string      `json:"message,omitempty"`
+	Details any         `json:"details,omitempty"`
+}
+
+// DiagnosticsResult contains the complete diagnostics output.
+type DiagnosticsResult struct {
+	Timestamp    time.Time     `json:"timestamp"`
+	AgentVersion string        `json:"agent_version"`
+	Hostname     string        `json:"hostname"`
+	OS           string        `json:"os"`
+	Arch         string        `json:"arch"`
+	Checks       []CheckResult `json:"checks"`
+	Summary      Summary       `json:"summary"`
+}
+
+// Summary provides a quick overview of the diagnostics results.
+type Summary struct {
+	Total   int  `json:"total"`
+	Passed  int  `json:"passed"`
+	Failed  int  `json:"failed"`
+	Warned  int  `json:"warned"`
+	Skipped int  `json:"skipped"`
+	AllPass bool `json:"all_pass"`
+}
+
+// DiskSpaceDetails contains disk space information.
+type DiskSpaceDetails struct {
+	Path       string `json:"path"`
+	TotalBytes int64  `json:"total_bytes"`
+	FreeBytes  int64  `json:"free_bytes"`
+	UsedBytes  int64  `json:"used_bytes"`
+	UsedPct    float64 `json:"used_percent"`
+}
+
+// ResticDetails contains restic binary information.
+type ResticDetails struct {
+	Path    string `json:"path,omitempty"`
+	Version string `json:"version,omitempty"`
+}
+
+// ServerDetails contains server connectivity information.
+type ServerDetails struct {
+	URL        string `json:"url"`
+	StatusCode int    `json:"status_code,omitempty"`
+	Latency    string `json:"latency,omitempty"`
+}
+
+// Runner runs diagnostic checks.
+type Runner struct {
+	cfg     *config.AgentConfig
+	version string
+}
+
+// NewRunner creates a new diagnostics runner.
+func NewRunner(cfg *config.AgentConfig, version string) *Runner {
+	return &Runner{
+		cfg:     cfg,
+		version: version,
+	}
+}
+
+// Run executes all diagnostic checks and returns the result.
+func (r *Runner) Run(ctx context.Context) *DiagnosticsResult {
+	hostname, _ := os.Hostname()
+
+	result := &DiagnosticsResult{
+		Timestamp:    time.Now().UTC(),
+		AgentVersion: r.version,
+		Hostname:     hostname,
+		OS:           runtime.GOOS,
+		Arch:         runtime.GOARCH,
+		Checks:       make([]CheckResult, 0),
+	}
+
+	// Run all checks
+	result.Checks = append(result.Checks, r.checkServerConnectivity(ctx))
+	result.Checks = append(result.Checks, r.checkAPIKey(ctx))
+	result.Checks = append(result.Checks, r.checkResticBinary(ctx))
+	result.Checks = append(result.Checks, r.checkDiskSpace(ctx))
+	result.Checks = append(result.Checks, r.checkConfigPermissions(ctx))
+
+	// Calculate summary
+	for _, check := range result.Checks {
+		result.Summary.Total++
+		switch check.Status {
+		case StatusPass:
+			result.Summary.Passed++
+		case StatusFail:
+			result.Summary.Failed++
+		case StatusWarn:
+			result.Summary.Warned++
+		case StatusSkip:
+			result.Summary.Skipped++
+		}
+	}
+	result.Summary.AllPass = result.Summary.Failed == 0
+
+	return result
+}
+
+// checkServerConnectivity tests connection to the Keldris server.
+func (r *Runner) checkServerConnectivity(ctx context.Context) CheckResult {
+	check := CheckResult{
+		Name: "server_connectivity",
+	}
+
+	if r.cfg == nil || r.cfg.ServerURL == "" {
+		check.Status = StatusSkip
+		check.Message = "Server URL not configured"
+		return check
+	}
+
+	details := ServerDetails{
+		URL: r.cfg.ServerURL,
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	healthURL := r.cfg.ServerURL + "/health"
+
+	start := time.Now()
+	resp, err := client.Get(healthURL)
+	latency := time.Since(start)
+
+	details.Latency = latency.String()
+
+	if err != nil {
+		check.Status = StatusFail
+		check.Message = fmt.Sprintf("Failed to connect to server: %v", err)
+		check.Details = details
+		return check
+	}
+	defer resp.Body.Close()
+
+	details.StatusCode = resp.StatusCode
+
+	if resp.StatusCode != http.StatusOK {
+		check.Status = StatusFail
+		check.Message = fmt.Sprintf("Server returned HTTP %d", resp.StatusCode)
+		check.Details = details
+		return check
+	}
+
+	check.Status = StatusPass
+	check.Message = fmt.Sprintf("Connected to server (latency: %s)", latency.Round(time.Millisecond))
+	check.Details = details
+	return check
+}
+
+// checkAPIKey verifies the API key is valid by making an authenticated request.
+func (r *Runner) checkAPIKey(ctx context.Context) CheckResult {
+	check := CheckResult{
+		Name: "api_key",
+	}
+
+	if r.cfg == nil || r.cfg.APIKey == "" {
+		check.Status = StatusSkip
+		check.Message = "API key not configured"
+		return check
+	}
+
+	if r.cfg.ServerURL == "" {
+		check.Status = StatusSkip
+		check.Message = "Server URL not configured"
+		return check
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+
+	// Use the agent health endpoint to verify API key
+	req, err := http.NewRequestWithContext(ctx, "GET", r.cfg.ServerURL+"/api/v1/agent/commands", nil)
+	if err != nil {
+		check.Status = StatusFail
+		check.Message = fmt.Sprintf("Failed to create request: %v", err)
+		return check
+	}
+
+	req.Header.Set("X-API-Key", r.cfg.APIKey)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		check.Status = StatusFail
+		check.Message = fmt.Sprintf("Failed to verify API key: %v", err)
+		return check
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		check.Status = StatusPass
+		check.Message = "API key is valid"
+	case http.StatusUnauthorized, http.StatusForbidden:
+		check.Status = StatusFail
+		check.Message = "API key is invalid or expired"
+	default:
+		check.Status = StatusWarn
+		check.Message = fmt.Sprintf("Unexpected response (HTTP %d)", resp.StatusCode)
+	}
+
+	return check
+}
+
+// checkResticBinary verifies the restic binary is available and working.
+func (r *Runner) checkResticBinary(ctx context.Context) CheckResult {
+	check := CheckResult{
+		Name: "restic_binary",
+	}
+
+	details := ResticDetails{}
+
+	// Find restic binary
+	resticPath, err := exec.LookPath("restic")
+	if err != nil {
+		check.Status = StatusFail
+		check.Message = "Restic binary not found in PATH"
+		return check
+	}
+
+	details.Path = resticPath
+
+	// Get restic version
+	cmd := exec.CommandContext(ctx, resticPath, "version")
+	output, err := cmd.Output()
+	if err != nil {
+		check.Status = StatusFail
+		check.Message = fmt.Sprintf("Failed to run restic: %v", err)
+		check.Details = details
+		return check
+	}
+
+	versionStr := strings.TrimSpace(string(output))
+	details.Version = versionStr
+
+	check.Status = StatusPass
+	check.Message = fmt.Sprintf("Restic available at %s", resticPath)
+	check.Details = details
+	return check
+}
+
+// checkDiskSpace verifies adequate disk space is available.
+func (r *Runner) checkDiskSpace(ctx context.Context) CheckResult {
+	check := CheckResult{
+		Name: "disk_space",
+	}
+
+	// Check the home directory's disk
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		check.Status = StatusFail
+		check.Message = fmt.Sprintf("Failed to get home directory: %v", err)
+		return check
+	}
+
+	details, err := getDiskSpace(homeDir)
+	if err != nil {
+		check.Status = StatusFail
+		check.Message = fmt.Sprintf("Failed to check disk space: %v", err)
+		return check
+	}
+
+	// Warning if > 90% used, fail if > 95% used
+	if details.UsedPct >= 95 {
+		check.Status = StatusFail
+		check.Message = fmt.Sprintf("Critically low disk space: %.1f%% used", details.UsedPct)
+		check.Details = details
+		return check
+	}
+
+	if details.UsedPct >= 90 {
+		check.Status = StatusWarn
+		check.Message = fmt.Sprintf("Low disk space warning: %.1f%% used", details.UsedPct)
+		check.Details = details
+		return check
+	}
+
+	check.Status = StatusPass
+	check.Message = fmt.Sprintf("Disk space OK: %.1f%% used, %s free", details.UsedPct, formatBytes(details.FreeBytes))
+	check.Details = details
+	return check
+}
+
+// checkConfigPermissions verifies file permissions on config directory.
+func (r *Runner) checkConfigPermissions(ctx context.Context) CheckResult {
+	check := CheckResult{
+		Name: "config_permissions",
+	}
+
+	configDir, err := config.DefaultConfigDir()
+	if err != nil {
+		check.Status = StatusFail
+		check.Message = fmt.Sprintf("Failed to get config directory: %v", err)
+		return check
+	}
+
+	// Check if config directory exists
+	info, err := os.Stat(configDir)
+	if os.IsNotExist(err) {
+		// Directory doesn't exist - check if we can create it
+		testDir := filepath.Join(configDir, ".test")
+		if err := os.MkdirAll(testDir, 0700); err != nil {
+			check.Status = StatusFail
+			check.Message = fmt.Sprintf("Cannot create config directory: %v", err)
+			return check
+		}
+		os.RemoveAll(testDir)
+
+		check.Status = StatusPass
+		check.Message = "Config directory can be created"
+		return check
+	}
+
+	if err != nil {
+		check.Status = StatusFail
+		check.Message = fmt.Sprintf("Failed to check config directory: %v", err)
+		return check
+	}
+
+	if !info.IsDir() {
+		check.Status = StatusFail
+		check.Message = "Config path exists but is not a directory"
+		return check
+	}
+
+	// Check permissions
+	mode := info.Mode().Perm()
+	details := map[string]any{
+		"path":        configDir,
+		"permissions": fmt.Sprintf("%04o", mode),
+	}
+
+	// On Unix, config directory should be readable/writable only by owner
+	if runtime.GOOS != "windows" {
+		if mode&0077 != 0 {
+			check.Status = StatusWarn
+			check.Message = fmt.Sprintf("Config directory has loose permissions (%04o), recommend 0700", mode)
+			check.Details = details
+			return check
+		}
+	}
+
+	// Check if we can write to the directory
+	testFile := filepath.Join(configDir, ".write_test")
+	if err := os.WriteFile(testFile, []byte("test"), 0600); err != nil {
+		check.Status = StatusFail
+		check.Message = fmt.Sprintf("Cannot write to config directory: %v", err)
+		check.Details = details
+		return check
+	}
+	os.Remove(testFile)
+
+	check.Status = StatusPass
+	check.Message = "Config directory permissions OK"
+	check.Details = details
+	return check
+}
+
+// getDiskSpace returns disk space information for the given path.
+func getDiskSpace(path string) (*DiskSpaceDetails, error) {
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(path, &stat); err != nil {
+		return nil, err
+	}
+
+	total := int64(stat.Blocks) * int64(stat.Bsize)
+	free := int64(stat.Bavail) * int64(stat.Bsize)
+	used := total - free
+	usedPct := float64(used) / float64(total) * 100
+
+	return &DiskSpaceDetails{
+		Path:       path,
+		TotalBytes: total,
+		FreeBytes:  free,
+		UsedBytes:  used,
+		UsedPct:    usedPct,
+	}, nil
+}
+
+// formatBytes formats bytes as a human-readable string.
+func formatBytes(b int64) string {
+	const unit = 1024
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(b)/float64(div), "KMGTPE"[exp])
+}
+
+// ToJSON returns the diagnostics result as JSON.
+func (r *DiagnosticsResult) ToJSON() ([]byte, error) {
+	return json.MarshalIndent(r, "", "  ")
+}
+
+// ToMap returns the diagnostics result as a map for command result reporting.
+func (r *DiagnosticsResult) ToMap() map[string]any {
+	return map[string]any{
+		"timestamp":     r.Timestamp,
+		"agent_version": r.AgentVersion,
+		"hostname":      r.Hostname,
+		"os":            r.OS,
+		"arch":          r.Arch,
+		"checks":        r.Checks,
+		"summary":       r.Summary,
+	}
+}

--- a/internal/diagnostics/diagnostics_test.go
+++ b/internal/diagnostics/diagnostics_test.go
@@ -1,0 +1,273 @@
+package diagnostics
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/MacJediWizard/keldris/internal/config"
+)
+
+func TestRunner_Run(t *testing.T) {
+	// Create a test server
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/health":
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"status":"ok"}`))
+		case "/api/v1/agent/commands":
+			// Check API key
+			if r.Header.Get("X-API-Key") == "test-api-key" {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{"commands":[]}`))
+			} else {
+				w.WriteHeader(http.StatusUnauthorized)
+			}
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	cfg := &config.AgentConfig{
+		ServerURL: ts.URL,
+		APIKey:    "test-api-key",
+	}
+
+	runner := NewRunner(cfg, "test-version")
+	result := runner.Run(context.Background())
+
+	if result == nil {
+		t.Fatal("expected result, got nil")
+	}
+
+	if result.AgentVersion != "test-version" {
+		t.Errorf("expected agent version 'test-version', got %s", result.AgentVersion)
+	}
+
+	if result.Summary.Total == 0 {
+		t.Error("expected at least one check to be run")
+	}
+
+	// Server connectivity check should pass
+	serverCheck := findCheck(result.Checks, "server_connectivity")
+	if serverCheck == nil {
+		t.Error("expected server_connectivity check")
+	} else if serverCheck.Status != StatusPass {
+		t.Errorf("expected server_connectivity to pass, got %s: %s", serverCheck.Status, serverCheck.Message)
+	}
+
+	// API key check should pass
+	apiKeyCheck := findCheck(result.Checks, "api_key")
+	if apiKeyCheck == nil {
+		t.Error("expected api_key check")
+	} else if apiKeyCheck.Status != StatusPass {
+		t.Errorf("expected api_key to pass, got %s: %s", apiKeyCheck.Status, apiKeyCheck.Message)
+	}
+}
+
+func TestRunner_Run_NoConfig(t *testing.T) {
+	cfg := &config.AgentConfig{}
+
+	runner := NewRunner(cfg, "test-version")
+	result := runner.Run(context.Background())
+
+	if result == nil {
+		t.Fatal("expected result, got nil")
+	}
+
+	// Server connectivity check should be skipped
+	serverCheck := findCheck(result.Checks, "server_connectivity")
+	if serverCheck == nil {
+		t.Error("expected server_connectivity check")
+	} else if serverCheck.Status != StatusSkip {
+		t.Errorf("expected server_connectivity to be skipped, got %s", serverCheck.Status)
+	}
+
+	// API key check should be skipped
+	apiKeyCheck := findCheck(result.Checks, "api_key")
+	if apiKeyCheck == nil {
+		t.Error("expected api_key check")
+	} else if apiKeyCheck.Status != StatusSkip {
+		t.Errorf("expected api_key to be skipped, got %s", apiKeyCheck.Status)
+	}
+}
+
+func TestRunner_Run_InvalidAPIKey(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/health":
+			w.WriteHeader(http.StatusOK)
+		case "/api/v1/agent/commands":
+			w.WriteHeader(http.StatusUnauthorized)
+		}
+	}))
+	defer ts.Close()
+
+	cfg := &config.AgentConfig{
+		ServerURL: ts.URL,
+		APIKey:    "invalid-key",
+	}
+
+	runner := NewRunner(cfg, "test-version")
+	result := runner.Run(context.Background())
+
+	apiKeyCheck := findCheck(result.Checks, "api_key")
+	if apiKeyCheck == nil {
+		t.Error("expected api_key check")
+	} else if apiKeyCheck.Status != StatusFail {
+		t.Errorf("expected api_key to fail, got %s", apiKeyCheck.Status)
+	}
+}
+
+func TestRunner_DiskSpace(t *testing.T) {
+	cfg := &config.AgentConfig{}
+
+	runner := NewRunner(cfg, "test-version")
+	result := runner.Run(context.Background())
+
+	diskCheck := findCheck(result.Checks, "disk_space")
+	if diskCheck == nil {
+		t.Error("expected disk_space check")
+	} else {
+		// Disk check should pass or warn (not fail unless disk is really full)
+		if diskCheck.Status == StatusFail {
+			t.Logf("disk_space check failed (disk may be full): %s", diskCheck.Message)
+		}
+	}
+}
+
+func TestRunner_ConfigPermissions(t *testing.T) {
+	cfg := &config.AgentConfig{}
+
+	runner := NewRunner(cfg, "test-version")
+	result := runner.Run(context.Background())
+
+	configCheck := findCheck(result.Checks, "config_permissions")
+	if configCheck == nil {
+		t.Error("expected config_permissions check")
+	}
+}
+
+func TestDiagnosticsResult_ToJSON(t *testing.T) {
+	result := &DiagnosticsResult{
+		AgentVersion: "1.0.0",
+		Hostname:     "test-host",
+		OS:           "linux",
+		Arch:         "amd64",
+		Checks: []CheckResult{
+			{
+				Name:    "test_check",
+				Status:  StatusPass,
+				Message: "Test passed",
+			},
+		},
+		Summary: Summary{
+			Total:   1,
+			Passed:  1,
+			AllPass: true,
+		},
+	}
+
+	data, err := result.ToJSON()
+	if err != nil {
+		t.Fatalf("ToJSON failed: %v", err)
+	}
+
+	if len(data) == 0 {
+		t.Error("expected non-empty JSON output")
+	}
+
+	// Verify it contains expected fields
+	json := string(data)
+	if !contains(json, "agent_version") {
+		t.Error("expected JSON to contain agent_version")
+	}
+	if !contains(json, "test_check") {
+		t.Error("expected JSON to contain test_check")
+	}
+}
+
+func TestDiagnosticsResult_ToMap(t *testing.T) {
+	result := &DiagnosticsResult{
+		AgentVersion: "1.0.0",
+		Hostname:     "test-host",
+	}
+
+	m := result.ToMap()
+	if m["agent_version"] != "1.0.0" {
+		t.Errorf("expected agent_version '1.0.0', got %v", m["agent_version"])
+	}
+	if m["hostname"] != "test-host" {
+		t.Errorf("expected hostname 'test-host', got %v", m["hostname"])
+	}
+}
+
+func TestFormatBytes(t *testing.T) {
+	tests := []struct {
+		bytes    int64
+		expected string
+	}{
+		{100, "100 B"},
+		{1024, "1.0 KB"},
+		{1536, "1.5 KB"},
+		{1048576, "1.0 MB"},
+		{1073741824, "1.0 GB"},
+	}
+
+	for _, tt := range tests {
+		result := formatBytes(tt.bytes)
+		if result != tt.expected {
+			t.Errorf("formatBytes(%d) = %s, expected %s", tt.bytes, result, tt.expected)
+		}
+	}
+}
+
+func TestGetDiskSpace(t *testing.T) {
+	// Test with home directory
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("could not get home directory")
+	}
+
+	details, err := getDiskSpace(homeDir)
+	if err != nil {
+		t.Fatalf("getDiskSpace failed: %v", err)
+	}
+
+	if details.TotalBytes <= 0 {
+		t.Error("expected positive total bytes")
+	}
+	if details.FreeBytes < 0 {
+		t.Error("expected non-negative free bytes")
+	}
+	if details.UsedPct < 0 || details.UsedPct > 100 {
+		t.Errorf("expected used percent between 0 and 100, got %.2f", details.UsedPct)
+	}
+}
+
+// Helper functions
+
+func findCheck(checks []CheckResult, name string) *CheckResult {
+	for i := range checks {
+		if checks[i].Name == name {
+			return &checks[i]
+		}
+	}
+	return nil
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))
+}
+
+func containsHelper(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
Adds a new `diagnostics` command to keldris-agent that performs self-test checks to verify the agent is properly configured and operational. The command includes checks for server connectivity, API key validation, restic binary availability, disk space, and config directory permissions.

## Checks Performed
- Server connectivity: Tests connection to the Keldris server
- API key validation: Verifies the API key is valid and can authenticate
- Restic binary: Confirms restic is installed and working
- Disk space: Verifies adequate free space with warning/critical thresholds
- Config permissions: Checks file permissions on the config directory

## Features
- Human-readable output with status icons (✓, ✗, !, -)
- JSON output via `--json` flag for automation and scripting
- Remote execution support via agent command interface (already integrated)
- Comprehensive test coverage

## Usage
```bash
keldris-agent diagnostics
keldris-agent diagnostics --json
```

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>