### PR TITLE
Add Docker backup support

### DIFF
--- a/internal/backup/docker/detector.go
+++ b/internal/backup/docker/detector.go
@@ -1,0 +1,78 @@
+package docker
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// DetectDocker checks if Docker is available and returns the version string.
+func DetectDocker() (bool, string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "docker", "version", "--format", "{{.Server.Version}}")
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+
+	if err := cmd.Run(); err != nil {
+		return false, ""
+	}
+
+	version := strings.TrimSpace(stdout.String())
+	if version == "" {
+		return false, ""
+	}
+
+	return true, version
+}
+
+// IsDockerRunning checks if the Docker daemon is responding.
+func IsDockerRunning() bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "docker", "info", "--format", "{{.ServerVersion}}")
+	return cmd.Run() == nil
+}
+
+// GetDockerInfo returns detailed information about the Docker installation.
+func GetDockerInfo() (*DockerInfo, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "docker", "info", "--format", "{{json .}}")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		errMsg := stderr.String()
+		if errMsg == "" {
+			errMsg = stdout.String()
+		}
+		return nil, fmt.Errorf("docker info: %w: %s", err, strings.TrimSpace(errMsg))
+	}
+
+	var raw dockerInfoOutput
+	if err := json.Unmarshal(stdout.Bytes(), &raw); err != nil {
+		return nil, fmt.Errorf("parse docker info: %w", err)
+	}
+
+	return &DockerInfo{
+		ServerVersion:   raw.ServerVersion,
+		StorageDriver:   raw.Driver,
+		DockerRootDir:   raw.DockerRootDir,
+		Containers:      raw.Containers,
+		ContRunning:     raw.ContainersRunning,
+		ContPaused:      raw.ContainersPaused,
+		ContStopped:     raw.ContainersStopped,
+		Images:          raw.Images,
+		OperatingSystem: raw.OperatingSystem,
+		Architecture:    raw.Architecture,
+	}, nil
+}

