### PR TITLE
Implement license feature gating system

### DIFF
--- a/internal/api/middleware/features.go
+++ b/internal/api/middleware/features.go
@@ -1,0 +1,78 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/MacJediWizard/keldris/internal/license"
+	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog"
+)
+
+// LicenseContextKey is the context key for the current license.
+const LicenseContextKey ContextKey = "license"
+
+// LicenseMiddleware stores the current license in the Gin context so downstream
+// middleware and handlers can access it.
+func LicenseMiddleware(lic *license.License, logger zerolog.Logger) gin.HandlerFunc {
+	log := logger.With().Str("component", "license_middleware").Logger()
+
+	return func(c *gin.Context) {
+		c.Set(string(LicenseContextKey), lic)
+		log.Debug().
+			Str("tier", string(lic.Tier)).
+			Str("path", c.Request.URL.Path).
+			Msg("license context set")
+		c.Next()
+	}
+}
+
+// FeatureMiddleware returns a Gin middleware that gates access to a feature.
+// If the current license does not include the required feature, the request
+// is rejected with HTTP 402 Payment Required.
+func FeatureMiddleware(feature license.Feature, logger zerolog.Logger) gin.HandlerFunc {
+	log := logger.With().
+		Str("component", "feature_middleware").
+		Str("feature", string(feature)).
+		Logger()
+
+	return func(c *gin.Context) {
+		lic := GetLicense(c)
+		if lic == nil {
+			log.Warn().Str("path", c.Request.URL.Path).Msg("no license in context")
+			c.AbortWithStatusJSON(http.StatusPaymentRequired, gin.H{
+				"error":   "license required",
+				"feature": string(feature),
+			})
+			return
+		}
+
+		if !license.HasFeature(lic.Tier, feature) {
+			log.Info().
+				Str("tier", string(lic.Tier)).
+				Str("path", c.Request.URL.Path).
+				Msg("feature not available for tier")
+			c.AbortWithStatusJSON(http.StatusPaymentRequired, gin.H{
+				"error":   "feature not available on your current plan",
+				"feature": string(feature),
+				"tier":    string(lic.Tier),
+			})
+			return
+		}
+
+		c.Next()
+	}
+}
+
+// GetLicense retrieves the license from the Gin context.
+// Returns nil if no license is set.
+func GetLicense(c *gin.Context) *license.License {
+	val, exists := c.Get(string(LicenseContextKey))
+	if !exists {
+		return nil
+	}
+	lic, ok := val.(*license.License)
+	if !ok {
+		return nil
+	}
+	return lic
+}

--- a/internal/license/features.go
+++ b/internal/license/features.go
@@ -1,0 +1,61 @@
+package license
+
+// Feature represents a gated feature that requires a specific license tier.
+type Feature string
+
+const (
+	// FeatureOIDC enables OIDC authentication (Pro+).
+	FeatureOIDC Feature = "oidc"
+	// FeatureAuditLogs enables audit logging (Pro+).
+	FeatureAuditLogs Feature = "audit_logs"
+	// FeatureMultiOrg enables multiple organizations (Enterprise).
+	FeatureMultiOrg Feature = "multi_org"
+	// FeatureSLATracking enables SLA tracking (Enterprise).
+	FeatureSLATracking Feature = "sla_tracking"
+	// FeatureWhiteLabel enables white-label branding (Enterprise).
+	FeatureWhiteLabel Feature = "white_label"
+	// FeatureAirGap enables air-gapped deployment (Enterprise).
+	FeatureAirGap Feature = "air_gap"
+)
+
+// featureAccess maps each license tier to the features it unlocks.
+var featureAccess = map[LicenseTier][]Feature{
+	TierFree: {},
+	TierPro: {
+		FeatureOIDC,
+		FeatureAuditLogs,
+	},
+	TierEnterprise: {
+		FeatureOIDC,
+		FeatureAuditLogs,
+		FeatureMultiOrg,
+		FeatureSLATracking,
+		FeatureWhiteLabel,
+		FeatureAirGap,
+	},
+}
+
+// HasFeature returns true if the given tier has access to the specified feature.
+func HasFeature(tier LicenseTier, feature Feature) bool {
+	features, ok := featureAccess[tier]
+	if !ok {
+		return false
+	}
+	for _, f := range features {
+		if f == feature {
+			return true
+		}
+	}
+	return false
+}
+
+// FeaturesForTier returns all features available for the given tier.
+func FeaturesForTier(tier LicenseTier) []Feature {
+	features, ok := featureAccess[tier]
+	if !ok {
+		return nil
+	}
+	result := make([]Feature, len(features))
+	copy(result, features)
+	return result
+}

