### PR TITLE
Add Teams and Discord notification senders

### DIFF
--- a/internal/models/notification.go
+++ b/internal/models/notification.go
@@ -14,6 +14,8 @@ const (
 	ChannelTypeSlack     NotificationChannelType = "slack"
 	ChannelTypeWebhook   NotificationChannelType = "webhook"
 	ChannelTypePagerDuty NotificationChannelType = "pagerduty"
+	ChannelTypeTeams     NotificationChannelType = "teams"
+	ChannelTypeDiscord   NotificationChannelType = "discord"
 )
 
 // NotificationEventType represents the type of notification event
@@ -152,6 +154,16 @@ type WebhookChannelConfig struct {
 // PagerDutyChannelConfig represents PagerDuty integration configuration
 type PagerDutyChannelConfig struct {
 	RoutingKey string `json:"routing_key"`
+}
+
+// TeamsChannelConfig represents Microsoft Teams webhook configuration
+type TeamsChannelConfig struct {
+	WebhookURL string `json:"webhook_url"`
+}
+
+// DiscordChannelConfig represents Discord webhook configuration
+type DiscordChannelConfig struct {
+	WebhookURL string `json:"webhook_url"`
 }
 
 // CreateNotificationChannelRequest represents a request to create a notification channel

--- a/internal/notifications/discord.go
+++ b/internal/notifications/discord.go
@@ -1,0 +1,89 @@
+package notifications
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/rs/zerolog"
+)
+
+// DiscordSender sends notifications via Discord webhooks.
+type DiscordSender struct {
+	client *http.Client
+	logger zerolog.Logger
+}
+
+// NewDiscordSender creates a new Discord sender.
+func NewDiscordSender(logger zerolog.Logger) *DiscordSender {
+	return &DiscordSender{
+		client: &http.Client{},
+		logger: logger.With().Str("component", "discord_sender").Logger(),
+	}
+}
+
+// discordWebhookPayload represents a Discord webhook payload with embeds.
+type discordWebhookPayload struct {
+	Embeds []discordEmbed `json:"embeds"`
+}
+
+type discordEmbed struct {
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Color       int    `json:"color"`
+}
+
+// discordSeverityColor maps notification severity to Discord embed colors (decimal).
+func discordSeverityColor(severity string) int {
+	switch severity {
+	case "critical", "error":
+		return 0xdc2626 // red
+	case "warning":
+		return 0xf59e0b // amber
+	default:
+		return 0x22c55e // green
+	}
+}
+
+// Send sends a notification message to a Discord webhook URL.
+func (d *DiscordSender) Send(ctx context.Context, webhookURL string, msg NotificationMessage) error {
+	payload := discordWebhookPayload{
+		Embeds: []discordEmbed{
+			{
+				Title:       msg.Title,
+				Description: msg.Body,
+				Color:       discordSeverityColor(msg.Severity),
+			},
+		},
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal discord payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, webhookURL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create discord request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("send discord webhook: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Discord returns 204 No Content on success
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("discord webhook returned status %d", resp.StatusCode)
+	}
+
+	d.logger.Info().
+		Str("event_type", msg.EventType).
+		Msg("discord notification sent")
+
+	return nil
+}

--- a/internal/notifications/discord_test.go
+++ b/internal/notifications/discord_test.go
@@ -1,0 +1,97 @@
+package notifications
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+func TestDiscordSender_Send(t *testing.T) {
+	var received discordWebhookPayload
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+			t.Errorf("expected Content-Type application/json, got %s", ct)
+		}
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read body: %v", err)
+		}
+		if err := json.Unmarshal(body, &received); err != nil {
+			t.Fatalf("failed to unmarshal body: %v", err)
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	sender := NewDiscordSender(zerolog.Nop())
+	msg := NotificationMessage{
+		Title:     "Backup Failed: server1 - daily",
+		Body:      "**Host:** server1\n**Error:** disk full",
+		EventType: "backup_failed",
+		Severity:  "error",
+	}
+
+	err := sender.Send(context.Background(), server.URL, msg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(received.Embeds) != 1 {
+		t.Fatalf("expected 1 embed, got %d", len(received.Embeds))
+	}
+	embed := received.Embeds[0]
+	if embed.Title != msg.Title {
+		t.Errorf("expected title %q, got %q", msg.Title, embed.Title)
+	}
+	if embed.Description != msg.Body {
+		t.Errorf("expected description %q, got %q", msg.Body, embed.Description)
+	}
+	if embed.Color != 0xdc2626 {
+		t.Errorf("expected red color for error severity, got %d", embed.Color)
+	}
+}
+
+func TestDiscordSender_SendError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	sender := NewDiscordSender(zerolog.Nop())
+	msg := NotificationMessage{Title: "Test", Body: "test", EventType: "test", Severity: "info"}
+
+	err := sender.Send(context.Background(), server.URL, msg)
+	if err == nil {
+		t.Fatal("expected error for non-200/204 response")
+	}
+}
+
+func TestDiscordSeverityColor(t *testing.T) {
+	tests := []struct {
+		severity string
+		want     int
+	}{
+		{"critical", 0xdc2626},
+		{"error", 0xdc2626},
+		{"warning", 0xf59e0b},
+		{"info", 0x22c55e},
+		{"", 0x22c55e},
+	}
+	for _, tt := range tests {
+		got := discordSeverityColor(tt.severity)
+		if got != tt.want {
+			t.Errorf("discordSeverityColor(%q) = %d, want %d", tt.severity, got, tt.want)
+		}
+	}
+}

