### PR TITLE
Clean up miscellaneous configuration and documentation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.github
+node_modules
+dist
+*.log
+*.md
+!README.md
+.env
+.env.*
+!.env.example
+coverage/
+tmp/
+.DS_Store

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   server:
     build:

--- a/docs/api/swagger.json
+++ b/docs/api/swagger.json
@@ -9,8 +9,8 @@
             "url": "https://github.com/MacJediWizard/keldris"
         },
         "license": {
-            "name": "MIT",
-            "url": "https://opensource.org/licenses/MIT"
+            "name": "AGPL-3.0",
+            "url": "https://www.gnu.org/licenses/agpl-3.0.html"
         },
         "version": "1.0"
     },

--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -599,8 +599,8 @@ info:
   description: Keldris - Keeper of your data. Self-hosted backup solution with OIDC
     authentication, Restic backup engine, and cloud storage support.
   license:
-    name: MIT
-    url: https://opensource.org/licenses/MIT
+    name: AGPL-3.0
+    url: https://www.gnu.org/licenses/agpl-3.0.html
   termsOfService: https://keldris.io/terms
   title: Keldris API
   version: "1.0"

--- a/internal/db/migrations/003_alerts.sql
+++ b/internal/db/migrations/003_alerts.sql
@@ -1,4 +1,4 @@
--- 002_alerts.sql
+-- 003_alerts.sql
 -- Migration: Add monitoring alerts and alert rules
 
 -- Alert rules define conditions that trigger alerts

--- a/internal/db/migrations/004_add_notifications.sql
+++ b/internal/db/migrations/004_add_notifications.sql
@@ -1,4 +1,4 @@
--- 002_add_notifications.sql
+-- 004_add_notifications.sql
 -- Migration: Add notification channels and preferences
 
 -- Notification channels (SMTP, Slack, Webhook, etc.)

--- a/internal/db/migrations/005_repository_keys.sql
+++ b/internal/db/migrations/005_repository_keys.sql
@@ -1,4 +1,4 @@
--- 002_repository_keys.sql
+-- 005_repository_keys.sql
 -- Migration: Add repository encryption keys table
 
 CREATE TABLE repository_keys (

--- a/internal/db/migrations/006_add_audit_logs.sql
+++ b/internal/db/migrations/006_add_audit_logs.sql
@@ -1,4 +1,4 @@
--- 002_add_audit_logs.sql
+-- 006_add_audit_logs.sql
 -- Add audit log tracking for compliance
 
 CREATE TABLE audit_logs (

--- a/internal/db/migrations/007_add_storage_stats.sql
+++ b/internal/db/migrations/007_add_storage_stats.sql
@@ -1,4 +1,4 @@
--- 002_add_storage_stats.sql
+-- 007_add_storage_stats.sql
 -- Migration: Add storage statistics table for tracking repository storage efficiency
 
 CREATE TABLE storage_stats (

--- a/internal/db/migrations/009_verification.sql
+++ b/internal/db/migrations/009_verification.sql
@@ -1,4 +1,4 @@
--- 002_verification.sql
+-- 009_verification.sql
 -- Migration: Add verification tables for backup integrity verification
 
 -- Verification schedules define when and how to verify repositories

--- a/internal/db/migrations/010_add_bandwidth_controls.sql
+++ b/internal/db/migrations/010_add_bandwidth_controls.sql
@@ -1,4 +1,4 @@
--- 002_add_bandwidth_controls.sql
+-- 010_add_bandwidth_controls.sql
 -- Migration: Add bandwidth and time window controls for schedules
 
 ALTER TABLE schedules ADD COLUMN bandwidth_limit_kbps INTEGER;

--- a/internal/db/migrations/012_add_dr_tables.sql
+++ b/internal/db/migrations/012_add_dr_tables.sql
@@ -1,4 +1,4 @@
--- 002_add_dr_tables.sql
+-- 012_add_dr_tables.sql
 -- Migration: Add disaster recovery runbook and test tables
 
 -- DR Runbooks - Templates for disaster recovery procedures

--- a/internal/db/migrations/013_multi_repo_schedules.sql
+++ b/internal/db/migrations/013_multi_repo_schedules.sql
@@ -1,4 +1,4 @@
--- 002_multi_repo_schedules.sql
+-- 013_multi_repo_schedules.sql
 -- Migration: Add multi-repository support for schedules with failover and replication
 
 -- Create junction table for schedule-repository many-to-many relationship

--- a/internal/db/migrations/020_add_compression_level.sql
+++ b/internal/db/migrations/020_add_compression_level.sql
@@ -1,4 +1,4 @@
--- 012_add_compression_level.sql
+-- 020_add_compression_level.sql
 -- Migration: Add compression level setting for schedules
 
 ALTER TABLE schedules ADD COLUMN compression_level VARCHAR(50);

--- a/internal/db/migrations/024_add_network_mounts.sql
+++ b/internal/db/migrations/024_add_network_mounts.sql
@@ -1,4 +1,4 @@
--- 012_add_network_mounts.sql
+-- 024_add_network_mounts.sql
 -- Migration: Add network mount tracking for agents and schedule behavior
 
 -- Add network mounts tracking to agents (stores array of detected mounts)

--- a/internal/db/migrations/025_add_onboarding.sql
+++ b/internal/db/migrations/025_add_onboarding.sql
@@ -1,4 +1,4 @@
--- 012_add_onboarding.sql
+-- 025_add_onboarding.sql
 -- Migration: Add onboarding progress tracking for organizations
 
 -- Track onboarding progress per organization


### PR DESCRIPTION
## Summary
- Add `.dockerignore` to exclude unnecessary files from container builds
- Update license from MIT to AGPL-3.0 in swagger specs
- Remove obsolete Docker Compose version directive  
- Fix migration comment headers to match actual file numbers

Tests pass and code follows project patterns.