--- a/internal/backup/docker/docker.go
+++ b/internal/backup/docker/docker.go
@@ -1,0 +1,241 @@
+package docker
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// DockerClient wraps the Docker CLI for container and volume operations.
+type DockerClient struct {
+	binary string
+	logger zerolog.Logger
+}
+
+// NewDockerClient creates a new DockerClient.
+func NewDockerClient(logger zerolog.Logger) *DockerClient {
+	return &DockerClient{
+		binary: "docker",
+		logger: logger.With().Str("component", "docker").Logger(),
+	}
+}
+
+// NewDockerClientWithBinary creates a new DockerClient with a custom binary path.
+func NewDockerClientWithBinary(binary string, logger zerolog.Logger) *DockerClient {
+	return &DockerClient{
+		binary: binary,
+		logger: logger.With().Str("component", "docker").Logger(),
+	}
+}
+
+// ListContainers returns all containers (including stopped ones).
+func (d *DockerClient) ListContainers(ctx context.Context) ([]Container, error) {
+	d.logger.Debug().Msg("listing containers")
+
+	args := []string{"ps", "-a", "--no-trunc", "--format", "{{json .}}"}
+	output, err := d.run(ctx, args)
+	if err != nil {
+		return nil, fmt.Errorf("list containers: %w", err)
+	}
+
+	var containers []Container
+	lines := bytes.Split(output, []byte("\n"))
+	for _, line := range lines {
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+
+		var ps dockerPSOutput
+		if err := json.Unmarshal(line, &ps); err != nil {
+			d.logger.Warn().Err(err).Msg("failed to parse container line")
+			continue
+		}
+
+		created, _ := time.Parse("2006-01-02 15:04:05 -0700 MST", ps.Created)
+
+		containers = append(containers, Container{
+			ID:      ps.ID,
+			Name:    strings.TrimPrefix(ps.Names, "/"),
+			Image:   ps.Image,
+			State:   ps.State,
+			Status:  ps.Status,
+			Labels:  parseLabels(ps.Labels),
+			Created: created,
+		})
+	}
+
+	d.logger.Debug().Int("count", len(containers)).Msg("containers listed")
+	return containers, nil
+}
+
+// ListVolumes returns all Docker volumes.
+func (d *DockerClient) ListVolumes(ctx context.Context) ([]Volume, error) {
+	d.logger.Debug().Msg("listing volumes")
+
+	args := []string{"volume", "ls", "--format", "{{json .}}"}
+	output, err := d.run(ctx, args)
+	if err != nil {
+		return nil, fmt.Errorf("list volumes: %w", err)
+	}
+
+	var volumes []Volume
+	lines := bytes.Split(output, []byte("\n"))
+	for _, line := range lines {
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+
+		var vol dockerVolumeOutput
+		if err := json.Unmarshal(line, &vol); err != nil {
+			d.logger.Warn().Err(err).Msg("failed to parse volume line")
+			continue
+		}
+
+		volumes = append(volumes, Volume{
+			Name:       vol.Name,
+			Driver:     vol.Driver,
+			Mountpoint: vol.Mountpoint,
+			Labels:     parseLabels(vol.Labels),
+			Scope:      vol.Scope,
+			CreatedAt:  vol.CreatedAt,
+		})
+	}
+
+	d.logger.Debug().Int("count", len(volumes)).Msg("volumes listed")
+	return volumes, nil
+}
+
+// InspectContainer returns detailed information about a container.
+func (d *DockerClient) InspectContainer(ctx context.Context, id string) (*ContainerInfo, error) {
+	d.logger.Debug().Str("container_id", id).Msg("inspecting container")
+
+	args := []string{"inspect", "--format", "{{json .}}", id}
+	output, err := d.run(ctx, args)
+	if err != nil {
+		return nil, fmt.Errorf("inspect container %s: %w", id, err)
+	}
+
+	var raw dockerInspectOutput
+	if err := json.Unmarshal(output, &raw); err != nil {
+		return nil, fmt.Errorf("parse inspect output: %w", err)
+	}
+
+	info := &ContainerInfo{
+		ID:    raw.ID,
+		Name:  strings.TrimPrefix(raw.Name, "/"),
+		Image: raw.Config.Image,
+		State: ContainerState{
+			Status:   raw.State.Status,
+			Running:  raw.State.Running,
+			Paused:   raw.State.Paused,
+			ExitCode: raw.State.ExitCode,
+		},
+		Config: ContainerConfig{
+			Hostname: raw.Config.Hostname,
+			Env:      raw.Config.Env,
+			Cmd:      raw.Config.Cmd,
+		},
+		Labels:     raw.Config.Labels,
+		RestartKey: raw.HostConfig.RestartPolicy.Name,
+	}
+
+	created, err := time.Parse(time.RFC3339Nano, raw.Created)
+	if err == nil {
+		info.Created = created
+	}
+
+	if raw.State.StartedAt != "" {
+		if t, err := time.Parse(time.RFC3339Nano, raw.State.StartedAt); err == nil {
+			info.State.StartedAt = &t
+		}
+	}
+	if raw.State.FinishedAt != "" {
+		if t, err := time.Parse(time.RFC3339Nano, raw.State.FinishedAt); err == nil {
+			info.State.FinishedAt = &t
+		}
+	}
+
+	for _, m := range raw.Mounts {
+		info.Mounts = append(info.Mounts, Mount{
+			Type:        m.Type,
+			Name:        m.Name,
+			Source:      m.Source,
+			Destination: m.Destination,
+			ReadOnly:    !m.RW,
+		})
+	}
+
+	return info, nil
+}
+
+// PauseContainer pauses a running container.
+func (d *DockerClient) PauseContainer(ctx context.Context, id string) error {
+	d.logger.Info().Str("container_id", id).Msg("pausing container")
+
+	args := []string{"pause", id}
+	if _, err := d.run(ctx, args); err != nil {
+		return fmt.Errorf("pause container %s: %w", id, err)
+	}
+
+	d.logger.Info().Str("container_id", id).Msg("container paused")
+	return nil
+}
+
+// UnpauseContainer unpauses a paused container.
+func (d *DockerClient) UnpauseContainer(ctx context.Context, id string) error {
+	d.logger.Info().Str("container_id", id).Msg("unpausing container")
+
+	args := []string{"unpause", id}
+	if _, err := d.run(ctx, args); err != nil {
+		return fmt.Errorf("unpause container %s: %w", id, err)
+	}
+
+	d.logger.Info().Str("container_id", id).Msg("container unpaused")
+	return nil
+}
+
+// run executes a docker command and returns the output.
+func (d *DockerClient) run(ctx context.Context, args []string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, d.binary, args...)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	d.logger.Debug().
+		Str("command", d.binary).
+		Strs("args", args).
+		Msg("executing docker command")
+
+	if err := cmd.Run(); err != nil {
+		errMsg := stderr.String()
+		if errMsg == "" {
+			errMsg = stdout.String()
+		}
+		return nil, fmt.Errorf("%w: %s", err, strings.TrimSpace(errMsg))
+	}
+
+	return stdout.Bytes(), nil
+}
+
+// parseLabels parses a Docker label string (key=val,key2=val2) into a map.
+func parseLabels(labels string) map[string]string {
+	if labels == "" {
+		return nil
+	}
+
+	result := make(map[string]string)
+	for _, pair := range strings.Split(labels, ",") {
+		parts := strings.SplitN(pair, "=", 2)
+		if len(parts) == 2 {
+			result[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
+		}
+	}
+	return result
+}

--- a/internal/backup/docker/types.go
+++ b/internal/backup/docker/types.go
@@ -1,0 +1,150 @@
+// Package docker provides Docker container and volume backup support.
+package docker
+
+import "time"
+
+// Container represents a Docker container.
+type Container struct {
+	ID      string            `json:"id"`
+	Name    string            `json:"name"`
+	Image   string            `json:"image"`
+	State   string            `json:"state"`
+	Status  string            `json:"status"`
+	Labels  map[string]string `json:"labels,omitempty"`
+	Mounts  []Mount           `json:"mounts,omitempty"`
+	Created time.Time         `json:"created"`
+}
+
+// Mount represents a container mount point.
+type Mount struct {
+	Type        string `json:"type"`
+	Name        string `json:"name,omitempty"`
+	Source      string `json:"source"`
+	Destination string `json:"destination"`
+	ReadOnly    bool   `json:"read_only"`
+}
+
+// Volume represents a Docker volume.
+type Volume struct {
+	Name       string            `json:"name"`
+	Driver     string            `json:"driver"`
+	Mountpoint string            `json:"mountpoint"`
+	Labels     map[string]string `json:"labels,omitempty"`
+	Scope      string            `json:"scope"`
+	CreatedAt  string            `json:"created_at"`
+}
+
+// ContainerInfo contains detailed information about a container.
+type ContainerInfo struct {
+	ID         string            `json:"id"`
+	Name       string            `json:"name"`
+	Image      string            `json:"image"`
+	State      ContainerState    `json:"state"`
+	Config     ContainerConfig   `json:"config"`
+	Mounts     []Mount           `json:"mounts,omitempty"`
+	Labels     map[string]string `json:"labels,omitempty"`
+	Created    time.Time         `json:"created"`
+	RestartKey string            `json:"restart_policy,omitempty"`
+}
+
+// ContainerState represents the running state of a container.
+type ContainerState struct {
+	Status     string     `json:"status"`
+	Running    bool       `json:"running"`
+	Paused     bool       `json:"paused"`
+	StartedAt  *time.Time `json:"started_at,omitempty"`
+	FinishedAt *time.Time `json:"finished_at,omitempty"`
+	ExitCode   int        `json:"exit_code"`
+}
+
+// ContainerConfig holds the container's configuration.
+type ContainerConfig struct {
+	Hostname string   `json:"hostname"`
+	Env      []string `json:"env,omitempty"`
+	Cmd      []string `json:"cmd,omitempty"`
+}
+
+// DockerInfo contains information about the Docker installation.
+type DockerInfo struct {
+	ServerVersion  string `json:"server_version"`
+	StorageDriver  string `json:"storage_driver"`
+	DockerRootDir  string `json:"docker_root_dir"`
+	Containers     int    `json:"containers"`
+	ContRunning    int    `json:"containers_running"`
+	ContPaused     int    `json:"containers_paused"`
+	ContStopped    int    `json:"containers_stopped"`
+	Images         int    `json:"images"`
+	OperatingSystem string `json:"operating_system"`
+	Architecture   string `json:"architecture"`
+}
+
+// dockerInspectOutput maps the JSON output from docker inspect.
+type dockerInspectOutput struct {
+	ID      string `json:"Id"`
+	Name    string `json:"Name"`
+	Image   string `json:"Image"`
+	Created string `json:"Created"`
+	State   struct {
+		Status     string `json:"Status"`
+		Running    bool   `json:"Running"`
+		Paused     bool   `json:"Paused"`
+		StartedAt  string `json:"StartedAt"`
+		FinishedAt string `json:"FinishedAt"`
+		ExitCode   int    `json:"ExitCode"`
+	} `json:"State"`
+	Config struct {
+		Hostname string   `json:"Hostname"`
+		Env      []string `json:"Env"`
+		Cmd      []string `json:"Cmd"`
+		Labels   map[string]string `json:"Labels"`
+		Image    string   `json:"Image"`
+	} `json:"Config"`
+	HostConfig struct {
+		RestartPolicy struct {
+			Name string `json:"Name"`
+		} `json:"RestartPolicy"`
+	} `json:"HostConfig"`
+	Mounts []struct {
+		Type        string `json:"Type"`
+		Name        string `json:"Name"`
+		Source      string `json:"Source"`
+		Destination string `json:"Destination"`
+		RW          bool   `json:"RW"`
+	} `json:"Mounts"`
+}
+
+// dockerPSOutput maps the JSON output from docker ps --format.
+type dockerPSOutput struct {
+	ID      string `json:"ID"`
+	Names   string `json:"Names"`
+	Image   string `json:"Image"`
+	State   string `json:"State"`
+	Status  string `json:"Status"`
+	Labels  string `json:"Labels"`
+	Mounts  string `json:"Mounts"`
+	Created string `json:"CreatedAt"`
+}
+
+// dockerVolumeOutput maps the JSON output from docker volume ls --format.
+type dockerVolumeOutput struct {
+	Name       string `json:"Name"`
+	Driver     string `json:"Driver"`
+	Mountpoint string `json:"Mountpoint"`
+	Labels     string `json:"Labels"`
+	Scope      string `json:"Scope"`
+	CreatedAt  string `json:"CreatedAt"`
+}
+
+// dockerInfoOutput maps the JSON output from docker info --format.
+type dockerInfoOutput struct {
+	ServerVersion   string `json:"ServerVersion"`
+	Driver          string `json:"Driver"`
+	DockerRootDir   string `json:"DockerRootDir"`
+	Containers      int    `json:"Containers"`
+	ContainersRunning int  `json:"ContainersRunning"`
+	ContainersPaused  int  `json:"ContainersPaused"`
+	ContainersStopped int  `json:"ContainersStopped"`
+	Images          int    `json:"Images"`
+	OperatingSystem string `json:"OperatingSystem"`
+	Architecture    string `json:"Architecture"`
+}

--- a/internal/backup/docker/volumes.go
+++ b/internal/backup/docker/volumes.go
@@ -1,0 +1,175 @@
+package docker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/MacJediWizard/keldris/internal/backup"
+	"github.com/MacJediWizard/keldris/internal/backup/backends"
+	"github.com/rs/zerolog"
+)
+
+// VolumeBackup handles backing up Docker volumes via restic.
+type VolumeBackup struct {
+	docker *DockerClient
+	restic *backup.Restic
+	logger zerolog.Logger
+}
+
+// NewVolumeBackup creates a new VolumeBackup instance.
+func NewVolumeBackup(docker *DockerClient, restic *backup.Restic, logger zerolog.Logger) *VolumeBackup {
+	return &VolumeBackup{
+		docker: docker,
+		restic: restic,
+		logger: logger.With().Str("component", "docker-volume-backup").Logger(),
+	}
+}
+
+// GetVolumePath returns the host mountpoint path for a Docker volume.
+func (vb *VolumeBackup) GetVolumePath(ctx context.Context, volumeName string) (string, error) {
+	vb.logger.Debug().Str("volume", volumeName).Msg("getting volume path")
+
+	args := []string{"volume", "inspect", "--format", "{{json .Mountpoint}}", volumeName}
+	output, err := vb.docker.run(ctx, args)
+	if err != nil {
+		return "", fmt.Errorf("inspect volume %s: %w", volumeName, err)
+	}
+
+	var mountpoint string
+	if err := json.Unmarshal(output, &mountpoint); err != nil {
+		return "", fmt.Errorf("parse volume mountpoint: %w", err)
+	}
+
+	if mountpoint == "" {
+		return "", fmt.Errorf("volume %s has no mountpoint", volumeName)
+	}
+
+	return mountpoint, nil
+}
+
+// ListVolumeContents lists the files in a Docker volume by running a temporary container.
+func (vb *VolumeBackup) ListVolumeContents(ctx context.Context, volumeName string) ([]string, error) {
+	vb.logger.Debug().Str("volume", volumeName).Msg("listing volume contents")
+
+	args := []string{
+		"run", "--rm",
+		"-v", volumeName + ":/data:ro",
+		"alpine", "find", "/data", "-type", "f",
+	}
+	output, err := vb.docker.run(ctx, args)
+	if err != nil {
+		return nil, fmt.Errorf("list volume contents %s: %w", volumeName, err)
+	}
+
+	var files []string
+	for _, line := range strings.Split(string(output), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" {
+			files = append(files, trimmed)
+		}
+	}
+
+	vb.logger.Debug().Str("volume", volumeName).Int("files", len(files)).Msg("volume contents listed")
+	return files, nil
+}
+
+// BackupVolumeOptions configures a Docker volume backup operation.
+type BackupVolumeOptions struct {
+	VolumeName       string
+	Tags             []string
+	Excludes         []string
+	PauseContainers  bool
+	BandwidthLimitKB *int
+	CompressionLevel *string
+}
+
+// BackupVolume backs up a Docker volume using restic.
+// If PauseContainers is true, all containers using the volume are paused during backup.
+func (vb *VolumeBackup) BackupVolume(ctx context.Context, cfg backends.ResticConfig, opts BackupVolumeOptions) (*backup.BackupStats, error) {
+	vb.logger.Info().
+		Str("volume", opts.VolumeName).
+		Bool("pause_containers", opts.PauseContainers).
+		Msg("starting volume backup")
+
+	mountpoint, err := vb.GetVolumePath(ctx, opts.VolumeName)
+	if err != nil {
+		return nil, err
+	}
+
+	// Find and optionally pause containers using this volume.
+	var pausedContainers []string
+	if opts.PauseContainers {
+		pausedContainers, err = vb.pauseVolumeContainers(ctx, opts.VolumeName)
+		if err != nil {
+			return nil, fmt.Errorf("pause containers for volume %s: %w", opts.VolumeName, err)
+		}
+		defer vb.unpauseContainers(ctx, pausedContainers)
+	}
+
+	tags := append(opts.Tags, "docker-volume:"+opts.VolumeName)
+
+	backupOpts := &backup.BackupOptions{
+		BandwidthLimitKB: opts.BandwidthLimitKB,
+		CompressionLevel: opts.CompressionLevel,
+	}
+
+	stats, err := vb.restic.BackupWithOptions(ctx, cfg, []string{mountpoint}, opts.Excludes, tags, backupOpts)
+	if err != nil {
+		return nil, fmt.Errorf("backup volume %s: %w", opts.VolumeName, err)
+	}
+
+	vb.logger.Info().
+		Str("volume", opts.VolumeName).
+		Str("snapshot_id", stats.SnapshotID).
+		Int64("size_bytes", stats.SizeBytes).
+		Msg("volume backup completed")
+
+	return stats, nil
+}
+
+// pauseVolumeContainers pauses all running containers that use the given volume.
+func (vb *VolumeBackup) pauseVolumeContainers(ctx context.Context, volumeName string) ([]string, error) {
+	containers, err := vb.docker.ListContainers(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var paused []string
+	for _, c := range containers {
+		if c.State != "running" {
+			continue
+		}
+
+		info, err := vb.docker.InspectContainer(ctx, c.ID)
+		if err != nil {
+			vb.logger.Warn().Err(err).Str("container", c.Name).Msg("failed to inspect container")
+			continue
+		}
+
+		for _, m := range info.Mounts {
+			if m.Name == volumeName {
+				if err := vb.docker.PauseContainer(ctx, c.ID); err != nil {
+					// Unpause any already-paused containers before returning.
+					vb.unpauseContainers(ctx, paused)
+					return nil, fmt.Errorf("pause container %s: %w", c.Name, err)
+				}
+				paused = append(paused, c.ID)
+				vb.logger.Info().Str("container", c.Name).Msg("paused container for volume backup")
+				break
+			}
+		}
+	}
+
+	return paused, nil
+}
+
+// unpauseContainers unpauses the given containers, logging any errors.
+func (vb *VolumeBackup) unpauseContainers(ctx context.Context, containerIDs []string) {
+	for _, id := range containerIDs {
+		if err := vb.docker.UnpauseContainer(ctx, id); err != nil {
+			vb.logger.Error().Err(err).Str("container_id", id).Msg("failed to unpause container")
+		}
+	}
+}

--- a/internal/models/schedule.go
+++ b/internal/models/schedule.go
@@ -41,9 +41,11 @@ type Schedule struct {
 	BackupWindow       *BackupWindow        `json:"backup_window,omitempty"`        // Allowed backup time window
 	ExcludedHours      []int                `json:"excluded_hours,omitempty"`       // Hours (0-23) when backups should not run
 	CompressionLevel   *string              `json:"compression_level,omitempty"`    // Compression level: off, auto, max
-	OnMountUnavailable MountBehavior        `json:"on_mount_unavailable,omitempty"` // Behavior when network mount unavailable
-	Enabled            bool                 `json:"enabled"`
-	Repositories       []ScheduleRepository `json:"repositories,omitempty"`
+	OnMountUnavailable   MountBehavior        `json:"on_mount_unavailable,omitempty"` // Behavior when network mount unavailable
+	DockerVolumes        []string             `json:"docker_volumes,omitempty"`        // Docker volume names to back up
+	DockerPauseContainers bool                `json:"docker_pause_containers,omitempty"` // Pause containers during volume backup
+	Enabled              bool                 `json:"enabled"`
+	Repositories         []ScheduleRepository `json:"repositories,omitempty"`
 	CreatedAt          time.Time            `json:"created_at"`
 	UpdatedAt          time.Time            `json:"updated_at"`
 }
@@ -123,6 +125,22 @@ func (s *Schedule) ExcludesJSON() ([]byte, error) {
 		return nil, nil
 	}
 	return json.Marshal(s.Excludes)
+}
+
+// SetDockerVolumes sets the Docker volumes from JSON bytes.
+func (s *Schedule) SetDockerVolumes(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
+	return json.Unmarshal(data, &s.DockerVolumes)
+}
+
+// DockerVolumesJSON returns the Docker volumes as JSON bytes for database storage.
+func (s *Schedule) DockerVolumesJSON() ([]byte, error) {
+	if s.DockerVolumes == nil {
+		return nil, nil
+	}
+	return json.Marshal(s.DockerVolumes)
 }
 
 // SetRetentionPolicy sets the retention policy from JSON bytes.


### PR DESCRIPTION
## Summary

Implemented comprehensive Docker backup support in `internal/backup/docker/` with integration into the restic backup system:

- **docker.go**: DockerClient wrapping Docker CLI for container/volume operations (list, inspect, pause/unpause)
- **detector.go**: Docker availability detection (version, running status, system info)
- **volumes.go**: VolumeBackup struct integrating Docker volumes with restic, with optional container pause during backup
- **types.go**: All Docker data structures (Container, Volume, ContainerInfo, DockerInfo)
- **schedule.go**: Added DockerVolumes and DockerPauseContainers fields to Schedule model

The implementation follows existing project patterns (using os/exec for CLI operations like restic) and includes proper logging, error handling, and context cancellation support.