--- a/internal/license/license.go
+++ b/internal/license/license.go
@@ -1,0 +1,149 @@
+// Package license provides license management and feature gating for Keldris.
+package license
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// LicenseTier represents the subscription level.
+type LicenseTier string
+
+const (
+	// TierFree is the default tier with basic functionality.
+	TierFree LicenseTier = "free"
+	// TierPro unlocks advanced features like OIDC and audit logs.
+	TierPro LicenseTier = "pro"
+	// TierEnterprise unlocks all features including multi-org and air-gap.
+	TierEnterprise LicenseTier = "enterprise"
+)
+
+// ValidTiers returns all valid license tiers.
+func ValidTiers() []LicenseTier {
+	return []LicenseTier{TierFree, TierPro, TierEnterprise}
+}
+
+// IsValid checks if the tier is a recognized value.
+func (t LicenseTier) IsValid() bool {
+	for _, valid := range ValidTiers() {
+		if t == valid {
+			return true
+		}
+	}
+	return false
+}
+
+// License represents a Keldris license with tier, limits, and expiry.
+type License struct {
+	Tier       LicenseTier `json:"tier"`
+	CustomerID string      `json:"customer_id"`
+	ExpiresAt  time.Time   `json:"expires_at"`
+	IssuedAt   time.Time   `json:"issued_at"`
+	Limits     TierLimits  `json:"limits"`
+}
+
+// licensePayload is the JSON structure encoded in a license key.
+type licensePayload struct {
+	Tier       LicenseTier `json:"tier"`
+	CustomerID string      `json:"customer_id"`
+	ExpiresAt  int64       `json:"expires_at"`
+	IssuedAt   int64       `json:"issued_at"`
+}
+
+// signingKey is used to validate license keys. In production this would be
+// loaded from configuration or an environment variable.
+var signingKey = []byte("keldris-license-signing-key")
+
+// SetSigningKey configures the HMAC key used for license validation.
+func SetSigningKey(key []byte) {
+	signingKey = key
+}
+
+// ParseLicense decodes and verifies a license key string.
+// License keys are base64-encoded JSON payloads with an HMAC-SHA256 signature
+// appended after a "." separator.
+func ParseLicense(key string) (*License, error) {
+	if key == "" {
+		return nil, errors.New("empty license key")
+	}
+
+	parts := strings.SplitN(key, ".", 2)
+	if len(parts) != 2 {
+		return nil, errors.New("invalid license key format")
+	}
+
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode license payload: %w", err)
+	}
+
+	sigBytes, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode license signature: %w", err)
+	}
+
+	// Verify HMAC signature.
+	mac := hmac.New(sha256.New, signingKey)
+	mac.Write(payloadBytes)
+	expectedMAC := mac.Sum(nil)
+	if !hmac.Equal(sigBytes, expectedMAC) {
+		return nil, errors.New("invalid license signature")
+	}
+
+	var payload licensePayload
+	if err := json.Unmarshal(payloadBytes, &payload); err != nil {
+		return nil, fmt.Errorf("failed to parse license payload: %w", err)
+	}
+
+	if !payload.Tier.IsValid() {
+		return nil, fmt.Errorf("unknown license tier: %s", payload.Tier)
+	}
+
+	license := &License{
+		Tier:       payload.Tier,
+		CustomerID: payload.CustomerID,
+		ExpiresAt:  time.Unix(payload.ExpiresAt, 0),
+		IssuedAt:   time.Unix(payload.IssuedAt, 0),
+		Limits:     GetLimits(payload.Tier),
+	}
+
+	return license, nil
+}
+
+// ValidateLicense checks that a license is still valid (not expired).
+func ValidateLicense(license *License) error {
+	if license == nil {
+		return errors.New("nil license")
+	}
+
+	if !license.Tier.IsValid() {
+		return fmt.Errorf("unknown license tier: %s", license.Tier)
+	}
+
+	if time.Now().After(license.ExpiresAt) {
+		return errors.New("license has expired")
+	}
+
+	if license.CustomerID == "" {
+		return errors.New("missing customer ID")
+	}
+
+	return nil
+}
+
+// FreeLicense returns a default free-tier license with no expiry constraint.
+func FreeLicense() *License {
+	return &License{
+		Tier:       TierFree,
+		CustomerID: "free",
+		ExpiresAt:  time.Date(2099, 12, 31, 23, 59, 59, 0, time.UTC),
+		IssuedAt:   time.Now(),
+		Limits:     GetLimits(TierFree),
+	}
+}