--- a/internal/notifications/service.go
+++ b/internal/notifications/service.go
@@ -191,6 +191,52 @@ func (s *Service) sendNotification(ctx context.Context, pref *models.Notificatio
 		sendErr := NewPagerDutySender(s.logger).Send(ctx, cfg.RoutingKey, event)
 		s.finalizeLog(ctx, log, sendErr, channel.ID.String(), "pagerduty")
 
+	case models.ChannelTypeTeams:
+		var cfg models.TeamsChannelConfig
+		if err := json.Unmarshal(channel.ConfigEncrypted, &cfg); err != nil {
+			s.logger.Error().Err(err).Str("channel_id", channel.ID.String()).Msg("failed to parse teams config")
+			return
+		}
+		log := models.NewNotificationLog(result.OrgID, &channel.ID, string(pref.EventType), cfg.WebhookURL, subject)
+		if err := s.store.CreateNotificationLog(ctx, log); err != nil {
+			s.logger.Error().Err(err).Msg("failed to create notification log")
+		}
+		var body string
+		if result.Success {
+			duration := result.CompletedAt.Sub(result.StartedAt)
+			body = fmt.Sprintf("**Host:** %s\n\n**Schedule:** %s\n\n**Snapshot:** %s\n\n**Duration:** %s\n\n**Size:** %s",
+				result.Hostname, result.ScheduleName, result.SnapshotID, formatDuration(duration), FormatBytes(result.SizeBytes))
+		} else {
+			body = fmt.Sprintf("**Host:** %s\n\n**Schedule:** %s\n\n**Error:** %s",
+				result.Hostname, result.ScheduleName, result.ErrorMessage)
+		}
+		msg := NotificationMessage{Title: subject, Body: body, EventType: string(pref.EventType), Severity: severity}
+		sendErr := NewTeamsSender(s.logger).Send(ctx, cfg.WebhookURL, msg)
+		s.finalizeLog(ctx, log, sendErr, channel.ID.String(), cfg.WebhookURL)
+
+	case models.ChannelTypeDiscord:
+		var cfg models.DiscordChannelConfig
+		if err := json.Unmarshal(channel.ConfigEncrypted, &cfg); err != nil {
+			s.logger.Error().Err(err).Str("channel_id", channel.ID.String()).Msg("failed to parse discord config")
+			return
+		}
+		log := models.NewNotificationLog(result.OrgID, &channel.ID, string(pref.EventType), cfg.WebhookURL, subject)
+		if err := s.store.CreateNotificationLog(ctx, log); err != nil {
+			s.logger.Error().Err(err).Msg("failed to create notification log")
+		}
+		var body string
+		if result.Success {
+			duration := result.CompletedAt.Sub(result.StartedAt)
+			body = fmt.Sprintf("**Host:** %s\n**Schedule:** %s\n**Snapshot:** %s\n**Duration:** %s\n**Size:** %s",
+				result.Hostname, result.ScheduleName, result.SnapshotID, formatDuration(duration), FormatBytes(result.SizeBytes))
+		} else {
+			body = fmt.Sprintf("**Host:** %s\n**Schedule:** %s\n**Error:** %s",
+				result.Hostname, result.ScheduleName, result.ErrorMessage)
+		}
+		msg := NotificationMessage{Title: subject, Body: body, EventType: string(pref.EventType), Severity: severity}
+		sendErr := NewDiscordSender(s.logger).Send(ctx, cfg.WebhookURL, msg)
+		s.finalizeLog(ctx, log, sendErr, channel.ID.String(), cfg.WebhookURL)
+
 	default:
 		s.logger.Warn().
 			Str("channel_type", string(channel.Type)).
@@ -317,6 +363,36 @@ func (s *Service) sendAgentOfflineNotification(ctx context.Context, pref *models
 		event := PagerDutyEvent{Summary: subject, Source: data.Hostname, Severity: "warning", Group: "agent"}
 		sendErr := NewPagerDutySender(s.logger).Send(ctx, cfg.RoutingKey, event)
 		s.finalizeLog(ctx, log, sendErr, channel.ID.String(), "pagerduty")
+
+	case models.ChannelTypeTeams:
+		var cfg models.TeamsChannelConfig
+		if err := json.Unmarshal(channel.ConfigEncrypted, &cfg); err != nil {
+			s.logger.Error().Err(err).Str("channel_id", channel.ID.String()).Msg("failed to parse teams config")
+			return
+		}
+		log := models.NewNotificationLog(orgID, &channel.ID, string(models.EventAgentOffline), cfg.WebhookURL, subject)
+		if err := s.store.CreateNotificationLog(ctx, log); err != nil {
+			s.logger.Error().Err(err).Msg("failed to create notification log")
+		}
+		body := fmt.Sprintf("**Host:** %s\n\n**Agent ID:** %s\n\n**Offline for:** %s", data.Hostname, data.AgentID, data.OfflineSince)
+		msg := NotificationMessage{Title: subject, Body: body, EventType: string(models.EventAgentOffline), Severity: "warning"}
+		sendErr := NewTeamsSender(s.logger).Send(ctx, cfg.WebhookURL, msg)
+		s.finalizeLog(ctx, log, sendErr, channel.ID.String(), cfg.WebhookURL)
+
+	case models.ChannelTypeDiscord:
+		var cfg models.DiscordChannelConfig
+		if err := json.Unmarshal(channel.ConfigEncrypted, &cfg); err != nil {
+			s.logger.Error().Err(err).Str("channel_id", channel.ID.String()).Msg("failed to parse discord config")
+			return
+		}
+		log := models.NewNotificationLog(orgID, &channel.ID, string(models.EventAgentOffline), cfg.WebhookURL, subject)
+		if err := s.store.CreateNotificationLog(ctx, log); err != nil {
+			s.logger.Error().Err(err).Msg("failed to create notification log")
+		}
+		body := fmt.Sprintf("**Host:** %s\n**Agent ID:** %s\n**Offline for:** %s", data.Hostname, data.AgentID, data.OfflineSince)
+		msg := NotificationMessage{Title: subject, Body: body, EventType: string(models.EventAgentOffline), Severity: "warning"}
+		sendErr := NewDiscordSender(s.logger).Send(ctx, cfg.WebhookURL, msg)
+		s.finalizeLog(ctx, log, sendErr, channel.ID.String(), cfg.WebhookURL)
 
 	default:
 		s.logger.Warn().
@@ -452,6 +528,38 @@ func (s *Service) sendMaintenanceNotification(ctx context.Context, pref *models.
 		event := PagerDutyEvent{Summary: subject, Source: "keldris", Severity: "info", Group: "maintenance"}
 		sendErr := NewPagerDutySender(s.logger).Send(ctx, cfg.RoutingKey, event)
 		s.finalizeLog(ctx, log, sendErr, channel.ID.String(), "pagerduty")
+
+	case models.ChannelTypeTeams:
+		var cfg models.TeamsChannelConfig
+		if err := json.Unmarshal(channel.ConfigEncrypted, &cfg); err != nil {
+			s.logger.Error().Err(err).Str("channel_id", channel.ID.String()).Msg("failed to parse teams config")
+			return
+		}
+		log := models.NewNotificationLog(orgID, &channel.ID, string(pref.EventType), cfg.WebhookURL, subject)
+		if err := s.store.CreateNotificationLog(ctx, log); err != nil {
+			s.logger.Error().Err(err).Msg("failed to create notification log")
+		}
+		body := fmt.Sprintf("**%s**\n\n%s\n\n**Starts:** %s\n\n**Ends:** %s\n\n**Duration:** %s",
+			data.Title, data.Message, data.StartsAt.Format(time.RFC822), data.EndsAt.Format(time.RFC822), data.Duration)
+		msg := NotificationMessage{Title: subject, Body: body, EventType: string(pref.EventType), Severity: "warning"}
+		sendErr := NewTeamsSender(s.logger).Send(ctx, cfg.WebhookURL, msg)
+		s.finalizeLog(ctx, log, sendErr, channel.ID.String(), cfg.WebhookURL)
+
+	case models.ChannelTypeDiscord:
+		var cfg models.DiscordChannelConfig
+		if err := json.Unmarshal(channel.ConfigEncrypted, &cfg); err != nil {
+			s.logger.Error().Err(err).Str("channel_id", channel.ID.String()).Msg("failed to parse discord config")
+			return
+		}
+		log := models.NewNotificationLog(orgID, &channel.ID, string(pref.EventType), cfg.WebhookURL, subject)
+		if err := s.store.CreateNotificationLog(ctx, log); err != nil {
+			s.logger.Error().Err(err).Msg("failed to create notification log")
+		}
+		body := fmt.Sprintf("**%s**\n%s\n**Starts:** %s\n**Ends:** %s\n**Duration:** %s",
+			data.Title, data.Message, data.StartsAt.Format(time.RFC822), data.EndsAt.Format(time.RFC822), data.Duration)
+		msg := NotificationMessage{Title: subject, Body: body, EventType: string(pref.EventType), Severity: "warning"}
+		sendErr := NewDiscordSender(s.logger).Send(ctx, cfg.WebhookURL, msg)
+		s.finalizeLog(ctx, log, sendErr, channel.ID.String(), cfg.WebhookURL)
 
 	default:
 		s.logger.Warn().

--- a/internal/notifications/teams.go
+++ b/internal/notifications/teams.go
@@ -1,0 +1,124 @@
+package notifications
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/rs/zerolog"
+)
+
+// TeamsSender sends notifications via Microsoft Teams incoming webhooks.
+type TeamsSender struct {
+	client *http.Client
+	logger zerolog.Logger
+}
+
+// NewTeamsSender creates a new Teams sender.
+func NewTeamsSender(logger zerolog.Logger) *TeamsSender {
+	return &TeamsSender{
+		client: &http.Client{},
+		logger: logger.With().Str("component", "teams_sender").Logger(),
+	}
+}
+
+// teamsAdaptiveCard represents a Teams webhook payload using Adaptive Cards.
+type teamsAdaptiveCard struct {
+	Type        string              `json:"type"`
+	Attachments []teamsAttachment   `json:"attachments"`
+}
+
+type teamsAttachment struct {
+	ContentType string            `json:"contentType"`
+	ContentURL  *string           `json:"contentUrl"`
+	Content     teamsCardContent  `json:"content"`
+}
+
+type teamsCardContent struct {
+	Schema  string          `json:"$schema"`
+	Type    string          `json:"type"`
+	Version string          `json:"version"`
+	Body    []teamsCardBody `json:"body"`
+}
+
+type teamsCardBody struct {
+	Type   string `json:"type"`
+	Text   string `json:"text"`
+	Size   string `json:"size,omitempty"`
+	Weight string `json:"weight,omitempty"`
+	Color  string `json:"color,omitempty"`
+	Wrap   bool   `json:"wrap,omitempty"`
+}
+
+// teamsSeverityColor maps notification severity to Adaptive Card color names.
+func teamsSeverityColor(severity string) string {
+	switch severity {
+	case "critical", "error":
+		return "attention"
+	case "warning":
+		return "warning"
+	default:
+		return "good"
+	}
+}
+
+// Send sends a notification message to a Teams webhook URL.
+func (t *TeamsSender) Send(ctx context.Context, webhookURL string, msg NotificationMessage) error {
+	payload := teamsAdaptiveCard{
+		Type: "message",
+		Attachments: []teamsAttachment{
+			{
+				ContentType: "application/vnd.microsoft.card.adaptive",
+				ContentURL:  nil,
+				Content: teamsCardContent{
+					Schema:  "http://adaptivecards.io/schemas/adaptive-card.json",
+					Type:    "AdaptiveCard",
+					Version: "1.4",
+					Body: []teamsCardBody{
+						{
+							Type:   "TextBlock",
+							Text:   msg.Title,
+							Size:   "Medium",
+							Weight: "Bolder",
+							Color:  teamsSeverityColor(msg.Severity),
+						},
+						{
+							Type: "TextBlock",
+							Text: msg.Body,
+							Wrap: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal teams payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, webhookURL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create teams request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := t.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("send teams webhook: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+		return fmt.Errorf("teams webhook returned status %d", resp.StatusCode)
+	}
+
+	t.logger.Info().
+		Str("event_type", msg.EventType).
+		Msg("teams notification sent")
+
+	return nil
+}

--- a/internal/notifications/teams_test.go
+++ b/internal/notifications/teams_test.go
@@ -1,0 +1,109 @@
+package notifications
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+func TestTeamsSender_Send(t *testing.T) {
+	var received teamsAdaptiveCard
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+			t.Errorf("expected Content-Type application/json, got %s", ct)
+		}
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read body: %v", err)
+		}
+		if err := json.Unmarshal(body, &received); err != nil {
+			t.Fatalf("failed to unmarshal body: %v", err)
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	sender := NewTeamsSender(zerolog.Nop())
+	msg := NotificationMessage{
+		Title:     "Backup Failed: server1 - daily",
+		Body:      "**Host:** server1\n\n**Error:** disk full",
+		EventType: "backup_failed",
+		Severity:  "error",
+	}
+
+	err := sender.Send(context.Background(), server.URL, msg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if received.Type != "message" {
+		t.Errorf("expected type 'message', got %q", received.Type)
+	}
+	if len(received.Attachments) != 1 {
+		t.Fatalf("expected 1 attachment, got %d", len(received.Attachments))
+	}
+	att := received.Attachments[0]
+	if att.ContentType != "application/vnd.microsoft.card.adaptive" {
+		t.Errorf("expected adaptive card content type, got %q", att.ContentType)
+	}
+	if att.Content.Type != "AdaptiveCard" {
+		t.Errorf("expected AdaptiveCard type, got %q", att.Content.Type)
+	}
+	if len(att.Content.Body) != 2 {
+		t.Fatalf("expected 2 body elements, got %d", len(att.Content.Body))
+	}
+	if att.Content.Body[0].Text != msg.Title {
+		t.Errorf("expected title %q, got %q", msg.Title, att.Content.Body[0].Text)
+	}
+	if att.Content.Body[0].Color != "attention" {
+		t.Errorf("expected color 'attention' for error severity, got %q", att.Content.Body[0].Color)
+	}
+	if att.Content.Body[1].Text != msg.Body {
+		t.Errorf("expected body %q, got %q", msg.Body, att.Content.Body[1].Text)
+	}
+}
+
+func TestTeamsSender_SendError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	sender := NewTeamsSender(zerolog.Nop())
+	msg := NotificationMessage{Title: "Test", Body: "test", EventType: "test", Severity: "info"}
+
+	err := sender.Send(context.Background(), server.URL, msg)
+	if err == nil {
+		t.Fatal("expected error for non-200 response")
+	}
+}
+
+func TestTeamsSeverityColor(t *testing.T) {
+	tests := []struct {
+		severity string
+		want     string
+	}{
+		{"critical", "attention"},
+		{"error", "attention"},
+		{"warning", "warning"},
+		{"info", "good"},
+		{"", "good"},
+	}
+	for _, tt := range tests {
+		got := teamsSeverityColor(tt.severity)
+		if got != tt.want {
+			t.Errorf("teamsSeverityColor(%q) = %q, want %q", tt.severity, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add TeamsSender for Microsoft Teams webhooks using Adaptive Cards format
- Add DiscordSender for Discord webhooks using embed format
- Support Teams and Discord for all notification event types (backup, agent offline, maintenance)
- Severity mapping: red for errors, amber for warnings, green for success

## Test plan
- All notification sender tests pass (17/17)
- Full test suite passes
- Teams format uses Adaptive Card schema with proper color mapping
- Discord format uses embeds with hex color values