### PR TITLE
Create pkg/models/ for shared agent-server types

### DIFF
--- a/internal/api/handlers/agent_api.go
+++ b/internal/api/handlers/agent_api.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/MacJediWizard/keldris/internal/api/middleware"
 	"github.com/MacJediWizard/keldris/internal/models"
+	pkgmodels "github.com/MacJediWizard/keldris/pkg/models"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -45,33 +46,6 @@ func (h *AgentAPIHandler) RegisterRoutes(r *gin.RouterGroup) {
 	r.POST("/health", h.ReportHealth)
 }
 
-// AgentHealthReport is the request body for agent health reporting.
-type AgentHealthReport struct {
-	Status  string         `json:"status" binding:"required,oneof=healthy unhealthy degraded"`
-	OSInfo  *models.OSInfo `json:"os_info,omitempty"`
-	Metrics *AgentMetrics  `json:"metrics,omitempty"`
-}
-
-// AgentMetrics contains optional metrics from the agent.
-type AgentMetrics struct {
-	CPUUsage        float64 `json:"cpu_usage,omitempty"`
-	MemoryUsage     float64 `json:"memory_usage,omitempty"`
-	DiskUsage       float64 `json:"disk_usage,omitempty"`
-	DiskFreeBytes   int64   `json:"disk_free_bytes,omitempty"`
-	DiskTotalBytes  int64   `json:"disk_total_bytes,omitempty"`
-	NetworkUp       bool    `json:"network_up"`
-	Uptime          int64   `json:"uptime_seconds,omitempty"`
-	ResticVersion   string  `json:"restic_version,omitempty"`
-	ResticAvailable bool    `json:"restic_available,omitempty"`
-}
-
-// AgentHealthResponse is the response for agent health reporting.
-type AgentHealthResponse struct {
-	Acknowledged bool      `json:"acknowledged"`
-	ServerTime   time.Time `json:"server_time"`
-	AgentID      string    `json:"agent_id"`
-}
-
 // ReportHealth handles agent health reports.
 // POST /api/v1/agent/health
 func (h *AgentAPIHandler) ReportHealth(c *gin.Context) {
@@ -80,7 +54,7 @@ func (h *AgentAPIHandler) ReportHealth(c *gin.Context) {
 		return
 	}
 
-	var req AgentHealthReport
+	var req pkgmodels.HeartbeatRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request: " + err.Error()})
 		return
@@ -102,7 +76,7 @@ func (h *AgentAPIHandler) ReportHealth(c *gin.Context) {
 			DiskFreeBytes:   req.Metrics.DiskFreeBytes,
 			DiskTotalBytes:  req.Metrics.DiskTotalBytes,
 			NetworkUp:       req.Metrics.NetworkUp,
-			UptimeSeconds:   req.Metrics.Uptime,
+			UptimeSeconds:   req.Metrics.UptimeSeconds,
 			ResticVersion:   req.Metrics.ResticVersion,
 			ResticAvailable: req.Metrics.ResticAvailable,
 		}
@@ -164,7 +138,7 @@ func (h *AgentAPIHandler) ReportHealth(c *gin.Context) {
 		Str("health_status", string(healthStatus)).
 		Msg("agent health report received")
 
-	c.JSON(http.StatusOK, AgentHealthResponse{
+	c.JSON(http.StatusOK, pkgmodels.HeartbeatResponse{
 		Acknowledged: true,
 		ServerTime:   time.Now().UTC(),
 		AgentID:      agent.ID.String(),

--- a/internal/models/agent.go
+++ b/internal/models/agent.go
@@ -4,8 +4,12 @@ import (
 	"encoding/json"
 	"time"
 
+	pkgmodels "github.com/MacJediWizard/keldris/pkg/models"
 	"github.com/google/uuid"
 )
+
+// OSInfo is a type alias for the shared OSInfo type in pkg/models.
+type OSInfo = pkgmodels.OSInfo
 
 // AgentStatus represents the current status of an agent.
 type AgentStatus string
@@ -20,14 +24,6 @@ const (
 	// AgentStatusDisabled indicates the agent has been manually disabled.
 	AgentStatusDisabled AgentStatus = "disabled"
 )
-
-// OSInfo contains operating system information from the agent.
-type OSInfo struct {
-	OS       string `json:"os" example:"linux"`
-	Arch     string `json:"arch" example:"amd64"`
-	Hostname string `json:"hostname" example:"backup-server-01"`
-	Version  string `json:"version,omitempty" example:"Ubuntu 22.04"`
-}
 
 // HealthStatus represents the overall health status of an agent.
 type HealthStatus string

--- a/internal/models/backup.go
+++ b/internal/models/backup.go
@@ -3,21 +3,18 @@ package models
 import (
 	"time"
 
+	pkgmodels "github.com/MacJediWizard/keldris/pkg/models"
 	"github.com/google/uuid"
 )
 
-// BackupStatus represents the current status of a backup.
-type BackupStatus string
+// BackupStatus is a type alias for the shared BackupStatus type in pkg/models.
+type BackupStatus = pkgmodels.BackupStatus
 
 const (
-	// BackupStatusRunning indicates the backup is in progress.
-	BackupStatusRunning BackupStatus = "running"
-	// BackupStatusCompleted indicates the backup completed successfully.
-	BackupStatusCompleted BackupStatus = "completed"
-	// BackupStatusFailed indicates the backup failed.
-	BackupStatusFailed BackupStatus = "failed"
-	// BackupStatusCanceled indicates the backup was canceled.
-	BackupStatusCanceled BackupStatus = "canceled"
+	BackupStatusRunning   = pkgmodels.BackupStatusRunning
+	BackupStatusCompleted = pkgmodels.BackupStatusCompleted
+	BackupStatusFailed    = pkgmodels.BackupStatusFailed
+	BackupStatusCanceled  = pkgmodels.BackupStatusCanceled
 )
 
 // Backup represents a single backup execution record.

--- a/pkg/models/agent.go
+++ b/pkg/models/agent.go
@@ -1,0 +1,46 @@
+package models
+
+import "time"
+
+// AgentInfo contains lightweight agent information for agent-server communication.
+type AgentInfo struct {
+	ID       string  `json:"id"`
+	Hostname string  `json:"hostname"`
+	Status   string  `json:"status"`
+	OSInfo   *OSInfo `json:"os_info,omitempty"`
+}
+
+// OSInfo contains operating system information from the agent.
+type OSInfo struct {
+	OS       string `json:"os" example:"linux"`
+	Arch     string `json:"arch" example:"amd64"`
+	Hostname string `json:"hostname" example:"backup-server-01"`
+	Version  string `json:"version,omitempty" example:"Ubuntu 22.04"`
+}
+
+// HeartbeatRequest is the request body for agent health reporting.
+type HeartbeatRequest struct {
+	Status  string            `json:"status" binding:"required,oneof=healthy unhealthy degraded"`
+	OSInfo  *OSInfo           `json:"os_info,omitempty"`
+	Metrics *HeartbeatMetrics `json:"metrics,omitempty"`
+}
+
+// HeartbeatMetrics contains system metrics reported by the agent.
+type HeartbeatMetrics struct {
+	CPUUsage        float64 `json:"cpu_usage,omitempty"`
+	MemoryUsage     float64 `json:"memory_usage,omitempty"`
+	DiskUsage       float64 `json:"disk_usage,omitempty"`
+	DiskFreeBytes   int64   `json:"disk_free_bytes,omitempty"`
+	DiskTotalBytes  int64   `json:"disk_total_bytes,omitempty"`
+	NetworkUp       bool    `json:"network_up"`
+	UptimeSeconds   int64   `json:"uptime_seconds,omitempty"`
+	ResticVersion   string  `json:"restic_version,omitempty"`
+	ResticAvailable bool    `json:"restic_available,omitempty"`
+}
+
+// HeartbeatResponse is the server response to a heartbeat request.
+type HeartbeatResponse struct {
+	Acknowledged bool      `json:"acknowledged"`
+	ServerTime   time.Time `json:"server_time"`
+	AgentID      string    `json:"agent_id"`
+}

--- a/pkg/models/backup.go
+++ b/pkg/models/backup.go
@@ -1,0 +1,31 @@
+package models
+
+// BackupStatus represents the current status of a backup.
+type BackupStatus string
+
+const (
+	// BackupStatusRunning indicates the backup is in progress.
+	BackupStatusRunning BackupStatus = "running"
+	// BackupStatusCompleted indicates the backup completed successfully.
+	BackupStatusCompleted BackupStatus = "completed"
+	// BackupStatusFailed indicates the backup failed.
+	BackupStatusFailed BackupStatus = "failed"
+	// BackupStatusCanceled indicates the backup was canceled.
+	BackupStatusCanceled BackupStatus = "canceled"
+)
+
+// BackupRequest is the request body for initiating a backup from the agent.
+type BackupRequest struct {
+	ScheduleID string   `json:"schedule_id" binding:"required"`
+	Paths      []string `json:"paths" binding:"required"`
+	Tags       []string `json:"tags,omitempty"`
+	Exclude    []string `json:"exclude,omitempty"`
+}
+
+// BackupResponse is the server response to a backup request.
+type BackupResponse struct {
+	BackupID   string       `json:"backup_id"`
+	Status     BackupStatus `json:"status"`
+	Message    string       `json:"message,omitempty"`
+	SnapshotID string       `json:"snapshot_id,omitempty"`
+}

--- a/pkg/models/common.go
+++ b/pkg/models/common.go
@@ -1,0 +1,14 @@
+package models
+
+// APIError represents a standard API error response.
+type APIError struct {
+	Error   string `json:"error"`
+	Code    int    `json:"code,omitempty"`
+	Details string `json:"details,omitempty"`
+}
+
+// APIResponse represents a standard API success response.
+type APIResponse struct {
+	Data    any    `json:"data,omitempty"`
+	Message string `json:"message,omitempty"`
+}


### PR DESCRIPTION
## Summary

This PR establishes a shared models package (`pkg/models/`) for types used by both the agent CLI and server, enabling them to communicate without violating Go's internal package boundaries.

- **pkg/models/agent.go**: `OSInfo`, `AgentInfo`, `HeartbeatRequest`, `HeartbeatMetrics`, `HeartbeatResponse`
- **pkg/models/backup.go**: `BackupStatus` (with constants), `BackupRequest`, `BackupResponse`
- **pkg/models/common.go**: `APIError`, `APIResponse`

Type aliases in `internal/models/` maintain backward compatibility with existing server code.

## Test plan

✅ `go build ./...` - All packages compile successfully  
✅ `go vet ./...` - No vet issues  
✅ `go test -race -cover ./...` - All tests pass  

🛠️ Generated with [Claude Code](https://claude.com/claude-code)