### PR TITLE
Implement Prometheus metrics endpoint

### DIFF
--- a/docs/prometheus-metrics.md
+++ b/docs/prometheus-metrics.md
@@ -1,0 +1,329 @@
+# Prometheus Metrics
+
+Keldris exposes metrics in Prometheus exposition format at the `/metrics` endpoint. This allows you to monitor backup operations, agent health, and storage utilization.
+
+## Endpoint
+
+```
+GET /metrics
+```
+
+No authentication is required for this endpoint.
+
+## Available Metrics
+
+### Backup Metrics
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `keldris_backup_total` | counter | Total number of backups |
+| `keldris_backup_status_total{status="..."}` | counter | Total number of backups by status (completed, failed, running, canceled) |
+| `keldris_backup_duration_seconds` | histogram | Histogram of backup duration in seconds |
+| `keldris_backup_size_bytes` | gauge | Total size of completed backups in bytes |
+
+The histogram uses the following bucket boundaries (in seconds):
+- 60 (1 minute)
+- 300 (5 minutes)
+- 600 (10 minutes)
+- 1800 (30 minutes)
+- 3600 (1 hour)
+- 7200 (2 hours)
+- 14400 (4 hours)
+- 28800 (8 hours)
+
+### Agent Metrics
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `keldris_agents_total` | gauge | Total number of registered agents |
+| `keldris_agents_online` | gauge | Number of online (active) agents |
+
+### Storage Metrics
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `keldris_storage_used_bytes` | gauge | Total storage used in bytes |
+
+### Server Health Metrics
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `keldris_info{component="server"}` | gauge | Server information (always 1) |
+| `keldris_up{component="database"}` | gauge | Database health status (1 = healthy, 0 = unhealthy) |
+
+### Database Pool Metrics
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `keldris_db_connections_total` | gauge | Total number of connections in the pool |
+| `keldris_db_connections_acquired` | gauge | Number of currently acquired connections |
+| `keldris_db_connections_idle` | gauge | Number of idle connections |
+| `keldris_db_connections_max` | gauge | Maximum number of connections in the pool |
+| `keldris_db_connections_constructing` | gauge | Number of connections being constructed |
+| `keldris_db_acquire_empty_total` | counter | Total number of acquire attempts that had to wait |
+| `keldris_db_acquire_canceled_total` | counter | Total number of acquire attempts that were canceled |
+| `keldris_db_lifetime_destroy_total` | counter | Total connections destroyed due to max lifetime |
+| `keldris_db_idle_destroy_total` | counter | Total connections destroyed due to max idle time |
+
+## Prometheus Scrape Configuration
+
+Add the following to your `prometheus.yml`:
+
+```yaml
+scrape_configs:
+  - job_name: 'keldris'
+    scrape_interval: 30s
+    scrape_timeout: 10s
+    static_configs:
+      - targets: ['keldris-server:8080']
+    metrics_path: /metrics
+    scheme: http
+```
+
+For HTTPS with self-signed certificates:
+
+```yaml
+scrape_configs:
+  - job_name: 'keldris'
+    scrape_interval: 30s
+    scrape_timeout: 10s
+    static_configs:
+      - targets: ['keldris-server:8443']
+    metrics_path: /metrics
+    scheme: https
+    tls_config:
+      insecure_skip_verify: true
+```
+
+With service discovery (Kubernetes example):
+
+```yaml
+scrape_configs:
+  - job_name: 'keldris'
+    scrape_interval: 30s
+    kubernetes_sd_configs:
+      - role: service
+        namespaces:
+          names:
+            - keldris
+    relabel_configs:
+      - source_labels: [__meta_kubernetes_service_name]
+        action: keep
+        regex: keldris-server
+      - source_labels: [__meta_kubernetes_service_port_name]
+        action: keep
+        regex: http
+```
+
+## Alerting Rules
+
+Create a file `keldris-alerts.yml` in your Prometheus rules directory:
+
+```yaml
+groups:
+  - name: keldris
+    rules:
+      # Alert when no agents are online
+      - alert: KeldrisNoAgentsOnline
+        expr: keldris_agents_online == 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "No Keldris agents online"
+          description: "All backup agents are offline. Backups cannot run."
+
+      # Alert when agent count drops significantly
+      - alert: KeldrisAgentsDegraded
+        expr: keldris_agents_online < (keldris_agents_total * 0.5)
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Less than 50% of agents online"
+          description: "{{ $value }} agents online out of {{ printf \"keldris_agents_total\" | query | first | value }} total."
+
+      # Alert on backup failures
+      - alert: KeldrisBackupFailures
+        expr: increase(keldris_backup_status_total{status="failed"}[1h]) > 5
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High number of backup failures"
+          description: "{{ $value }} backup failures in the last hour."
+
+      # Alert when backups are taking too long
+      - alert: KeldrisSlowBackups
+        expr: histogram_quantile(0.95, rate(keldris_backup_duration_seconds_bucket[1h])) > 7200
+        for: 30m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Backups taking longer than expected"
+          description: "95th percentile backup duration is {{ $value | humanizeDuration }}."
+
+      # Alert on database connection pool exhaustion
+      - alert: KeldrisDBPoolExhausted
+        expr: keldris_db_connections_acquired / keldris_db_connections_max > 0.9
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Database connection pool near capacity"
+          description: "{{ $value | humanizePercentage }} of database connections in use."
+
+      # Alert when database is unhealthy
+      - alert: KeldrisDBUnhealthy
+        expr: keldris_up{component="database"} == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Keldris database unhealthy"
+          description: "Database connection has failed."
+
+      # Alert on rapid storage growth
+      - alert: KeldrisStorageGrowth
+        expr: deriv(keldris_storage_used_bytes[1d]) > 10737418240
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: "Rapid storage growth detected"
+          description: "Storage is growing at {{ $value | humanize1024 }}/day."
+
+      # Alert when no backups have completed recently
+      - alert: KeldrisNoRecentBackups
+        expr: increase(keldris_backup_status_total{status="completed"}[24h]) == 0
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: "No successful backups in 24 hours"
+          description: "No backups have completed successfully in the last 24 hours."
+```
+
+## Grafana Dashboard
+
+Import the following dashboard JSON for a pre-built visualization:
+
+```json
+{
+  "title": "Keldris Backup Monitoring",
+  "panels": [
+    {
+      "title": "Agents Online",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "keldris_agents_online",
+          "legendFormat": "Online"
+        }
+      ]
+    },
+    {
+      "title": "Agent Status",
+      "type": "gauge",
+      "targets": [
+        {
+          "expr": "keldris_agents_online / keldris_agents_total * 100",
+          "legendFormat": "% Online"
+        }
+      ],
+      "options": {
+        "minValue": 0,
+        "maxValue": 100
+      }
+    },
+    {
+      "title": "Backup Success Rate",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "keldris_backup_status_total{status=\"completed\"} / keldris_backup_total * 100",
+          "legendFormat": "Success %"
+        }
+      ]
+    },
+    {
+      "title": "Backups by Status",
+      "type": "piechart",
+      "targets": [
+        {
+          "expr": "keldris_backup_status_total",
+          "legendFormat": "{{ status }}"
+        }
+      ]
+    },
+    {
+      "title": "Backup Duration (95th percentile)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, rate(keldris_backup_duration_seconds_bucket[5m]))",
+          "legendFormat": "p95 duration"
+        }
+      ]
+    },
+    {
+      "title": "Storage Used",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "keldris_storage_used_bytes",
+          "legendFormat": "Used"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        }
+      }
+    },
+    {
+      "title": "Database Connections",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "keldris_db_connections_acquired",
+          "legendFormat": "Acquired"
+        },
+        {
+          "expr": "keldris_db_connections_idle",
+          "legendFormat": "Idle"
+        },
+        {
+          "expr": "keldris_db_connections_max",
+          "legendFormat": "Max"
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Troubleshooting
+
+### Metrics not appearing
+
+1. Check that the server is running and accessible:
+   ```bash
+   curl http://keldris-server:8080/metrics
+   ```
+
+2. Verify Prometheus can reach the target:
+   ```bash
+   # Check Prometheus targets page
+   curl http://prometheus:9090/api/v1/targets
+   ```
+
+3. Check for firewall rules blocking port 8080
+
+### Stale metrics
+
+Metrics are cached for 15 seconds to reduce database load. If you need more frequent updates, consider adjusting your scrape interval.
+
+### High cardinality issues
+
+The current implementation does not include high-cardinality labels (like agent IDs or backup IDs). If you need per-agent metrics, consider using the dashboard API endpoints instead.

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -12179,3 +12179,74 @@ func (db *DB) UpdateKomodoWebhookEvent(ctx context.Context, event *models.Komodo
 	}
 	return nil
 }
+
+// =============================================================================
+// Prometheus Metrics Methods
+// =============================================================================
+
+// GetAllBackups returns all backups across all organizations (for Prometheus metrics).
+func (db *DB) GetAllBackups(ctx context.Context) ([]*models.Backup, error) {
+	rows, err := db.Pool.Query(ctx, `
+		SELECT id, schedule_id, agent_id, repository_id, snapshot_id, started_at, completed_at,
+		       status, size_bytes, files_new, files_changed, error_message,
+		       retention_applied, snapshots_removed, snapshots_kept, retention_error,
+		       pre_script_output, pre_script_error, post_script_output, post_script_error,
+		       excluded_large_files, resumed, checkpoint_id, original_backup_id, created_at
+		FROM backups
+		ORDER BY started_at DESC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("get all backups: %w", err)
+	}
+	defer rows.Close()
+
+	return scanBackups(rows)
+}
+
+// GetBackupsByStatus returns all backups with the specified status (for Prometheus metrics).
+func (db *DB) GetBackupsByStatus(ctx context.Context, status models.BackupStatus) ([]*models.Backup, error) {
+	rows, err := db.Pool.Query(ctx, `
+		SELECT id, schedule_id, agent_id, repository_id, snapshot_id, started_at, completed_at,
+		       status, size_bytes, files_new, files_changed, error_message,
+		       retention_applied, snapshots_removed, snapshots_kept, retention_error,
+		       pre_script_output, pre_script_error, post_script_output, post_script_error,
+		       excluded_large_files, resumed, checkpoint_id, original_backup_id, created_at
+		FROM backups
+		WHERE status = $1
+		ORDER BY started_at DESC
+	`, status)
+	if err != nil {
+		return nil, fmt.Errorf("get backups by status: %w", err)
+	}
+	defer rows.Close()
+
+	return scanBackups(rows)
+}
+
+// GetStorageStatsSummaryGlobal returns aggregated storage statistics across all organizations.
+func (db *DB) GetStorageStatsSummaryGlobal(ctx context.Context) (*models.StorageStatsSummary, error) {
+	var summary models.StorageStatsSummary
+	err := db.Pool.QueryRow(ctx, `
+		SELECT
+			COALESCE(SUM(latest.raw_data_size), 0) as total_raw_size,
+			COALESCE(SUM(latest.restore_size), 0) as total_restore_size,
+			COALESCE(SUM(latest.space_saved), 0) as total_space_saved,
+			COALESCE(AVG(latest.dedup_ratio), 0) as avg_dedup_ratio,
+			COUNT(DISTINCT latest.repository_id) as repository_count,
+			COALESCE(SUM(latest.snapshot_count), 0) as total_snapshots
+		FROM (
+			SELECT DISTINCT ON (s.repository_id)
+				s.repository_id, s.raw_data_size, s.restore_size, s.space_saved,
+				s.dedup_ratio, s.snapshot_count
+			FROM storage_stats s
+			ORDER BY s.repository_id, s.collected_at DESC
+		) as latest
+	`).Scan(
+		&summary.TotalRawSize, &summary.TotalRestoreSize, &summary.TotalSpaceSaved,
+		&summary.AvgDedupRatio, &summary.RepositoryCount, &summary.TotalSnapshots,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get storage stats summary global: %w", err)
+	}
+	return &summary, nil
+}