--- a/internal/license/limits.go
+++ b/internal/license/limits.go
@@ -1,0 +1,54 @@
+package license
+
+// TierLimits defines the resource limits for a license tier.
+type TierLimits struct {
+	MaxAgents  int   `json:"max_agents"`
+	MaxUsers   int   `json:"max_users"`
+	MaxOrgs    int   `json:"max_orgs"`
+	MaxStorage int64 `json:"max_storage_bytes"`
+}
+
+// Unlimited is a sentinel value indicating no limit on a resource.
+const Unlimited = -1
+
+// tierLimits maps each license tier to its resource limits.
+var tierLimits = map[LicenseTier]TierLimits{
+	TierFree: {
+		MaxAgents:  3,
+		MaxUsers:   3,
+		MaxOrgs:    1,
+		MaxStorage: 10 * 1024 * 1024 * 1024, // 10 GB
+	},
+	TierPro: {
+		MaxAgents:  25,
+		MaxUsers:   10,
+		MaxOrgs:    3,
+		MaxStorage: 100 * 1024 * 1024 * 1024, // 100 GB
+	},
+	TierEnterprise: {
+		MaxAgents:  Unlimited,
+		MaxUsers:   Unlimited,
+		MaxOrgs:    Unlimited,
+		MaxStorage: Unlimited,
+	},
+}
+
+// GetLimits returns the resource limits for the given license tier.
+// Returns free-tier limits for unrecognized tiers.
+func GetLimits(tier LicenseTier) TierLimits {
+	limits, ok := tierLimits[tier]
+	if !ok {
+		return tierLimits[TierFree]
+	}
+	return limits
+}
+
+// IsUnlimited returns true if the given limit value represents unlimited.
+func IsUnlimited(limit int) bool {
+	return limit == Unlimited
+}
+
+// IsStorageUnlimited returns true if the storage limit is unlimited.
+func IsStorageUnlimited(limit int64) bool {
+	return limit == Unlimited
+}


### PR DESCRIPTION
## Summary

Adds a complete license feature gating system with three subscription tiers (Free, Pro, Enterprise). Supports license parsing with HMAC-SHA256 verification, per-tier feature access control, and resource limits.

## Changes

- **`internal/license/license.go`** - License types, parsing, and validation with HMAC-SHA256 signature verification
- **`internal/license/features.go`** - Feature enum and tier-based access mapping
- **`internal/license/limits.go`** - Resource limits per tier (agents, users, orgs, storage)
- **`internal/api/middleware/features.go`** - Gin middleware for feature enforcement with 402 Payment Required responses

## Test Plan

- [x] `go vet` passes
- [x] `staticcheck` passes
- [x] `go test -race` passes with all existing tests
- Feature access validated by middleware in protected routes