--- a/internal/metrics/prometheus.go
+++ b/internal/metrics/prometheus.go
@@ -1,0 +1,235 @@
+// Package metrics provides Prometheus metrics collection for Keldris.
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/MacJediWizard/keldris/internal/models"
+	"github.com/rs/zerolog"
+)
+
+// PrometheusStore defines the interface for retrieving metrics data.
+type PrometheusStore interface {
+	// Agent metrics
+	GetAllAgents(ctx context.Context) ([]*models.Agent, error)
+
+	// Backup metrics
+	GetAllBackups(ctx context.Context) ([]*models.Backup, error)
+	GetBackupsByStatus(ctx context.Context, status models.BackupStatus) ([]*models.Backup, error)
+
+	// Storage metrics
+	GetStorageStatsSummaryGlobal(ctx context.Context) (*models.StorageStatsSummary, error)
+}
+
+// PrometheusCollector collects and exposes Prometheus metrics.
+type PrometheusCollector struct {
+	store  PrometheusStore
+	logger zerolog.Logger
+
+	// Cached metrics with mutex for thread safety
+	mu               sync.RWMutex
+	lastCollected    time.Time
+	cachedMetrics    *PrometheusMetrics
+	cacheExpiry      time.Duration
+}
+
+// PrometheusMetrics holds all collected Prometheus metrics.
+type PrometheusMetrics struct {
+	// Backup metrics
+	BackupTotal           int64              // Total number of backups
+	BackupByStatus        map[string]int64   // Backups by status (completed, failed, running, canceled)
+	BackupDurationBuckets map[float64]int64  // Histogram buckets for backup duration
+	BackupDurationSum     float64            // Sum of all backup durations
+	BackupDurationCount   int64              // Count of backups with duration
+	BackupSizeBytes       int64              // Total size of completed backups
+
+	// Agent metrics
+	AgentsTotal  int64 // Total number of agents
+	AgentsOnline int64 // Number of online agents
+
+	// Storage metrics
+	StorageUsedBytes int64 // Total storage used
+}
+
+// NewPrometheusCollector creates a new PrometheusCollector.
+func NewPrometheusCollector(store PrometheusStore, logger zerolog.Logger) *PrometheusCollector {
+	return &PrometheusCollector{
+		store:       store,
+		logger:      logger.With().Str("component", "prometheus_collector").Logger(),
+		cacheExpiry: 15 * time.Second,
+	}
+}
+
+// Collect gathers all metrics from the database.
+func (c *PrometheusCollector) Collect(ctx context.Context) (*PrometheusMetrics, error) {
+	// Check cache first
+	c.mu.RLock()
+	if c.cachedMetrics != nil && time.Since(c.lastCollected) < c.cacheExpiry {
+		metrics := c.cachedMetrics
+		c.mu.RUnlock()
+		return metrics, nil
+	}
+	c.mu.RUnlock()
+
+	// Collect fresh metrics
+	metrics := &PrometheusMetrics{
+		BackupByStatus:        make(map[string]int64),
+		BackupDurationBuckets: make(map[float64]int64),
+	}
+
+	// Collect agent metrics
+	if err := c.collectAgentMetrics(ctx, metrics); err != nil {
+		c.logger.Warn().Err(err).Msg("failed to collect agent metrics")
+	}
+
+	// Collect backup metrics
+	if err := c.collectBackupMetrics(ctx, metrics); err != nil {
+		c.logger.Warn().Err(err).Msg("failed to collect backup metrics")
+	}
+
+	// Collect storage metrics
+	if err := c.collectStorageMetrics(ctx, metrics); err != nil {
+		c.logger.Warn().Err(err).Msg("failed to collect storage metrics")
+	}
+
+	// Update cache
+	c.mu.Lock()
+	c.cachedMetrics = metrics
+	c.lastCollected = time.Now()
+	c.mu.Unlock()
+
+	return metrics, nil
+}
+
+func (c *PrometheusCollector) collectAgentMetrics(ctx context.Context, metrics *PrometheusMetrics) error {
+	agents, err := c.store.GetAllAgents(ctx)
+	if err != nil {
+		return fmt.Errorf("get agents: %w", err)
+	}
+
+	metrics.AgentsTotal = int64(len(agents))
+	for _, agent := range agents {
+		if agent.Status == models.AgentStatusActive {
+			metrics.AgentsOnline++
+		}
+	}
+
+	return nil
+}
+
+func (c *PrometheusCollector) collectBackupMetrics(ctx context.Context, metrics *PrometheusMetrics) error {
+	backups, err := c.store.GetAllBackups(ctx)
+	if err != nil {
+		return fmt.Errorf("get backups: %w", err)
+	}
+
+	metrics.BackupTotal = int64(len(backups))
+
+	// Histogram buckets for backup duration (in seconds)
+	buckets := []float64{60, 300, 600, 1800, 3600, 7200, 14400, 28800}
+	for _, b := range buckets {
+		metrics.BackupDurationBuckets[b] = 0
+	}
+
+	for _, backup := range backups {
+		// Count by status
+		status := string(backup.Status)
+		metrics.BackupByStatus[status]++
+
+		// Calculate duration for completed backups
+		if backup.CompletedAt != nil && !backup.StartedAt.IsZero() {
+			duration := backup.CompletedAt.Sub(backup.StartedAt).Seconds()
+			metrics.BackupDurationSum += duration
+			metrics.BackupDurationCount++
+
+			// Populate histogram buckets
+			for _, b := range buckets {
+				if duration <= b {
+					metrics.BackupDurationBuckets[b]++
+				}
+			}
+		}
+
+		// Sum size for completed backups
+		if backup.Status == models.BackupStatusCompleted && backup.SizeBytes != nil {
+			metrics.BackupSizeBytes += *backup.SizeBytes
+		}
+	}
+
+	return nil
+}
+
+func (c *PrometheusCollector) collectStorageMetrics(ctx context.Context, metrics *PrometheusMetrics) error {
+	stats, err := c.store.GetStorageStatsSummaryGlobal(ctx)
+	if err != nil {
+		return fmt.Errorf("get storage stats: %w", err)
+	}
+
+	if stats != nil {
+		metrics.StorageUsedBytes = stats.TotalRawSize
+	}
+
+	return nil
+}
+
+// Format returns the metrics in Prometheus exposition format.
+func (c *PrometheusCollector) Format(metrics *PrometheusMetrics) string {
+	var sb strings.Builder
+
+	// backup_total - Counter for total number of backups
+	sb.WriteString("# HELP keldris_backup_total Total number of backups\n")
+	sb.WriteString("# TYPE keldris_backup_total counter\n")
+	sb.WriteString(fmt.Sprintf("keldris_backup_total %d\n", metrics.BackupTotal))
+	sb.WriteString("\n")
+
+	// backup_total by status
+	sb.WriteString("# HELP keldris_backup_status_total Total number of backups by status\n")
+	sb.WriteString("# TYPE keldris_backup_status_total counter\n")
+	for status, count := range metrics.BackupByStatus {
+		sb.WriteString(fmt.Sprintf("keldris_backup_status_total{status=\"%s\"} %d\n", status, count))
+	}
+	sb.WriteString("\n")
+
+	// backup_duration_seconds - Histogram for backup duration
+	sb.WriteString("# HELP keldris_backup_duration_seconds Histogram of backup duration in seconds\n")
+	sb.WriteString("# TYPE keldris_backup_duration_seconds histogram\n")
+
+	buckets := []float64{60, 300, 600, 1800, 3600, 7200, 14400, 28800}
+	for _, b := range buckets {
+		count := metrics.BackupDurationBuckets[b]
+		sb.WriteString(fmt.Sprintf("keldris_backup_duration_seconds_bucket{le=\"%.0f\"} %d\n", b, count))
+	}
+	sb.WriteString(fmt.Sprintf("keldris_backup_duration_seconds_bucket{le=\"+Inf\"} %d\n", metrics.BackupDurationCount))
+	sb.WriteString(fmt.Sprintf("keldris_backup_duration_seconds_sum %.2f\n", metrics.BackupDurationSum))
+	sb.WriteString(fmt.Sprintf("keldris_backup_duration_seconds_count %d\n", metrics.BackupDurationCount))
+	sb.WriteString("\n")
+
+	// backup_size_bytes - Gauge for total backup size
+	sb.WriteString("# HELP keldris_backup_size_bytes Total size of completed backups in bytes\n")
+	sb.WriteString("# TYPE keldris_backup_size_bytes gauge\n")
+	sb.WriteString(fmt.Sprintf("keldris_backup_size_bytes %d\n", metrics.BackupSizeBytes))
+	sb.WriteString("\n")
+
+	// agents_total - Gauge for total number of agents
+	sb.WriteString("# HELP keldris_agents_total Total number of registered agents\n")
+	sb.WriteString("# TYPE keldris_agents_total gauge\n")
+	sb.WriteString(fmt.Sprintf("keldris_agents_total %d\n", metrics.AgentsTotal))
+	sb.WriteString("\n")
+
+	// agents_online - Gauge for number of online agents
+	sb.WriteString("# HELP keldris_agents_online Number of online agents\n")
+	sb.WriteString("# TYPE keldris_agents_online gauge\n")
+	sb.WriteString(fmt.Sprintf("keldris_agents_online %d\n", metrics.AgentsOnline))
+	sb.WriteString("\n")
+
+	// storage_used_bytes - Gauge for total storage used
+	sb.WriteString("# HELP keldris_storage_used_bytes Total storage used in bytes\n")
+	sb.WriteString("# TYPE keldris_storage_used_bytes gauge\n")
+	sb.WriteString(fmt.Sprintf("keldris_storage_used_bytes %d\n", metrics.StorageUsedBytes))
+
+	return sb.String()
+}


### PR DESCRIPTION
## Summary
Add comprehensive Prometheus metrics endpoint for monitoring Keldris backup operations, agent health, and storage utilization.

## Key Features
- Backup metrics: total count, status breakdown, duration histogram, and size gauge
- Agent metrics: total count and online status
- Storage metrics: total usage across all repositories
- 15-second metric caching to reduce database load
- Complete documentation with Prometheus scrape config and alerting rules

## Metrics Exposed
- `keldris_backup_total` (counter)
- `keldris_backup_duration_seconds` (histogram)
- `keldris_backup_size_bytes` (gauge)
- `keldris_agents_total` (gauge)
- `keldris_agents_online` (gauge)
- `keldris_storage_used_bytes` (gauge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)