### PR TITLE
Add unit tests for handlers, middleware, models, and license

### DIFF
--- a/internal/api/handlers/agents_test.go
+++ b/internal/api/handlers/agents_test.go
@@ -1,0 +1,450 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/MacJediWizard/keldris/internal/api/middleware"
+	"github.com/MacJediWizard/keldris/internal/auth"
+	"github.com/MacJediWizard/keldris/internal/models"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+)
+
+// mockAgentStore implements AgentStore for testing.
+type mockAgentStore struct {
+	agents           []*models.Agent
+	agentByID        map[uuid.UUID]*models.Agent
+	user             *models.User
+	stats            *models.AgentStats
+	backups          []*models.Backup
+	schedules        []*models.Schedule
+	healthHistory    []*models.AgentHealthHistory
+	fleetHealth      *models.FleetHealthSummary
+	createErr        error
+	deleteErr        error
+	updateErr        error
+	getErr           error
+	updateAPIKeyErr  error
+	revokeAPIKeyErr  error
+}
+
+func (m *mockAgentStore) GetAgentsByOrgID(_ context.Context, orgID uuid.UUID) ([]*models.Agent, error) {
+	var result []*models.Agent
+	for _, a := range m.agents {
+		if a.OrgID == orgID {
+			result = append(result, a)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockAgentStore) GetAgentByID(_ context.Context, id uuid.UUID) (*models.Agent, error) {
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+	if a, ok := m.agentByID[id]; ok {
+		return a, nil
+	}
+	return nil, errors.New("agent not found")
+}
+
+func (m *mockAgentStore) CreateAgent(_ context.Context, agent *models.Agent) error {
+	return m.createErr
+}
+
+func (m *mockAgentStore) UpdateAgent(_ context.Context, agent *models.Agent) error {
+	return m.updateErr
+}
+
+func (m *mockAgentStore) DeleteAgent(_ context.Context, id uuid.UUID) error {
+	return m.deleteErr
+}
+
+func (m *mockAgentStore) GetUserByID(_ context.Context, id uuid.UUID) (*models.User, error) {
+	if m.user != nil && m.user.ID == id {
+		return m.user, nil
+	}
+	return nil, errors.New("user not found")
+}
+
+func (m *mockAgentStore) GetAgentByAPIKeyHash(_ context.Context, hash string) (*models.Agent, error) {
+	return nil, errors.New("not found")
+}
+
+func (m *mockAgentStore) UpdateAgentAPIKeyHash(_ context.Context, id uuid.UUID, hash string) error {
+	return m.updateAPIKeyErr
+}
+
+func (m *mockAgentStore) RevokeAgentAPIKey(_ context.Context, id uuid.UUID) error {
+	return m.revokeAPIKeyErr
+}
+
+func (m *mockAgentStore) GetAgentStats(_ context.Context, agentID uuid.UUID) (*models.AgentStats, error) {
+	if m.stats != nil {
+		return m.stats, nil
+	}
+	return nil, errors.New("no stats")
+}
+
+func (m *mockAgentStore) GetBackupsByAgentID(_ context.Context, agentID uuid.UUID) ([]*models.Backup, error) {
+	return m.backups, nil
+}
+
+func (m *mockAgentStore) GetSchedulesByAgentID(_ context.Context, agentID uuid.UUID) ([]*models.Schedule, error) {
+	return m.schedules, nil
+}
+
+func (m *mockAgentStore) GetAgentHealthHistory(_ context.Context, agentID uuid.UUID, limit int) ([]*models.AgentHealthHistory, error) {
+	return m.healthHistory, nil
+}
+
+func (m *mockAgentStore) GetFleetHealthSummary(_ context.Context, orgID uuid.UUID) (*models.FleetHealthSummary, error) {
+	if m.fleetHealth != nil {
+		return m.fleetHealth, nil
+	}
+	return nil, errors.New("no fleet health")
+}
+
+func setupAgentTestRouter(store AgentStore, user *auth.SessionUser) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+
+	// Inject user into context
+	r.Use(func(c *gin.Context) {
+		if user != nil {
+			c.Set(string(middleware.UserContextKey), user)
+		}
+		c.Next()
+	})
+
+	handler := NewAgentsHandler(store, zerolog.Nop())
+	api := r.Group("/api/v1")
+	handler.RegisterRoutes(api)
+	return r
+}
+
+func TestListAgents(t *testing.T) {
+	orgID := uuid.New()
+	agentID := uuid.New()
+
+	agent := &models.Agent{
+		ID:       agentID,
+		OrgID:    orgID,
+		Hostname: "test-host",
+		Status:   models.AgentStatusActive,
+	}
+
+	store := &mockAgentStore{
+		agents:    []*models.Agent{agent},
+		agentByID: map[uuid.UUID]*models.Agent{agentID: agent},
+	}
+
+	user := &auth.SessionUser{
+		ID:           uuid.New(),
+		CurrentOrgID: orgID,
+	}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupAgentTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/agents", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", w.Code)
+		}
+
+		var resp map[string]json.RawMessage
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to unmarshal response: %v", err)
+		}
+		if _, ok := resp["agents"]; !ok {
+			t.Fatal("expected 'agents' key in response")
+		}
+	})
+
+	t.Run("no org selected", func(t *testing.T) {
+		noOrgUser := &auth.SessionUser{ID: uuid.New()}
+		r := setupAgentTestRouter(store, noOrgUser)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/agents", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected status 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("unauthenticated", func(t *testing.T) {
+		r := setupAgentTestRouter(store, nil)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/agents", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("expected status 401, got %d", w.Code)
+		}
+	})
+}
+
+func TestCreateAgent(t *testing.T) {
+	orgID := uuid.New()
+	store := &mockAgentStore{
+		agentByID: map[uuid.UUID]*models.Agent{},
+	}
+	user := &auth.SessionUser{
+		ID:           uuid.New(),
+		CurrentOrgID: orgID,
+	}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupAgentTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"hostname":"new-agent"}`
+		req, _ := http.NewRequest("POST", "/api/v1/agents", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusCreated {
+			t.Fatalf("expected status 201, got %d: %s", w.Code, w.Body.String())
+		}
+
+		var resp CreateAgentResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to unmarshal response: %v", err)
+		}
+		if resp.Hostname != "new-agent" {
+			t.Fatalf("expected hostname 'new-agent', got %q", resp.Hostname)
+		}
+		if resp.APIKey == "" {
+			t.Fatal("expected non-empty API key")
+		}
+		if !strings.HasPrefix(resp.APIKey, "kld_") {
+			t.Fatalf("expected API key to start with 'kld_', got %q", resp.APIKey)
+		}
+	})
+
+	t.Run("invalid body", func(t *testing.T) {
+		r := setupAgentTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"hostname":""}`
+		req, _ := http.NewRequest("POST", "/api/v1/agents", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected status 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("missing body", func(t *testing.T) {
+		r := setupAgentTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{}`
+		req, _ := http.NewRequest("POST", "/api/v1/agents", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected status 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("store error", func(t *testing.T) {
+		errStore := &mockAgentStore{
+			agentByID: map[uuid.UUID]*models.Agent{},
+			createErr: errors.New("db error"),
+		}
+		r := setupAgentTestRouter(errStore, user)
+		w := httptest.NewRecorder()
+		body := `{"hostname":"fail-agent"}`
+		req, _ := http.NewRequest("POST", "/api/v1/agents", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("expected status 500, got %d", w.Code)
+		}
+	})
+}
+
+func TestDeleteAgent(t *testing.T) {
+	orgID := uuid.New()
+	agentID := uuid.New()
+	otherOrgID := uuid.New()
+
+	agent := &models.Agent{
+		ID:       agentID,
+		OrgID:    orgID,
+		Hostname: "delete-me",
+		Status:   models.AgentStatusActive,
+	}
+
+	store := &mockAgentStore{
+		agents:    []*models.Agent{agent},
+		agentByID: map[uuid.UUID]*models.Agent{agentID: agent},
+	}
+
+	user := &auth.SessionUser{
+		ID:           uuid.New(),
+		CurrentOrgID: orgID,
+	}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupAgentTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/v1/agents/"+agentID.String(), nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("invalid id", func(t *testing.T) {
+		r := setupAgentTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/v1/agents/not-a-uuid", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected status 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		r := setupAgentTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/v1/agents/"+uuid.New().String(), nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected status 404, got %d", w.Code)
+		}
+	})
+
+	t.Run("wrong org", func(t *testing.T) {
+		wrongUser := &auth.SessionUser{
+			ID:           uuid.New(),
+			CurrentOrgID: otherOrgID,
+		}
+		r := setupAgentTestRouter(store, wrongUser)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/v1/agents/"+agentID.String(), nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected status 404, got %d", w.Code)
+		}
+	})
+
+	t.Run("store error", func(t *testing.T) {
+		errStore := &mockAgentStore{
+			agents:    []*models.Agent{agent},
+			agentByID: map[uuid.UUID]*models.Agent{agentID: agent},
+			deleteErr: errors.New("db error"),
+		}
+		r := setupAgentTestRouter(errStore, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/v1/agents/"+agentID.String(), nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("expected status 500, got %d", w.Code)
+		}
+	})
+}
+
+func TestGetAgent(t *testing.T) {
+	orgID := uuid.New()
+	agentID := uuid.New()
+
+	agent := &models.Agent{
+		ID:       agentID,
+		OrgID:    orgID,
+		Hostname: "test-host",
+		Status:   models.AgentStatusActive,
+	}
+
+	store := &mockAgentStore{
+		agentByID: map[uuid.UUID]*models.Agent{agentID: agent},
+	}
+
+	user := &auth.SessionUser{
+		ID:           uuid.New(),
+		CurrentOrgID: orgID,
+	}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupAgentTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/agents/"+agentID.String(), nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", w.Code)
+		}
+	})
+
+	t.Run("invalid id", func(t *testing.T) {
+		r := setupAgentTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/agents/bad-uuid", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected status 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("wrong org", func(t *testing.T) {
+		wrongUser := &auth.SessionUser{
+			ID:           uuid.New(),
+			CurrentOrgID: uuid.New(),
+		}
+		r := setupAgentTestRouter(store, wrongUser)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/agents/"+agentID.String(), nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected status 404, got %d", w.Code)
+		}
+	})
+}
+
+func TestFleetHealth(t *testing.T) {
+	orgID := uuid.New()
+	store := &mockAgentStore{
+		agentByID: map[uuid.UUID]*models.Agent{},
+		fleetHealth: &models.FleetHealthSummary{
+			TotalAgents:  5,
+			HealthyCount: 3,
+			WarningCount: 1,
+			CriticalCount: 1,
+		},
+	}
+
+	user := &auth.SessionUser{
+		ID:           uuid.New(),
+		CurrentOrgID: orgID,
+	}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupAgentTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/agents/fleet-health", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+}

--- a/internal/api/handlers/backups_test.go
+++ b/internal/api/handlers/backups_test.go
@@ -1,0 +1,310 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/MacJediWizard/keldris/internal/api/middleware"
+	"github.com/MacJediWizard/keldris/internal/auth"
+	"github.com/MacJediWizard/keldris/internal/models"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+)
+
+// mockBackupStore implements BackupStore for testing.
+type mockBackupStore struct {
+	backupsBySchedule map[uuid.UUID][]*models.Backup
+	backupsByAgent    map[uuid.UUID][]*models.Backup
+	backupByID        map[uuid.UUID]*models.Backup
+	agentByID         map[uuid.UUID]*models.Agent
+	agentsByOrg       map[uuid.UUID][]*models.Agent
+	scheduleByID      map[uuid.UUID]*models.Schedule
+}
+
+func newMockBackupStore() *mockBackupStore {
+	return &mockBackupStore{
+		backupsBySchedule: make(map[uuid.UUID][]*models.Backup),
+		backupsByAgent:    make(map[uuid.UUID][]*models.Backup),
+		backupByID:        make(map[uuid.UUID]*models.Backup),
+		agentByID:         make(map[uuid.UUID]*models.Agent),
+		agentsByOrg:       make(map[uuid.UUID][]*models.Agent),
+		scheduleByID:      make(map[uuid.UUID]*models.Schedule),
+	}
+}
+
+func (m *mockBackupStore) GetBackupsByScheduleID(_ context.Context, scheduleID uuid.UUID) ([]*models.Backup, error) {
+	return m.backupsBySchedule[scheduleID], nil
+}
+
+func (m *mockBackupStore) GetBackupsByAgentID(_ context.Context, agentID uuid.UUID) ([]*models.Backup, error) {
+	return m.backupsByAgent[agentID], nil
+}
+
+func (m *mockBackupStore) GetBackupByID(_ context.Context, id uuid.UUID) (*models.Backup, error) {
+	if b, ok := m.backupByID[id]; ok {
+		return b, nil
+	}
+	return nil, errors.New("backup not found")
+}
+
+func (m *mockBackupStore) GetAgentByID(_ context.Context, id uuid.UUID) (*models.Agent, error) {
+	if a, ok := m.agentByID[id]; ok {
+		return a, nil
+	}
+	return nil, errors.New("agent not found")
+}
+
+func (m *mockBackupStore) GetAgentsByOrgID(_ context.Context, orgID uuid.UUID) ([]*models.Agent, error) {
+	return m.agentsByOrg[orgID], nil
+}
+
+func (m *mockBackupStore) GetScheduleByID(_ context.Context, id uuid.UUID) (*models.Schedule, error) {
+	if s, ok := m.scheduleByID[id]; ok {
+		return s, nil
+	}
+	return nil, errors.New("schedule not found")
+}
+
+func setupBackupTestRouter(store BackupStore, user *auth.SessionUser) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+
+	r.Use(func(c *gin.Context) {
+		if user != nil {
+			c.Set(string(middleware.UserContextKey), user)
+		}
+		c.Next()
+	})
+
+	handler := NewBackupsHandler(store, zerolog.Nop())
+	api := r.Group("/api/v1")
+	handler.RegisterRoutes(api)
+	return r
+}
+
+func TestListBackups(t *testing.T) {
+	orgID := uuid.New()
+	agentID := uuid.New()
+	scheduleID := uuid.New()
+	backupID := uuid.New()
+
+	agent := &models.Agent{ID: agentID, OrgID: orgID, Hostname: "test-host"}
+	schedule := &models.Schedule{ID: scheduleID, AgentID: agentID, Name: "daily"}
+	backup := &models.Backup{ID: backupID, ScheduleID: scheduleID, AgentID: agentID, Status: models.BackupStatusCompleted}
+
+	store := newMockBackupStore()
+	store.agentByID[agentID] = agent
+	store.agentsByOrg[orgID] = []*models.Agent{agent}
+	store.scheduleByID[scheduleID] = schedule
+	store.backupsBySchedule[scheduleID] = []*models.Backup{backup}
+	store.backupsByAgent[agentID] = []*models.Backup{backup}
+
+	user := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: orgID}
+
+	t.Run("list all", func(t *testing.T) {
+		r := setupBackupTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/backups", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+		}
+
+		var resp map[string]json.RawMessage
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to unmarshal: %v", err)
+		}
+		if _, ok := resp["backups"]; !ok {
+			t.Fatal("expected 'backups' key")
+		}
+	})
+
+	t.Run("filter by agent_id", func(t *testing.T) {
+		r := setupBackupTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/backups?agent_id="+agentID.String(), nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", w.Code)
+		}
+	})
+
+	t.Run("filter by schedule_id", func(t *testing.T) {
+		r := setupBackupTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/backups?schedule_id="+scheduleID.String(), nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", w.Code)
+		}
+	})
+
+	t.Run("filter by status", func(t *testing.T) {
+		r := setupBackupTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/backups?status=completed", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", w.Code)
+		}
+	})
+
+	t.Run("invalid agent_id", func(t *testing.T) {
+		r := setupBackupTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/backups?agent_id=bad", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected status 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("invalid schedule_id", func(t *testing.T) {
+		r := setupBackupTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/backups?schedule_id=bad", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected status 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("agent wrong org", func(t *testing.T) {
+		otherAgent := &models.Agent{ID: uuid.New(), OrgID: uuid.New(), Hostname: "other"}
+		store2 := newMockBackupStore()
+		store2.agentByID[otherAgent.ID] = otherAgent
+
+		r := setupBackupTestRouter(store2, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/backups?agent_id="+otherAgent.ID.String(), nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected status 404, got %d", w.Code)
+		}
+	})
+
+	t.Run("no org selected", func(t *testing.T) {
+		noOrgUser := &auth.SessionUser{ID: uuid.New()}
+		r := setupBackupTestRouter(store, noOrgUser)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/backups", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected status 400, got %d", w.Code)
+		}
+	})
+}
+
+func TestGetBackup(t *testing.T) {
+	orgID := uuid.New()
+	agentID := uuid.New()
+	backupID := uuid.New()
+
+	agent := &models.Agent{ID: agentID, OrgID: orgID, Hostname: "test-host"}
+	backup := &models.Backup{ID: backupID, AgentID: agentID, Status: models.BackupStatusCompleted}
+
+	store := newMockBackupStore()
+	store.agentByID[agentID] = agent
+	store.backupByID[backupID] = backup
+
+	user := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupBackupTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/backups/"+backupID.String(), nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("invalid id", func(t *testing.T) {
+		r := setupBackupTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/backups/not-uuid", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected status 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		r := setupBackupTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/backups/"+uuid.New().String(), nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected status 404, got %d", w.Code)
+		}
+	})
+
+	t.Run("wrong org", func(t *testing.T) {
+		wrongOrgAgent := &models.Agent{ID: agentID, OrgID: uuid.New(), Hostname: "other"}
+		store2 := newMockBackupStore()
+		store2.agentByID[agentID] = wrongOrgAgent
+		store2.backupByID[backupID] = backup
+
+		r := setupBackupTestRouter(store2, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/backups/"+backupID.String(), nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected status 404, got %d", w.Code)
+		}
+	})
+}
+
+func TestFilterByStatus(t *testing.T) {
+	backups := []*models.Backup{
+		{ID: uuid.New(), Status: models.BackupStatusCompleted},
+		{ID: uuid.New(), Status: models.BackupStatusFailed},
+		{ID: uuid.New(), Status: models.BackupStatusRunning},
+		{ID: uuid.New(), Status: models.BackupStatusCompleted},
+	}
+
+	t.Run("no filter", func(t *testing.T) {
+		result := filterByStatus(backups, "")
+		if len(result) != 4 {
+			t.Fatalf("expected 4 backups, got %d", len(result))
+		}
+	})
+
+	t.Run("filter completed", func(t *testing.T) {
+		result := filterByStatus(backups, "completed")
+		if len(result) != 2 {
+			t.Fatalf("expected 2 completed backups, got %d", len(result))
+		}
+	})
+
+	t.Run("filter failed", func(t *testing.T) {
+		result := filterByStatus(backups, "failed")
+		if len(result) != 1 {
+			t.Fatalf("expected 1 failed backup, got %d", len(result))
+		}
+	})
+
+	t.Run("filter nonexistent status", func(t *testing.T) {
+		result := filterByStatus(backups, "nonexistent")
+		if len(result) != 0 {
+			t.Fatalf("expected 0 backups, got %d", len(result))
+		}
+	})
+}

--- a/internal/api/handlers/schedules_test.go
+++ b/internal/api/handlers/schedules_test.go
@@ -1,0 +1,504 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/MacJediWizard/keldris/internal/api/middleware"
+	"github.com/MacJediWizard/keldris/internal/auth"
+	"github.com/MacJediWizard/keldris/internal/models"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+)
+
+// mockScheduleStore implements ScheduleStore for testing.
+type mockScheduleStore struct {
+	schedulesByAgent    map[uuid.UUID][]*models.Schedule
+	scheduleByID        map[uuid.UUID]*models.Schedule
+	agentByID           map[uuid.UUID]*models.Agent
+	agentsByOrg         map[uuid.UUID][]*models.Agent
+	repositoryByID      map[uuid.UUID]*models.Repository
+	replicationStatuses map[uuid.UUID][]*models.ReplicationStatus
+	createErr           error
+	updateErr           error
+	deleteErr           error
+	setReposErr         error
+}
+
+func newMockScheduleStore() *mockScheduleStore {
+	return &mockScheduleStore{
+		schedulesByAgent:    make(map[uuid.UUID][]*models.Schedule),
+		scheduleByID:        make(map[uuid.UUID]*models.Schedule),
+		agentByID:           make(map[uuid.UUID]*models.Agent),
+		agentsByOrg:         make(map[uuid.UUID][]*models.Agent),
+		repositoryByID:      make(map[uuid.UUID]*models.Repository),
+		replicationStatuses: make(map[uuid.UUID][]*models.ReplicationStatus),
+	}
+}
+
+func (m *mockScheduleStore) GetSchedulesByAgentID(_ context.Context, agentID uuid.UUID) ([]*models.Schedule, error) {
+	return m.schedulesByAgent[agentID], nil
+}
+
+func (m *mockScheduleStore) GetScheduleByID(_ context.Context, id uuid.UUID) (*models.Schedule, error) {
+	if s, ok := m.scheduleByID[id]; ok {
+		return s, nil
+	}
+	return nil, errors.New("schedule not found")
+}
+
+func (m *mockScheduleStore) CreateSchedule(_ context.Context, schedule *models.Schedule) error {
+	return m.createErr
+}
+
+func (m *mockScheduleStore) UpdateSchedule(_ context.Context, schedule *models.Schedule) error {
+	return m.updateErr
+}
+
+func (m *mockScheduleStore) DeleteSchedule(_ context.Context, id uuid.UUID) error {
+	return m.deleteErr
+}
+
+func (m *mockScheduleStore) SetScheduleRepositories(_ context.Context, scheduleID uuid.UUID, repos []models.ScheduleRepository) error {
+	return m.setReposErr
+}
+
+func (m *mockScheduleStore) GetAgentByID(_ context.Context, id uuid.UUID) (*models.Agent, error) {
+	if a, ok := m.agentByID[id]; ok {
+		return a, nil
+	}
+	return nil, errors.New("agent not found")
+}
+
+func (m *mockScheduleStore) GetAgentsByOrgID(_ context.Context, orgID uuid.UUID) ([]*models.Agent, error) {
+	return m.agentsByOrg[orgID], nil
+}
+
+func (m *mockScheduleStore) GetRepositoryByID(_ context.Context, id uuid.UUID) (*models.Repository, error) {
+	if r, ok := m.repositoryByID[id]; ok {
+		return r, nil
+	}
+	return nil, errors.New("repository not found")
+}
+
+func (m *mockScheduleStore) GetReplicationStatusBySchedule(_ context.Context, scheduleID uuid.UUID) ([]*models.ReplicationStatus, error) {
+	return m.replicationStatuses[scheduleID], nil
+}
+
+func setupScheduleTestRouter(store ScheduleStore, user *auth.SessionUser) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+
+	r.Use(func(c *gin.Context) {
+		if user != nil {
+			c.Set(string(middleware.UserContextKey), user)
+		}
+		c.Next()
+	})
+
+	handler := NewSchedulesHandler(store, zerolog.Nop())
+	api := r.Group("/api/v1")
+	handler.RegisterRoutes(api)
+	return r
+}
+
+func TestCreateSchedule(t *testing.T) {
+	orgID := uuid.New()
+	agentID := uuid.New()
+	repoID := uuid.New()
+
+	agent := &models.Agent{ID: agentID, OrgID: orgID, Hostname: "test-host"}
+	repo := &models.Repository{ID: repoID, OrgID: orgID, Name: "test-repo", Type: models.RepositoryTypeLocal}
+
+	store := newMockScheduleStore()
+	store.agentByID[agentID] = agent
+	store.repositoryByID[repoID] = repo
+
+	user := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupScheduleTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{
+			"agent_id": "` + agentID.String() + `",
+			"repositories": [{"repository_id": "` + repoID.String() + `", "priority": 0, "enabled": true}],
+			"name": "daily-backup",
+			"cron_expression": "0 2 * * *",
+			"paths": ["/data"]
+		}`
+		req, _ := http.NewRequest("POST", "/api/v1/schedules", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusCreated {
+			t.Fatalf("expected status 201, got %d: %s", w.Code, w.Body.String())
+		}
+
+		var resp models.Schedule
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to unmarshal response: %v", err)
+		}
+		if resp.Name != "daily-backup" {
+			t.Fatalf("expected name 'daily-backup', got %q", resp.Name)
+		}
+	})
+
+	t.Run("invalid body", func(t *testing.T) {
+		r := setupScheduleTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"name":"test"}`
+		req, _ := http.NewRequest("POST", "/api/v1/schedules", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected status 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("agent not found", func(t *testing.T) {
+		r := setupScheduleTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{
+			"agent_id": "` + uuid.New().String() + `",
+			"repositories": [{"repository_id": "` + repoID.String() + `", "priority": 0, "enabled": true}],
+			"name": "daily-backup",
+			"cron_expression": "0 2 * * *",
+			"paths": ["/data"]
+		}`
+		req, _ := http.NewRequest("POST", "/api/v1/schedules", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected status 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("agent wrong org", func(t *testing.T) {
+		otherAgent := &models.Agent{ID: uuid.New(), OrgID: uuid.New(), Hostname: "other"}
+		store2 := newMockScheduleStore()
+		store2.agentByID[otherAgent.ID] = otherAgent
+		store2.repositoryByID[repoID] = repo
+
+		r := setupScheduleTestRouter(store2, user)
+		w := httptest.NewRecorder()
+		body := `{
+			"agent_id": "` + otherAgent.ID.String() + `",
+			"repositories": [{"repository_id": "` + repoID.String() + `", "priority": 0, "enabled": true}],
+			"name": "daily-backup",
+			"cron_expression": "0 2 * * *",
+			"paths": ["/data"]
+		}`
+		req, _ := http.NewRequest("POST", "/api/v1/schedules", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected status 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("repo not found", func(t *testing.T) {
+		r := setupScheduleTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{
+			"agent_id": "` + agentID.String() + `",
+			"repositories": [{"repository_id": "` + uuid.New().String() + `", "priority": 0, "enabled": true}],
+			"name": "daily-backup",
+			"cron_expression": "0 2 * * *",
+			"paths": ["/data"]
+		}`
+		req, _ := http.NewRequest("POST", "/api/v1/schedules", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected status 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("store error", func(t *testing.T) {
+		errStore := newMockScheduleStore()
+		errStore.agentByID[agentID] = agent
+		errStore.repositoryByID[repoID] = repo
+		errStore.createErr = errors.New("db error")
+
+		r := setupScheduleTestRouter(errStore, user)
+		w := httptest.NewRecorder()
+		body := `{
+			"agent_id": "` + agentID.String() + `",
+			"repositories": [{"repository_id": "` + repoID.String() + `", "priority": 0, "enabled": true}],
+			"name": "daily-backup",
+			"cron_expression": "0 2 * * *",
+			"paths": ["/data"]
+		}`
+		req, _ := http.NewRequest("POST", "/api/v1/schedules", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("expected status 500, got %d", w.Code)
+		}
+	})
+}
+
+func TestUpdateSchedule(t *testing.T) {
+	orgID := uuid.New()
+	agentID := uuid.New()
+	scheduleID := uuid.New()
+
+	agent := &models.Agent{ID: agentID, OrgID: orgID, Hostname: "test-host"}
+	schedule := &models.Schedule{ID: scheduleID, AgentID: agentID, Name: "old-name", CronExpression: "0 2 * * *", Paths: []string{"/data"}}
+
+	store := newMockScheduleStore()
+	store.agentByID[agentID] = agent
+	store.scheduleByID[scheduleID] = schedule
+
+	user := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupScheduleTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"name":"new-name"}`
+		req, _ := http.NewRequest("PUT", "/api/v1/schedules/"+scheduleID.String(), strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("invalid id", func(t *testing.T) {
+		r := setupScheduleTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"name":"new-name"}`
+		req, _ := http.NewRequest("PUT", "/api/v1/schedules/bad-uuid", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected status 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		r := setupScheduleTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"name":"new-name"}`
+		req, _ := http.NewRequest("PUT", "/api/v1/schedules/"+uuid.New().String(), strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected status 404, got %d", w.Code)
+		}
+	})
+
+	t.Run("wrong org", func(t *testing.T) {
+		otherAgent := &models.Agent{ID: agentID, OrgID: uuid.New(), Hostname: "other"}
+		store2 := newMockScheduleStore()
+		store2.agentByID[agentID] = otherAgent
+		store2.scheduleByID[scheduleID] = schedule
+
+		r := setupScheduleTestRouter(store2, user)
+		w := httptest.NewRecorder()
+		body := `{"name":"new-name"}`
+		req, _ := http.NewRequest("PUT", "/api/v1/schedules/"+scheduleID.String(), strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected status 404, got %d", w.Code)
+		}
+	})
+
+	t.Run("store error", func(t *testing.T) {
+		errStore := newMockScheduleStore()
+		errStore.agentByID[agentID] = agent
+		errStore.scheduleByID[scheduleID] = schedule
+		errStore.updateErr = errors.New("db error")
+
+		r := setupScheduleTestRouter(errStore, user)
+		w := httptest.NewRecorder()
+		body := `{"name":"new-name"}`
+		req, _ := http.NewRequest("PUT", "/api/v1/schedules/"+scheduleID.String(), strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("expected status 500, got %d", w.Code)
+		}
+	})
+}
+
+func TestListSchedules(t *testing.T) {
+	orgID := uuid.New()
+	agentID := uuid.New()
+	scheduleID := uuid.New()
+
+	agent := &models.Agent{ID: agentID, OrgID: orgID, Hostname: "test-host"}
+	schedule := &models.Schedule{ID: scheduleID, AgentID: agentID, Name: "daily"}
+
+	store := newMockScheduleStore()
+	store.agentByID[agentID] = agent
+	store.agentsByOrg[orgID] = []*models.Agent{agent}
+	store.schedulesByAgent[agentID] = []*models.Schedule{schedule}
+	store.scheduleByID[scheduleID] = schedule
+
+	user := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: orgID}
+
+	t.Run("list all", func(t *testing.T) {
+		r := setupScheduleTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/schedules", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+		}
+
+		var resp map[string]json.RawMessage
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to unmarshal: %v", err)
+		}
+		if _, ok := resp["schedules"]; !ok {
+			t.Fatal("expected 'schedules' key")
+		}
+	})
+
+	t.Run("filter by agent_id", func(t *testing.T) {
+		r := setupScheduleTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/schedules?agent_id="+agentID.String(), nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", w.Code)
+		}
+	})
+
+	t.Run("invalid agent_id", func(t *testing.T) {
+		r := setupScheduleTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/schedules?agent_id=bad", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected status 400, got %d", w.Code)
+		}
+	})
+}
+
+func TestDeleteSchedule(t *testing.T) {
+	orgID := uuid.New()
+	agentID := uuid.New()
+	scheduleID := uuid.New()
+
+	agent := &models.Agent{ID: agentID, OrgID: orgID, Hostname: "test-host"}
+	schedule := &models.Schedule{ID: scheduleID, AgentID: agentID, Name: "daily"}
+
+	store := newMockScheduleStore()
+	store.agentByID[agentID] = agent
+	store.scheduleByID[scheduleID] = schedule
+
+	user := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupScheduleTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/v1/schedules/"+scheduleID.String(), nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		r := setupScheduleTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/v1/schedules/"+uuid.New().String(), nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected status 404, got %d", w.Code)
+		}
+	})
+
+	t.Run("store error", func(t *testing.T) {
+		errStore := newMockScheduleStore()
+		errStore.agentByID[agentID] = agent
+		errStore.scheduleByID[scheduleID] = schedule
+		errStore.deleteErr = errors.New("db error")
+
+		r := setupScheduleTestRouter(errStore, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/v1/schedules/"+scheduleID.String(), nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("expected status 500, got %d", w.Code)
+		}
+	})
+}
+
+func TestRunSchedule(t *testing.T) {
+	orgID := uuid.New()
+	agentID := uuid.New()
+	scheduleID := uuid.New()
+
+	agent := &models.Agent{ID: agentID, OrgID: orgID, Hostname: "test-host"}
+	schedule := &models.Schedule{ID: scheduleID, AgentID: agentID, Name: "daily"}
+
+	store := newMockScheduleStore()
+	store.agentByID[agentID] = agent
+	store.scheduleByID[scheduleID] = schedule
+
+	user := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupScheduleTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("POST", "/api/v1/schedules/"+scheduleID.String()+"/run", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusAccepted {
+			t.Fatalf("expected status 202, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+}
+
+func TestGetReplicationStatus(t *testing.T) {
+	orgID := uuid.New()
+	agentID := uuid.New()
+	scheduleID := uuid.New()
+
+	agent := &models.Agent{ID: agentID, OrgID: orgID, Hostname: "test-host"}
+	schedule := &models.Schedule{ID: scheduleID, AgentID: agentID, Name: "daily"}
+
+	store := newMockScheduleStore()
+	store.agentByID[agentID] = agent
+	store.scheduleByID[scheduleID] = schedule
+	store.replicationStatuses[scheduleID] = []*models.ReplicationStatus{}
+
+	user := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupScheduleTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/schedules/"+scheduleID.String()+"/replication", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+}

--- a/internal/api/middleware/auth_test.go
+++ b/internal/api/middleware/auth_test.go
@@ -1,0 +1,260 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/MacJediWizard/keldris/internal/auth"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+func newTestSessionStore(t *testing.T) *auth.SessionStore {
+	t.Helper()
+	cfg := auth.DefaultSessionConfig([]byte("test-secret-that-is-at-least-32-bytes-long!"), false)
+	store, err := auth.NewSessionStore(cfg, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("failed to create session store: %v", err)
+	}
+	return store
+}
+
+func TestAuthMiddleware_ValidSession(t *testing.T) {
+	sessions := newTestSessionStore(t)
+	mw := AuthMiddleware(sessions, zerolog.Nop())
+
+	// Set up authenticated session
+	userID := uuid.New()
+	orgID := uuid.New()
+	sessionUser := &auth.SessionUser{
+		ID:              userID,
+		OIDCSubject:     "subject-123",
+		Email:           "test@example.com",
+		Name:            "Test User",
+		AuthenticatedAt: time.Now(),
+		CurrentOrgID:    orgID,
+	}
+
+	// Create request and set session
+	r := gin.New()
+	r.Use(mw)
+	r.GET("/test", func(c *gin.Context) {
+		user := GetUser(c)
+		if user == nil {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "no user"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"user_id": user.ID.String()})
+	})
+
+	// First, create a request to set the session
+	setReq, _ := http.NewRequest("GET", "/test", nil)
+	setW := httptest.NewRecorder()
+	if err := sessions.SetUser(setReq, setW, sessionUser); err != nil {
+		t.Fatalf("failed to set user: %v", err)
+	}
+
+	// Get cookie from the response
+	cookies := setW.Result().Cookies()
+
+	// Now make request with the session cookie
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/test", nil)
+	for _, cookie := range cookies {
+		req.AddCookie(cookie)
+	}
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAuthMiddleware_NoSession(t *testing.T) {
+	sessions := newTestSessionStore(t)
+	mw := AuthMiddleware(sessions, zerolog.Nop())
+
+	r := gin.New()
+	r.Use(mw)
+	r.GET("/test", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/test", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status 401, got %d", w.Code)
+	}
+}
+
+func TestOptionalAuthMiddleware(t *testing.T) {
+	sessions := newTestSessionStore(t)
+	mw := OptionalAuthMiddleware(sessions, zerolog.Nop())
+
+	r := gin.New()
+	r.Use(mw)
+	r.GET("/test", func(c *gin.Context) {
+		user := GetUser(c)
+		if user != nil {
+			c.JSON(http.StatusOK, gin.H{"authenticated": true})
+		} else {
+			c.JSON(http.StatusOK, gin.H{"authenticated": false})
+		}
+	})
+
+	t.Run("no session proceeds", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/test", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", w.Code)
+		}
+	})
+}
+
+func TestGetUser_NoUser(t *testing.T) {
+	r := gin.New()
+	r.GET("/test", func(c *gin.Context) {
+		user := GetUser(c)
+		if user != nil {
+			t.Fatal("expected nil user")
+		}
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/test", nil)
+	r.ServeHTTP(w, req)
+}
+
+func TestGetUser_WrongType(t *testing.T) {
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set(string(UserContextKey), "not-a-session-user")
+		c.Next()
+	})
+	r.GET("/test", func(c *gin.Context) {
+		user := GetUser(c)
+		if user != nil {
+			t.Fatal("expected nil user for wrong type")
+		}
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/test", nil)
+	r.ServeHTTP(w, req)
+}
+
+func TestRequireUser(t *testing.T) {
+	t.Run("with user", func(t *testing.T) {
+		r := gin.New()
+		sessionUser := &auth.SessionUser{
+			ID:           uuid.New(),
+			CurrentOrgID: uuid.New(),
+		}
+		r.Use(func(c *gin.Context) {
+			c.Set(string(UserContextKey), sessionUser)
+			c.Next()
+		})
+		r.GET("/test", func(c *gin.Context) {
+			user := RequireUser(c)
+			if user == nil {
+				return
+			}
+			c.JSON(http.StatusOK, gin.H{"user_id": user.ID.String()})
+		})
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/test", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", w.Code)
+		}
+	})
+
+	t.Run("without user", func(t *testing.T) {
+		r := gin.New()
+		r.GET("/test", func(c *gin.Context) {
+			user := RequireUser(c)
+			if user == nil {
+				return
+			}
+			c.JSON(http.StatusOK, gin.H{"ok": true})
+		})
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/test", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("expected status 401, got %d", w.Code)
+		}
+	})
+}
+
+func TestGetAgent_NoAgent(t *testing.T) {
+	r := gin.New()
+	r.GET("/test", func(c *gin.Context) {
+		agent := GetAgent(c)
+		if agent != nil {
+			t.Fatal("expected nil agent")
+		}
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/test", nil)
+	r.ServeHTTP(w, req)
+}
+
+func TestGetAgent_WrongType(t *testing.T) {
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set(string(AgentContextKey), "not-an-agent")
+		c.Next()
+	})
+	r.GET("/test", func(c *gin.Context) {
+		agent := GetAgent(c)
+		if agent != nil {
+			t.Fatal("expected nil agent for wrong type")
+		}
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/test", nil)
+	r.ServeHTTP(w, req)
+}
+
+func TestRequireAgent(t *testing.T) {
+	t.Run("without agent", func(t *testing.T) {
+		r := gin.New()
+		r.GET("/test", func(c *gin.Context) {
+			agent := RequireAgent(c)
+			if agent == nil {
+				return
+			}
+			c.JSON(http.StatusOK, gin.H{"ok": true})
+		})
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/test", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("expected status 401, got %d", w.Code)
+		}
+	})
+}

--- a/internal/api/middleware/features_test.go
+++ b/internal/api/middleware/features_test.go
@@ -1,0 +1,174 @@
+package middleware
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/MacJediWizard/keldris/internal/license"
+	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog"
+)
+
+func TestLicenseMiddleware(t *testing.T) {
+	lic := license.FreeLicense()
+
+	r := gin.New()
+	r.Use(LicenseMiddleware(lic, zerolog.Nop()))
+	r.GET("/test", func(c *gin.Context) {
+		got := GetLicense(c)
+		if got == nil {
+			t.Fatal("expected license in context")
+		}
+		if got.Tier != license.TierFree {
+			t.Fatalf("expected free tier, got %s", got.Tier)
+		}
+		c.JSON(http.StatusOK, gin.H{"tier": string(got.Tier)})
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/test", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+}
+
+func TestFeatureMiddleware_FeatureAvailable(t *testing.T) {
+	lic := &license.License{Tier: license.TierPro}
+
+	r := gin.New()
+	r.Use(LicenseMiddleware(lic, zerolog.Nop()))
+	r.Use(FeatureMiddleware(license.FeatureOIDC, zerolog.Nop()))
+	r.GET("/test", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/test", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestFeatureMiddleware_FeatureNotAvailable(t *testing.T) {
+	lic := &license.License{Tier: license.TierFree}
+
+	r := gin.New()
+	r.Use(LicenseMiddleware(lic, zerolog.Nop()))
+	r.Use(FeatureMiddleware(license.FeatureOIDC, zerolog.Nop()))
+	r.GET("/test", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/test", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusPaymentRequired {
+		t.Fatalf("expected status 402, got %d", w.Code)
+	}
+
+	var resp map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if resp["feature"] != "oidc" {
+		t.Fatalf("expected feature 'oidc', got %q", resp["feature"])
+	}
+}
+
+func TestFeatureMiddleware_NoLicense(t *testing.T) {
+	r := gin.New()
+	// No LicenseMiddleware - license won't be in context
+	r.Use(FeatureMiddleware(license.FeatureOIDC, zerolog.Nop()))
+	r.GET("/test", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/test", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusPaymentRequired {
+		t.Fatalf("expected status 402, got %d", w.Code)
+	}
+}
+
+func TestFeatureMiddleware_EnterpriseFeature(t *testing.T) {
+	t.Run("enterprise tier has access", func(t *testing.T) {
+		lic := &license.License{Tier: license.TierEnterprise}
+
+		r := gin.New()
+		r.Use(LicenseMiddleware(lic, zerolog.Nop()))
+		r.Use(FeatureMiddleware(license.FeatureMultiOrg, zerolog.Nop()))
+		r.GET("/test", func(c *gin.Context) {
+			c.JSON(http.StatusOK, gin.H{"ok": true})
+		})
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/test", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", w.Code)
+		}
+	})
+
+	t.Run("pro tier lacks enterprise feature", func(t *testing.T) {
+		lic := &license.License{Tier: license.TierPro}
+
+		r := gin.New()
+		r.Use(LicenseMiddleware(lic, zerolog.Nop()))
+		r.Use(FeatureMiddleware(license.FeatureMultiOrg, zerolog.Nop()))
+		r.GET("/test", func(c *gin.Context) {
+			c.JSON(http.StatusOK, gin.H{"ok": true})
+		})
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/test", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusPaymentRequired {
+			t.Fatalf("expected status 402, got %d", w.Code)
+		}
+	})
+}
+
+func TestGetLicense_NoLicense(t *testing.T) {
+	r := gin.New()
+	r.GET("/test", func(c *gin.Context) {
+		lic := GetLicense(c)
+		if lic != nil {
+			t.Fatal("expected nil license")
+		}
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/test", nil)
+	r.ServeHTTP(w, req)
+}
+
+func TestGetLicense_WrongType(t *testing.T) {
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set(string(LicenseContextKey), "not-a-license")
+		c.Next()
+	})
+	r.GET("/test", func(c *gin.Context) {
+		lic := GetLicense(c)
+		if lic != nil {
+			t.Fatal("expected nil license for wrong type")
+		}
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/test", nil)
+	r.ServeHTTP(w, req)
+}

--- a/internal/api/middleware/ratelimit_test.go
+++ b/internal/api/middleware/ratelimit_test.go
@@ -1,0 +1,115 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestNewRateLimiter(t *testing.T) {
+	t.Run("valid configuration", func(t *testing.T) {
+		mw, err := NewRateLimiter(10, "1m")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if mw == nil {
+			t.Fatal("expected non-nil middleware")
+		}
+	})
+
+	t.Run("invalid period", func(t *testing.T) {
+		_, err := NewRateLimiter(10, "invalid")
+		if err == nil {
+			t.Fatal("expected error for invalid period")
+		}
+	})
+
+	t.Run("requests within limit succeed", func(t *testing.T) {
+		mw, err := NewRateLimiter(5, "1m")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		r := gin.New()
+		r.Use(mw)
+		r.GET("/test", func(c *gin.Context) {
+			c.JSON(http.StatusOK, gin.H{"ok": true})
+		})
+
+		// Make requests within the limit
+		for i := 0; i < 5; i++ {
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest("GET", "/test", nil)
+			req.RemoteAddr = "127.0.0.1:12345"
+			r.ServeHTTP(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("request %d: expected status 200, got %d", i+1, w.Code)
+			}
+		}
+	})
+
+	t.Run("requests exceeding limit rejected", func(t *testing.T) {
+		mw, err := NewRateLimiter(2, "1m")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		r := gin.New()
+		r.Use(mw)
+		r.GET("/test", func(c *gin.Context) {
+			c.JSON(http.StatusOK, gin.H{"ok": true})
+		})
+
+		// Exhaust the limit
+		for i := 0; i < 2; i++ {
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest("GET", "/test", nil)
+			req.RemoteAddr = "10.0.0.1:12345"
+			r.ServeHTTP(w, req)
+		}
+
+		// Next request should be rate limited
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/test", nil)
+		req.RemoteAddr = "10.0.0.1:12345"
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusTooManyRequests {
+			t.Fatalf("expected status 429, got %d", w.Code)
+		}
+	})
+
+	t.Run("different IPs have separate limits", func(t *testing.T) {
+		mw, err := NewRateLimiter(1, "1m")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		r := gin.New()
+		r.Use(mw)
+		r.GET("/test", func(c *gin.Context) {
+			c.JSON(http.StatusOK, gin.H{"ok": true})
+		})
+
+		// First IP uses its limit
+		w1 := httptest.NewRecorder()
+		req1, _ := http.NewRequest("GET", "/test", nil)
+		req1.RemoteAddr = "192.168.1.1:12345"
+		r.ServeHTTP(w1, req1)
+		if w1.Code != http.StatusOK {
+			t.Fatalf("first IP: expected status 200, got %d", w1.Code)
+		}
+
+		// Second IP should still work
+		w2 := httptest.NewRecorder()
+		req2, _ := http.NewRequest("GET", "/test", nil)
+		req2.RemoteAddr = "192.168.1.2:12345"
+		r.ServeHTTP(w2, req2)
+		if w2.Code != http.StatusOK {
+			t.Fatalf("second IP: expected status 200, got %d", w2.Code)
+		}
+	})
+}

--- a/internal/license/features_test.go
+++ b/internal/license/features_test.go
@@ -1,0 +1,77 @@
+package license
+
+import (
+	"testing"
+)
+
+func TestHasFeature(t *testing.T) {
+	tests := []struct {
+		name    string
+		tier    LicenseTier
+		feature Feature
+		has     bool
+	}{
+		// Free tier - no features
+		{"free tier has no OIDC", TierFree, FeatureOIDC, false},
+		{"free tier has no audit logs", TierFree, FeatureAuditLogs, false},
+		{"free tier has no multi-org", TierFree, FeatureMultiOrg, false},
+
+		// Pro tier - OIDC and audit logs
+		{"pro tier has OIDC", TierPro, FeatureOIDC, true},
+		{"pro tier has audit logs", TierPro, FeatureAuditLogs, true},
+		{"pro tier has no multi-org", TierPro, FeatureMultiOrg, false},
+		{"pro tier has no SLA tracking", TierPro, FeatureSLATracking, false},
+		{"pro tier has no white label", TierPro, FeatureWhiteLabel, false},
+		{"pro tier has no air gap", TierPro, FeatureAirGap, false},
+
+		// Enterprise tier - all features
+		{"enterprise tier has OIDC", TierEnterprise, FeatureOIDC, true},
+		{"enterprise tier has audit logs", TierEnterprise, FeatureAuditLogs, true},
+		{"enterprise tier has multi-org", TierEnterprise, FeatureMultiOrg, true},
+		{"enterprise tier has SLA tracking", TierEnterprise, FeatureSLATracking, true},
+		{"enterprise tier has white label", TierEnterprise, FeatureWhiteLabel, true},
+		{"enterprise tier has air gap", TierEnterprise, FeatureAirGap, true},
+
+		// Invalid tier
+		{"invalid tier has no OIDC", LicenseTier("invalid"), FeatureOIDC, false},
+		{"empty tier has no features", LicenseTier(""), FeatureOIDC, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := HasFeature(tt.tier, tt.feature); got != tt.has {
+				t.Errorf("HasFeature(%v, %v) = %v, want %v", tt.tier, tt.feature, got, tt.has)
+			}
+		})
+	}
+}
+
+func TestFeaturesForTier(t *testing.T) {
+	t.Run("free tier features", func(t *testing.T) {
+		features := FeaturesForTier(TierFree)
+		if len(features) != 0 {
+			t.Errorf("FeaturesForTier(TierFree) returned %d features, want 0", len(features))
+		}
+	})
+
+	t.Run("pro tier features", func(t *testing.T) {
+		features := FeaturesForTier(TierPro)
+		if len(features) != 2 {
+			t.Errorf("FeaturesForTier(TierPro) returned %d features, want 2", len(features))
+		}
+	})
+
+	t.Run("enterprise tier features", func(t *testing.T) {
+		features := FeaturesForTier(TierEnterprise)
+		if len(features) != 6 {
+			t.Errorf("FeaturesForTier(TierEnterprise) returned %d features, want 6", len(features))
+		}
+	})
+
+	t.Run("invalid tier features", func(t *testing.T) {
+		features := FeaturesForTier(LicenseTier("invalid"))
+		if features != nil {
+			t.Errorf("FeaturesForTier(invalid) = %v, want nil", features)
+		}
+	})
+}

--- a/internal/license/license_test.go
+++ b/internal/license/license_test.go
@@ -1,0 +1,267 @@
+package license
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestLicenseTier_IsValid(t *testing.T) {
+	tests := []struct {
+		name  string
+		tier  LicenseTier
+		valid bool
+	}{
+		{"free tier is valid", TierFree, true},
+		{"pro tier is valid", TierPro, true},
+		{"enterprise tier is valid", TierEnterprise, true},
+		{"empty tier is invalid", LicenseTier(""), false},
+		{"unknown tier is invalid", LicenseTier("unknown"), false},
+		{"random tier is invalid", LicenseTier("basic"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.tier.IsValid(); got != tt.valid {
+				t.Errorf("IsValid() = %v, want %v", got, tt.valid)
+			}
+		})
+	}
+}
+
+func TestValidTiers(t *testing.T) {
+	tiers := ValidTiers()
+
+	if len(tiers) != 3 {
+		t.Errorf("ValidTiers() returned %d tiers, want 3", len(tiers))
+	}
+
+	expected := map[LicenseTier]bool{
+		TierFree:       false,
+		TierPro:        false,
+		TierEnterprise: false,
+	}
+
+	for _, tier := range tiers {
+		if _, ok := expected[tier]; !ok {
+			t.Errorf("ValidTiers() returned unexpected tier: %s", tier)
+		}
+		expected[tier] = true
+	}
+
+	for tier, found := range expected {
+		if !found {
+			t.Errorf("ValidTiers() missing expected tier: %s", tier)
+		}
+	}
+}
+
+func createValidLicenseKey(tier LicenseTier, customerID string, expiresAt, issuedAt int64) string {
+	payload := licensePayload{
+		Tier:       tier,
+		CustomerID: customerID,
+		ExpiresAt:  expiresAt,
+		IssuedAt:   issuedAt,
+	}
+
+	payloadJSON, _ := json.Marshal(payload)
+	payloadB64 := base64.RawURLEncoding.EncodeToString(payloadJSON)
+
+	key := []byte("keldris-license-signing-key")
+	h := hmac.New(sha256.New, key)
+	h.Write(payloadJSON)
+	signature := h.Sum(nil)
+	signatureB64 := base64.RawURLEncoding.EncodeToString(signature)
+
+	return payloadB64 + "." + signatureB64
+}
+
+func TestParseLicense(t *testing.T) {
+	now := time.Now()
+	futureExpiry := now.Add(365 * 24 * time.Hour).Unix()
+	issuedAt := now.Unix()
+
+	validKey := createValidLicenseKey(TierPro, "customer-123", futureExpiry, issuedAt)
+
+	t.Run("valid license key", func(t *testing.T) {
+		lic, err := ParseLicense(validKey)
+		if err != nil {
+			t.Fatalf("ParseLicense() error = %v, want nil", err)
+		}
+		if lic.Tier != TierPro {
+			t.Errorf("Tier = %v, want %v", lic.Tier, TierPro)
+		}
+		if lic.CustomerID != "customer-123" {
+			t.Errorf("CustomerID = %v, want customer-123", lic.CustomerID)
+		}
+	})
+
+	t.Run("empty key", func(t *testing.T) {
+		_, err := ParseLicense("")
+		if err == nil {
+			t.Error("ParseLicense() error = nil, want error")
+		}
+	})
+
+	t.Run("missing dot separator", func(t *testing.T) {
+		_, err := ParseLicense("no-dot-separator")
+		if err == nil {
+			t.Error("ParseLicense() error = nil, want error")
+		}
+	})
+
+	t.Run("invalid base64 in payload", func(t *testing.T) {
+		_, err := ParseLicense("invalid!!!.validbase64")
+		if err == nil {
+			t.Error("ParseLicense() error = nil, want error")
+		}
+	})
+
+	t.Run("invalid base64 in signature", func(t *testing.T) {
+		payload := licensePayload{
+			Tier:       TierPro,
+			CustomerID: "customer-123",
+			ExpiresAt:  futureExpiry,
+			IssuedAt:   issuedAt,
+		}
+		payloadJSON, _ := json.Marshal(payload)
+		payloadB64 := base64.RawURLEncoding.EncodeToString(payloadJSON)
+
+		_, err := ParseLicense(payloadB64 + ".invalid!!!")
+		if err == nil {
+			t.Error("ParseLicense() error = nil, want error")
+		}
+	})
+
+	t.Run("invalid signature", func(t *testing.T) {
+		payload := licensePayload{
+			Tier:       TierPro,
+			CustomerID: "customer-123",
+			ExpiresAt:  futureExpiry,
+			IssuedAt:   issuedAt,
+		}
+		payloadJSON, _ := json.Marshal(payload)
+		payloadB64 := base64.RawURLEncoding.EncodeToString(payloadJSON)
+
+		wrongSignature := base64.RawURLEncoding.EncodeToString([]byte("wrong-signature-value-here"))
+		_, err := ParseLicense(payloadB64 + "." + wrongSignature)
+		if err == nil {
+			t.Error("ParseLicense() error = nil, want error")
+		}
+	})
+
+	t.Run("invalid JSON payload", func(t *testing.T) {
+		invalidJSON := []byte("{invalid json")
+		payloadB64 := base64.RawURLEncoding.EncodeToString(invalidJSON)
+
+		key := []byte("keldris-license-signing-key")
+		h := hmac.New(sha256.New, key)
+		h.Write(invalidJSON)
+		signature := h.Sum(nil)
+		signatureB64 := base64.RawURLEncoding.EncodeToString(signature)
+
+		_, err := ParseLicense(payloadB64 + "." + signatureB64)
+		if err == nil {
+			t.Error("ParseLicense() error = nil, want error")
+		}
+	})
+
+	t.Run("unknown tier", func(t *testing.T) {
+		unknownTierKey := createValidLicenseKey(LicenseTier("unknown"), "customer-123", futureExpiry, issuedAt)
+		_, err := ParseLicense(unknownTierKey)
+		if err == nil {
+			t.Error("ParseLicense() error = nil, want error for unknown tier")
+		}
+	})
+}
+
+func TestValidateLicense(t *testing.T) {
+	now := time.Now()
+
+	t.Run("nil license", func(t *testing.T) {
+		err := ValidateLicense(nil)
+		if err == nil {
+			t.Error("ValidateLicense() error = nil, want error for nil license")
+		}
+	})
+
+	t.Run("invalid tier", func(t *testing.T) {
+		lic := &License{
+			Tier:       LicenseTier("invalid"),
+			CustomerID: "customer-123",
+			ExpiresAt:  now.Add(365 * 24 * time.Hour),
+			IssuedAt:   now,
+		}
+		err := ValidateLicense(lic)
+		if err == nil {
+			t.Error("ValidateLicense() error = nil, want error for invalid tier")
+		}
+	})
+
+	t.Run("expired license", func(t *testing.T) {
+		lic := &License{
+			Tier:       TierPro,
+			CustomerID: "customer-123",
+			ExpiresAt:  now.Add(-24 * time.Hour),
+			IssuedAt:   now.Add(-48 * time.Hour),
+		}
+		err := ValidateLicense(lic)
+		if err == nil {
+			t.Error("ValidateLicense() error = nil, want error for expired license")
+		}
+	})
+
+	t.Run("empty customer ID", func(t *testing.T) {
+		lic := &License{
+			Tier:       TierPro,
+			CustomerID: "",
+			ExpiresAt:  now.Add(365 * 24 * time.Hour),
+			IssuedAt:   now,
+		}
+		err := ValidateLicense(lic)
+		if err == nil {
+			t.Error("ValidateLicense() error = nil, want error for empty customer ID")
+		}
+	})
+
+	t.Run("valid license", func(t *testing.T) {
+		lic := &License{
+			Tier:       TierPro,
+			CustomerID: "customer-123",
+			ExpiresAt:  now.Add(365 * 24 * time.Hour),
+			IssuedAt:   now,
+		}
+		err := ValidateLicense(lic)
+		if err != nil {
+			t.Errorf("ValidateLicense() error = %v, want nil", err)
+		}
+	})
+}
+
+func TestFreeLicense(t *testing.T) {
+	lic := FreeLicense()
+
+	if lic == nil {
+		t.Fatal("FreeLicense() returned nil")
+	}
+
+	if lic.Tier != TierFree {
+		t.Errorf("Tier = %v, want %v", lic.Tier, TierFree)
+	}
+
+	if lic.CustomerID == "" {
+		t.Error("CustomerID is empty, want non-empty")
+	}
+
+	if time.Until(lic.ExpiresAt) < 50*365*24*time.Hour {
+		t.Error("ExpiresAt is not far enough in the future")
+	}
+
+	err := ValidateLicense(lic)
+	if err != nil {
+		t.Errorf("ValidateLicense() error = %v, want nil for free license", err)
+	}
+}

--- a/internal/license/limits_test.go
+++ b/internal/license/limits_test.go
@@ -1,0 +1,117 @@
+package license
+
+import (
+	"testing"
+)
+
+func TestGetLimits(t *testing.T) {
+	t.Run("free tier limits", func(t *testing.T) {
+		limits := GetLimits(TierFree)
+
+		if limits.MaxAgents != 3 {
+			t.Errorf("MaxAgents = %d, want 3", limits.MaxAgents)
+		}
+		if limits.MaxUsers != 3 {
+			t.Errorf("MaxUsers = %d, want 3", limits.MaxUsers)
+		}
+		if limits.MaxOrgs != 1 {
+			t.Errorf("MaxOrgs = %d, want 1", limits.MaxOrgs)
+		}
+		if limits.MaxStorage != 10*1024*1024*1024 {
+			t.Errorf("MaxStorage = %d, want %d", limits.MaxStorage, int64(10*1024*1024*1024))
+		}
+	})
+
+	t.Run("pro tier limits", func(t *testing.T) {
+		limits := GetLimits(TierPro)
+
+		if limits.MaxAgents != 25 {
+			t.Errorf("MaxAgents = %d, want 25", limits.MaxAgents)
+		}
+		if limits.MaxUsers != 10 {
+			t.Errorf("MaxUsers = %d, want 10", limits.MaxUsers)
+		}
+		if limits.MaxOrgs != 3 {
+			t.Errorf("MaxOrgs = %d, want 3", limits.MaxOrgs)
+		}
+		if limits.MaxStorage != 100*1024*1024*1024 {
+			t.Errorf("MaxStorage = %d, want %d", limits.MaxStorage, int64(100*1024*1024*1024))
+		}
+	})
+
+	t.Run("enterprise tier limits", func(t *testing.T) {
+		limits := GetLimits(TierEnterprise)
+
+		if limits.MaxAgents != -1 {
+			t.Errorf("MaxAgents = %d, want -1 (unlimited)", limits.MaxAgents)
+		}
+		if limits.MaxUsers != -1 {
+			t.Errorf("MaxUsers = %d, want -1 (unlimited)", limits.MaxUsers)
+		}
+		if limits.MaxOrgs != -1 {
+			t.Errorf("MaxOrgs = %d, want -1 (unlimited)", limits.MaxOrgs)
+		}
+		if limits.MaxStorage != -1 {
+			t.Errorf("MaxStorage = %d, want -1 (unlimited)", limits.MaxStorage)
+		}
+	})
+
+	t.Run("unknown tier returns free limits", func(t *testing.T) {
+		limits := GetLimits(LicenseTier("unknown"))
+
+		if limits.MaxAgents != 3 {
+			t.Errorf("MaxAgents = %d, want 3 (free tier default)", limits.MaxAgents)
+		}
+		if limits.MaxUsers != 3 {
+			t.Errorf("MaxUsers = %d, want 3 (free tier default)", limits.MaxUsers)
+		}
+	})
+}
+
+func TestIsUnlimited(t *testing.T) {
+	tests := []struct {
+		name      string
+		limit     int
+		unlimited bool
+	}{
+		{"negative one is unlimited", -1, true},
+		{"zero is limited", 0, false},
+		{"positive number is limited", 10, false},
+		{"negative two is limited", -2, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsUnlimited(tt.limit); got != tt.unlimited {
+				t.Errorf("IsUnlimited(%d) = %v, want %v", tt.limit, got, tt.unlimited)
+			}
+		})
+	}
+}
+
+func TestIsStorageUnlimited(t *testing.T) {
+	tests := []struct {
+		name      string
+		limit     int64
+		unlimited bool
+	}{
+		{"negative one is unlimited", -1, true},
+		{"zero is limited", 0, false},
+		{"positive number is limited", 10 * 1024 * 1024 * 1024, false},
+		{"negative two is limited", -2, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsStorageUnlimited(tt.limit); got != tt.unlimited {
+				t.Errorf("IsStorageUnlimited(%d) = %v, want %v", tt.limit, got, tt.unlimited)
+			}
+		})
+	}
+}
+
+func TestUnlimitedConstant(t *testing.T) {
+	if Unlimited != -1 {
+		t.Errorf("Unlimited constant = %d, want -1", Unlimited)
+	}
+}

--- a/internal/models/agent_test.go
+++ b/internal/models/agent_test.go
@@ -1,0 +1,293 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestNewAgent(t *testing.T) {
+	orgID := uuid.New()
+	hostname := "test-host"
+	apiKeyHash := "hash123"
+
+	agent := NewAgent(orgID, hostname, apiKeyHash)
+
+	if agent.ID == uuid.Nil {
+		t.Error("expected ID to be set")
+	}
+	if agent.OrgID != orgID {
+		t.Errorf("expected OrgID %v, got %v", orgID, agent.OrgID)
+	}
+	if agent.Hostname != hostname {
+		t.Errorf("expected Hostname %s, got %s", hostname, agent.Hostname)
+	}
+	if agent.APIKeyHash != apiKeyHash {
+		t.Errorf("expected APIKeyHash %s, got %s", apiKeyHash, agent.APIKeyHash)
+	}
+	if agent.Status != AgentStatusPending {
+		t.Errorf("expected Status %s, got %s", AgentStatusPending, agent.Status)
+	}
+	if agent.CreatedAt.IsZero() {
+		t.Error("expected CreatedAt to be set")
+	}
+	if agent.LastSeen != nil {
+		t.Error("expected LastSeen to be nil")
+	}
+}
+
+func TestAgent_SetOSInfo_OSInfoJSON(t *testing.T) {
+	agent := NewAgent(uuid.New(), "test-host", "hash123")
+
+	osInfo := OSInfo{
+		OS:       "linux",
+		Arch:     "amd64",
+		Hostname: "test-host",
+		Version:  "22.04",
+	}
+
+	data, err := json.Marshal(osInfo)
+	if err != nil {
+		t.Fatalf("failed to marshal OSInfo: %v", err)
+	}
+
+	t.Run("round trip", func(t *testing.T) {
+		if err := agent.SetOSInfo(data); err != nil {
+			t.Fatalf("SetOSInfo failed: %v", err)
+		}
+
+		retrieved, err := agent.OSInfoJSON()
+		if err != nil {
+			t.Fatalf("OSInfoJSON failed: %v", err)
+		}
+
+		var got OSInfo
+		if err := json.Unmarshal(retrieved, &got); err != nil {
+			t.Fatalf("failed to unmarshal: %v", err)
+		}
+
+		if got.OS != osInfo.OS || got.Arch != osInfo.Arch {
+			t.Errorf("round trip mismatch: got %+v, want %+v", got, osInfo)
+		}
+	})
+
+	t.Run("empty data", func(t *testing.T) {
+		a := NewAgent(uuid.New(), "test", "hash")
+		if err := a.SetOSInfo(nil); err != nil {
+			t.Errorf("SetOSInfo(nil) should not error: %v", err)
+		}
+	})
+
+	t.Run("invalid JSON", func(t *testing.T) {
+		a := NewAgent(uuid.New(), "test", "hash")
+		if err := a.SetOSInfo([]byte("invalid")); err == nil {
+			t.Error("expected error for invalid JSON")
+		}
+	})
+
+	t.Run("nil OSInfo", func(t *testing.T) {
+		a := NewAgent(uuid.New(), "test", "hash")
+		data, err := a.OSInfoJSON()
+		if err != nil {
+			t.Errorf("OSInfoJSON failed: %v", err)
+		}
+		if data != nil {
+			t.Errorf("expected nil, got %v", data)
+		}
+	})
+}
+
+func TestAgent_IsOnline(t *testing.T) {
+	tests := []struct {
+		name      string
+		lastSeen  *time.Time
+		threshold time.Duration
+		expected  bool
+	}{
+		{"nil last seen", nil, 5 * time.Minute, false},
+		{"within threshold", timePtr(time.Now().Add(-2 * time.Minute)), 5 * time.Minute, true},
+		{"outside threshold", timePtr(time.Now().Add(-10 * time.Minute)), 5 * time.Minute, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			agent := NewAgent(uuid.New(), "test", "hash")
+			agent.LastSeen = tt.lastSeen
+
+			if got := agent.IsOnline(tt.threshold); got != tt.expected {
+				t.Errorf("IsOnline() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestAgent_MarkSeen(t *testing.T) {
+	agent := NewAgent(uuid.New(), "test-host", "hash123")
+
+	if agent.LastSeen != nil {
+		t.Error("expected LastSeen to be nil initially")
+	}
+
+	before := time.Now()
+	agent.MarkSeen()
+	after := time.Now()
+
+	if agent.LastSeen == nil {
+		t.Fatal("expected LastSeen to be set")
+	}
+	if agent.LastSeen.Before(before) || agent.LastSeen.After(after) {
+		t.Errorf("LastSeen %v not within expected range", agent.LastSeen)
+	}
+	if agent.Status != AgentStatusActive {
+		t.Errorf("expected Status %s, got %s", AgentStatusActive, agent.Status)
+	}
+}
+
+func TestAgent_NetworkMounts(t *testing.T) {
+	agent := NewAgent(uuid.New(), "test-host", "hash123")
+
+	mounts := []NetworkMount{
+		{Path: "/mnt/share1", Type: MountTypeNFS, Remote: "192.168.1.100:/share", Status: MountStatusConnected, LastChecked: time.Now()},
+		{Path: "/mnt/share2", Type: MountTypeSMB, Remote: "//server/share", Status: MountStatusDisconnected, LastChecked: time.Now()},
+	}
+
+	data, _ := json.Marshal(mounts)
+	if err := agent.SetNetworkMounts(data); err != nil {
+		t.Fatalf("SetNetworkMounts failed: %v", err)
+	}
+
+	t.Run("round trip", func(t *testing.T) {
+		retrieved, err := agent.NetworkMountsJSON()
+		if err != nil {
+			t.Fatalf("NetworkMountsJSON failed: %v", err)
+		}
+		var got []NetworkMount
+		if err := json.Unmarshal(retrieved, &got); err != nil {
+			t.Fatalf("failed to unmarshal: %v", err)
+		}
+		if len(got) != 2 {
+			t.Errorf("expected 2 mounts, got %d", len(got))
+		}
+	})
+
+	t.Run("nil mounts returns empty array", func(t *testing.T) {
+		a := NewAgent(uuid.New(), "test", "hash")
+		data, err := a.NetworkMountsJSON()
+		if err != nil {
+			t.Errorf("NetworkMountsJSON failed: %v", err)
+		}
+		if string(data) != "[]" {
+			t.Errorf("expected [], got %s", string(data))
+		}
+	})
+}
+
+func TestAgent_GetMountByPath(t *testing.T) {
+	agent := NewAgent(uuid.New(), "test-host", "hash123")
+	mounts := []NetworkMount{
+		{Path: "/mnt/share1", Type: MountTypeNFS, Status: MountStatusConnected},
+		{Path: "/mnt/share2", Type: MountTypeSMB, Status: MountStatusDisconnected},
+	}
+	data, _ := json.Marshal(mounts)
+	agent.SetNetworkMounts(data)
+
+	t.Run("found", func(t *testing.T) {
+		mount := agent.GetMountByPath("/mnt/share1")
+		if mount == nil {
+			t.Fatal("expected mount to be found")
+		}
+		if mount.Type != MountTypeNFS {
+			t.Errorf("expected Type %s, got %s", MountTypeNFS, mount.Type)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		if mount := agent.GetMountByPath("/nonexistent"); mount != nil {
+			t.Error("expected nil for nonexistent path")
+		}
+	})
+}
+
+func TestAgent_GetConnectedMounts(t *testing.T) {
+	agent := NewAgent(uuid.New(), "test-host", "hash123")
+	mounts := []NetworkMount{
+		{Path: "/mnt/a", Status: MountStatusConnected},
+		{Path: "/mnt/b", Status: MountStatusDisconnected},
+		{Path: "/mnt/c", Status: MountStatusConnected},
+		{Path: "/mnt/d", Status: MountStatusStale},
+	}
+	data, _ := json.Marshal(mounts)
+	agent.SetNetworkMounts(data)
+
+	connected := agent.GetConnectedMounts()
+	if len(connected) != 2 {
+		t.Errorf("expected 2 connected mounts, got %d", len(connected))
+	}
+	for _, m := range connected {
+		if m.Status != MountStatusConnected {
+			t.Errorf("expected connected status, got %s", m.Status)
+		}
+	}
+}
+
+func TestAgent_HealthMetrics(t *testing.T) {
+	agent := NewAgent(uuid.New(), "test-host", "hash123")
+
+	metrics := HealthMetrics{
+		CPUUsage:        45.5,
+		MemoryUsage:     60.2,
+		DiskUsage:       75.8,
+		DiskFreeBytes:   100000000000,
+		DiskTotalBytes:  500000000000,
+		NetworkUp:       true,
+		UptimeSeconds:   86400,
+		ResticVersion:   "0.16.0",
+		ResticAvailable: true,
+	}
+
+	data, _ := json.Marshal(metrics)
+
+	t.Run("round trip", func(t *testing.T) {
+		if err := agent.SetHealthMetrics(data); err != nil {
+			t.Fatalf("SetHealthMetrics failed: %v", err)
+		}
+
+		retrieved, err := agent.HealthMetricsJSON()
+		if err != nil {
+			t.Fatalf("HealthMetricsJSON failed: %v", err)
+		}
+
+		var got HealthMetrics
+		if err := json.Unmarshal(retrieved, &got); err != nil {
+			t.Fatalf("failed to unmarshal: %v", err)
+		}
+
+		if got.CPUUsage != metrics.CPUUsage {
+			t.Errorf("expected CPUUsage %f, got %f", metrics.CPUUsage, got.CPUUsage)
+		}
+	})
+
+	t.Run("nil metrics", func(t *testing.T) {
+		a := NewAgent(uuid.New(), "test", "hash")
+		data, err := a.HealthMetricsJSON()
+		if err != nil {
+			t.Errorf("HealthMetricsJSON failed: %v", err)
+		}
+		if data != nil {
+			t.Errorf("expected nil, got %v", data)
+		}
+	})
+
+	t.Run("invalid JSON", func(t *testing.T) {
+		a := NewAgent(uuid.New(), "test", "hash")
+		if err := a.SetHealthMetrics([]byte("invalid")); err == nil {
+			t.Error("expected error for invalid JSON")
+		}
+	})
+}
+
+func timePtr(t time.Time) *time.Time {
+	return &t
+}

--- a/internal/models/backup_test.go
+++ b/internal/models/backup_test.go
@@ -1,0 +1,222 @@
+package models
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestNewBackup(t *testing.T) {
+	scheduleID := uuid.New()
+	agentID := uuid.New()
+	repoID := uuid.New()
+
+	backup := NewBackup(scheduleID, agentID, &repoID)
+
+	if backup.ID == uuid.Nil {
+		t.Error("expected ID to be set")
+	}
+	if backup.ScheduleID != scheduleID {
+		t.Errorf("expected ScheduleID %v, got %v", scheduleID, backup.ScheduleID)
+	}
+	if backup.AgentID != agentID {
+		t.Errorf("expected AgentID %v, got %v", agentID, backup.AgentID)
+	}
+	if backup.RepositoryID == nil || *backup.RepositoryID != repoID {
+		t.Errorf("expected RepositoryID %v, got %v", repoID, backup.RepositoryID)
+	}
+	if backup.Status != BackupStatusRunning {
+		t.Errorf("expected Status %s, got %s", BackupStatusRunning, backup.Status)
+	}
+	if backup.StartedAt.IsZero() {
+		t.Error("expected StartedAt to be set")
+	}
+	if backup.CompletedAt != nil {
+		t.Error("expected CompletedAt to be nil")
+	}
+}
+
+func TestNewBackup_NilRepo(t *testing.T) {
+	backup := NewBackup(uuid.New(), uuid.New(), nil)
+	if backup.RepositoryID != nil {
+		t.Error("expected nil RepositoryID")
+	}
+}
+
+func TestBackup_Complete(t *testing.T) {
+	backup := NewBackup(uuid.New(), uuid.New(), nil)
+
+	backup.Complete("snap-123", 1024*1024, 10, 5)
+
+	if backup.Status != BackupStatusCompleted {
+		t.Errorf("expected Status %s, got %s", BackupStatusCompleted, backup.Status)
+	}
+	if backup.CompletedAt == nil {
+		t.Fatal("expected CompletedAt to be set")
+	}
+	if backup.SnapshotID != "snap-123" {
+		t.Errorf("expected SnapshotID 'snap-123', got %s", backup.SnapshotID)
+	}
+	if backup.SizeBytes == nil || *backup.SizeBytes != 1024*1024 {
+		t.Errorf("expected SizeBytes 1048576, got %v", backup.SizeBytes)
+	}
+	if backup.FilesNew == nil || *backup.FilesNew != 10 {
+		t.Errorf("expected FilesNew 10, got %v", backup.FilesNew)
+	}
+	if backup.FilesChanged == nil || *backup.FilesChanged != 5 {
+		t.Errorf("expected FilesChanged 5, got %v", backup.FilesChanged)
+	}
+}
+
+func TestBackup_Fail(t *testing.T) {
+	backup := NewBackup(uuid.New(), uuid.New(), nil)
+
+	backup.Fail("disk full")
+
+	if backup.Status != BackupStatusFailed {
+		t.Errorf("expected Status %s, got %s", BackupStatusFailed, backup.Status)
+	}
+	if backup.CompletedAt == nil {
+		t.Fatal("expected CompletedAt to be set")
+	}
+	if backup.ErrorMessage != "disk full" {
+		t.Errorf("expected ErrorMessage 'disk full', got %s", backup.ErrorMessage)
+	}
+}
+
+func TestBackup_Cancel(t *testing.T) {
+	backup := NewBackup(uuid.New(), uuid.New(), nil)
+
+	backup.Cancel()
+
+	if backup.Status != BackupStatusCanceled {
+		t.Errorf("expected Status %s, got %s", BackupStatusCanceled, backup.Status)
+	}
+	if backup.CompletedAt == nil {
+		t.Fatal("expected CompletedAt to be set")
+	}
+}
+
+func TestBackup_RecordRetention(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		backup := NewBackup(uuid.New(), uuid.New(), nil)
+		backup.RecordRetention(3, 7, nil)
+
+		if !backup.RetentionApplied {
+			t.Error("expected RetentionApplied to be true")
+		}
+		if backup.SnapshotsRemoved == nil || *backup.SnapshotsRemoved != 3 {
+			t.Errorf("expected SnapshotsRemoved 3, got %v", backup.SnapshotsRemoved)
+		}
+		if backup.SnapshotsKept == nil || *backup.SnapshotsKept != 7 {
+			t.Errorf("expected SnapshotsKept 7, got %v", backup.SnapshotsKept)
+		}
+		if backup.RetentionError != "" {
+			t.Errorf("expected empty RetentionError, got %s", backup.RetentionError)
+		}
+	})
+
+	t.Run("with error", func(t *testing.T) {
+		backup := NewBackup(uuid.New(), uuid.New(), nil)
+		backup.RecordRetention(0, 10, errors.New("retention error"))
+
+		if !backup.RetentionApplied {
+			t.Error("expected RetentionApplied to be true")
+		}
+		if backup.RetentionError != "retention error" {
+			t.Errorf("expected RetentionError 'retention error', got %s", backup.RetentionError)
+		}
+	})
+}
+
+func TestBackup_Duration(t *testing.T) {
+	t.Run("not completed", func(t *testing.T) {
+		backup := NewBackup(uuid.New(), uuid.New(), nil)
+		if d := backup.Duration(); d != 0 {
+			t.Errorf("expected 0 duration, got %v", d)
+		}
+	})
+
+	t.Run("completed", func(t *testing.T) {
+		backup := NewBackup(uuid.New(), uuid.New(), nil)
+		time.Sleep(10 * time.Millisecond)
+		backup.Complete("snap-1", 100, 1, 0)
+
+		if d := backup.Duration(); d <= 0 {
+			t.Errorf("expected positive duration, got %v", d)
+		}
+	})
+}
+
+func TestBackup_IsComplete(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   BackupStatus
+		complete bool
+	}{
+		{"running", BackupStatusRunning, false},
+		{"completed", BackupStatusCompleted, true},
+		{"failed", BackupStatusFailed, true},
+		{"canceled", BackupStatusCanceled, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			backup := &Backup{Status: tt.status}
+			if got := backup.IsComplete(); got != tt.complete {
+				t.Errorf("IsComplete() = %v, want %v", got, tt.complete)
+			}
+		})
+	}
+}
+
+func TestBackup_RecordPreScript(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		backup := NewBackup(uuid.New(), uuid.New(), nil)
+		backup.RecordPreScript("output here", nil)
+
+		if backup.PreScriptOutput != "output here" {
+			t.Errorf("expected PreScriptOutput 'output here', got %s", backup.PreScriptOutput)
+		}
+		if backup.PreScriptError != "" {
+			t.Errorf("expected empty PreScriptError, got %s", backup.PreScriptError)
+		}
+	})
+
+	t.Run("with error", func(t *testing.T) {
+		backup := NewBackup(uuid.New(), uuid.New(), nil)
+		backup.RecordPreScript("partial output", errors.New("script failed"))
+
+		if backup.PreScriptOutput != "partial output" {
+			t.Errorf("expected PreScriptOutput 'partial output', got %s", backup.PreScriptOutput)
+		}
+		if backup.PreScriptError != "script failed" {
+			t.Errorf("expected PreScriptError 'script failed', got %s", backup.PreScriptError)
+		}
+	})
+}
+
+func TestBackup_RecordPostScript(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		backup := NewBackup(uuid.New(), uuid.New(), nil)
+		backup.RecordPostScript("cleanup done", nil)
+
+		if backup.PostScriptOutput != "cleanup done" {
+			t.Errorf("expected PostScriptOutput 'cleanup done', got %s", backup.PostScriptOutput)
+		}
+		if backup.PostScriptError != "" {
+			t.Errorf("expected empty PostScriptError, got %s", backup.PostScriptError)
+		}
+	})
+
+	t.Run("with error", func(t *testing.T) {
+		backup := NewBackup(uuid.New(), uuid.New(), nil)
+		backup.RecordPostScript("", errors.New("cleanup failed"))
+
+		if backup.PostScriptError != "cleanup failed" {
+			t.Errorf("expected PostScriptError 'cleanup failed', got %s", backup.PostScriptError)
+		}
+	})
+}

--- a/internal/models/schedule_test.go
+++ b/internal/models/schedule_test.go
@@ -1,0 +1,346 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestNewSchedule(t *testing.T) {
+	agentID := uuid.New()
+	name := "daily-backup"
+	cronExpr := "0 2 * * *"
+	paths := []string{"/data", "/home"}
+
+	schedule := NewSchedule(agentID, name, cronExpr, paths)
+
+	if schedule.ID == uuid.Nil {
+		t.Error("expected ID to be set")
+	}
+	if schedule.AgentID != agentID {
+		t.Errorf("expected AgentID %v, got %v", agentID, schedule.AgentID)
+	}
+	if schedule.Name != name {
+		t.Errorf("expected Name %s, got %s", name, schedule.Name)
+	}
+	if schedule.CronExpression != cronExpr {
+		t.Errorf("expected CronExpression %s, got %s", cronExpr, schedule.CronExpression)
+	}
+	if len(schedule.Paths) != 2 {
+		t.Errorf("expected 2 paths, got %d", len(schedule.Paths))
+	}
+	if !schedule.Enabled {
+		t.Error("expected Enabled to be true")
+	}
+	if schedule.OnMountUnavailable != MountBehaviorFail {
+		t.Errorf("expected OnMountUnavailable %s, got %s", MountBehaviorFail, schedule.OnMountUnavailable)
+	}
+}
+
+func TestSchedule_GetPrimaryRepository(t *testing.T) {
+	t.Run("found", func(t *testing.T) {
+		schedule := NewSchedule(uuid.New(), "test", "0 * * * *", []string{"/data"})
+		schedule.Repositories = []ScheduleRepository{
+			{RepositoryID: uuid.New(), Priority: 1, Enabled: true},
+			{RepositoryID: uuid.New(), Priority: 0, Enabled: true},
+		}
+
+		primary := schedule.GetPrimaryRepository()
+		if primary == nil {
+			t.Fatal("expected primary repository")
+		}
+		if primary.Priority != 0 {
+			t.Errorf("expected Priority 0, got %d", primary.Priority)
+		}
+	})
+
+	t.Run("disabled primary", func(t *testing.T) {
+		schedule := NewSchedule(uuid.New(), "test", "0 * * * *", []string{"/data"})
+		schedule.Repositories = []ScheduleRepository{
+			{RepositoryID: uuid.New(), Priority: 0, Enabled: false},
+			{RepositoryID: uuid.New(), Priority: 1, Enabled: true},
+		}
+
+		primary := schedule.GetPrimaryRepository()
+		if primary != nil {
+			t.Error("expected nil for disabled primary")
+		}
+	})
+
+	t.Run("no repos", func(t *testing.T) {
+		schedule := NewSchedule(uuid.New(), "test", "0 * * * *", []string{"/data"})
+		if primary := schedule.GetPrimaryRepository(); primary != nil {
+			t.Error("expected nil for no repos")
+		}
+	})
+}
+
+func TestSchedule_GetEnabledRepositories(t *testing.T) {
+	schedule := NewSchedule(uuid.New(), "test", "0 * * * *", []string{"/data"})
+	schedule.Repositories = []ScheduleRepository{
+		{RepositoryID: uuid.New(), Priority: 2, Enabled: true},
+		{RepositoryID: uuid.New(), Priority: 0, Enabled: true},
+		{RepositoryID: uuid.New(), Priority: 1, Enabled: false},
+		{RepositoryID: uuid.New(), Priority: 3, Enabled: true},
+	}
+
+	enabled := schedule.GetEnabledRepositories()
+	if len(enabled) != 3 {
+		t.Fatalf("expected 3 enabled repos, got %d", len(enabled))
+	}
+
+	// Check sorting by priority
+	for i := 1; i < len(enabled); i++ {
+		if enabled[i-1].Priority > enabled[i].Priority {
+			t.Errorf("repos not sorted by priority: %d > %d", enabled[i-1].Priority, enabled[i].Priority)
+		}
+	}
+}
+
+func TestSchedule_PathsJSON(t *testing.T) {
+	schedule := NewSchedule(uuid.New(), "test", "0 * * * *", []string{"/data", "/home"})
+
+	data, err := schedule.PathsJSON()
+	if err != nil {
+		t.Fatalf("PathsJSON failed: %v", err)
+	}
+
+	var paths []string
+	if err := json.Unmarshal(data, &paths); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if len(paths) != 2 {
+		t.Errorf("expected 2 paths, got %d", len(paths))
+	}
+
+	t.Run("nil paths", func(t *testing.T) {
+		s := &Schedule{}
+		data, err := s.PathsJSON()
+		if err != nil {
+			t.Fatalf("PathsJSON failed: %v", err)
+		}
+		if string(data) != "[]" {
+			t.Errorf("expected [], got %s", string(data))
+		}
+	})
+
+	t.Run("SetPaths", func(t *testing.T) {
+		s := &Schedule{}
+		if err := s.SetPaths(data); err != nil {
+			t.Fatalf("SetPaths failed: %v", err)
+		}
+		if len(s.Paths) != 2 {
+			t.Errorf("expected 2 paths, got %d", len(s.Paths))
+		}
+	})
+
+	t.Run("SetPaths empty", func(t *testing.T) {
+		s := &Schedule{}
+		if err := s.SetPaths(nil); err != nil {
+			t.Fatalf("SetPaths(nil) failed: %v", err)
+		}
+	})
+}
+
+func TestSchedule_RetentionPolicy(t *testing.T) {
+	policy := DefaultRetentionPolicy()
+
+	if policy.KeepLast != 5 {
+		t.Errorf("expected KeepLast 5, got %d", policy.KeepLast)
+	}
+	if policy.KeepDaily != 7 {
+		t.Errorf("expected KeepDaily 7, got %d", policy.KeepDaily)
+	}
+	if policy.KeepWeekly != 4 {
+		t.Errorf("expected KeepWeekly 4, got %d", policy.KeepWeekly)
+	}
+	if policy.KeepMonthly != 6 {
+		t.Errorf("expected KeepMonthly 6, got %d", policy.KeepMonthly)
+	}
+
+	t.Run("round trip", func(t *testing.T) {
+		s := &Schedule{}
+		data, _ := json.Marshal(policy)
+		if err := s.SetRetentionPolicy(data); err != nil {
+			t.Fatalf("SetRetentionPolicy failed: %v", err)
+		}
+
+		retrieved, err := s.RetentionPolicyJSON()
+		if err != nil {
+			t.Fatalf("RetentionPolicyJSON failed: %v", err)
+		}
+
+		var got RetentionPolicy
+		if err := json.Unmarshal(retrieved, &got); err != nil {
+			t.Fatalf("failed to unmarshal: %v", err)
+		}
+		if got.KeepLast != policy.KeepLast {
+			t.Errorf("expected KeepLast %d, got %d", policy.KeepLast, got.KeepLast)
+		}
+	})
+
+	t.Run("nil policy", func(t *testing.T) {
+		s := &Schedule{}
+		data, err := s.RetentionPolicyJSON()
+		if err != nil {
+			t.Fatalf("RetentionPolicyJSON failed: %v", err)
+		}
+		if data != nil {
+			t.Errorf("expected nil, got %v", data)
+		}
+	})
+}
+
+func TestSchedule_IsWithinBackupWindow(t *testing.T) {
+	tests := []struct {
+		name     string
+		window   *BackupWindow
+		time     time.Time
+		expected bool
+	}{
+		{"no window", nil, time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC), true},
+		{"empty window", &BackupWindow{}, time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC), true},
+		{"within normal window", &BackupWindow{Start: "02:00", End: "06:00"}, time.Date(2024, 1, 1, 3, 0, 0, 0, time.UTC), true},
+		{"outside normal window", &BackupWindow{Start: "02:00", End: "06:00"}, time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC), false},
+		{"within midnight-crossing window before midnight", &BackupWindow{Start: "22:00", End: "06:00"}, time.Date(2024, 1, 1, 23, 0, 0, 0, time.UTC), true},
+		{"within midnight-crossing window after midnight", &BackupWindow{Start: "22:00", End: "06:00"}, time.Date(2024, 1, 1, 3, 0, 0, 0, time.UTC), true},
+		{"outside midnight-crossing window", &BackupWindow{Start: "22:00", End: "06:00"}, time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Schedule{BackupWindow: tt.window}
+			if got := s.IsWithinBackupWindow(tt.time); got != tt.expected {
+				t.Errorf("IsWithinBackupWindow() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSchedule_IsHourExcluded(t *testing.T) {
+	s := &Schedule{ExcludedHours: []int{9, 10, 11, 12, 13, 14, 15, 16, 17}}
+
+	if !s.IsHourExcluded(9) {
+		t.Error("expected hour 9 to be excluded")
+	}
+	if !s.IsHourExcluded(17) {
+		t.Error("expected hour 17 to be excluded")
+	}
+	if s.IsHourExcluded(2) {
+		t.Error("expected hour 2 to not be excluded")
+	}
+	if s.IsHourExcluded(20) {
+		t.Error("expected hour 20 to not be excluded")
+	}
+
+	t.Run("no excluded hours", func(t *testing.T) {
+		s := &Schedule{}
+		if s.IsHourExcluded(12) {
+			t.Error("expected no hours to be excluded")
+		}
+	})
+}
+
+func TestSchedule_CanRunAt(t *testing.T) {
+	s := &Schedule{
+		BackupWindow:  &BackupWindow{Start: "02:00", End: "06:00"},
+		ExcludedHours: []int{3},
+	}
+
+	// Within window, not excluded
+	if !s.CanRunAt(time.Date(2024, 1, 1, 4, 0, 0, 0, time.UTC)) {
+		t.Error("expected CanRunAt to be true at 04:00")
+	}
+
+	// Within window, but excluded
+	if s.CanRunAt(time.Date(2024, 1, 1, 3, 0, 0, 0, time.UTC)) {
+		t.Error("expected CanRunAt to be false at 03:00 (excluded)")
+	}
+
+	// Outside window
+	if s.CanRunAt(time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)) {
+		t.Error("expected CanRunAt to be false at 12:00 (outside window)")
+	}
+}
+
+func TestSchedule_NextAllowedTime(t *testing.T) {
+	t.Run("already allowed", func(t *testing.T) {
+		s := &Schedule{}
+		now := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+		next := s.NextAllowedTime(now)
+		if !next.Equal(now) {
+			t.Errorf("expected %v, got %v", now, next)
+		}
+	})
+
+	t.Run("finds next allowed", func(t *testing.T) {
+		s := &Schedule{
+			BackupWindow: &BackupWindow{Start: "02:00", End: "06:00"},
+		}
+		blocked := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+		next := s.NextAllowedTime(blocked)
+		if !next.After(blocked) {
+			t.Errorf("expected next time to be after %v, got %v", blocked, next)
+		}
+	})
+}
+
+func TestSchedule_ExcludesJSON(t *testing.T) {
+	t.Run("nil excludes", func(t *testing.T) {
+		s := &Schedule{}
+		data, err := s.ExcludesJSON()
+		if err != nil {
+			t.Fatalf("ExcludesJSON failed: %v", err)
+		}
+		if data != nil {
+			t.Errorf("expected nil, got %v", data)
+		}
+	})
+
+	t.Run("round trip", func(t *testing.T) {
+		s := &Schedule{Excludes: []string{"*.tmp", "cache/"}}
+		data, err := s.ExcludesJSON()
+		if err != nil {
+			t.Fatalf("ExcludesJSON failed: %v", err)
+		}
+
+		s2 := &Schedule{}
+		if err := s2.SetExcludes(data); err != nil {
+			t.Fatalf("SetExcludes failed: %v", err)
+		}
+		if len(s2.Excludes) != 2 {
+			t.Errorf("expected 2 excludes, got %d", len(s2.Excludes))
+		}
+	})
+}
+
+func TestSchedule_ExcludedHoursJSON(t *testing.T) {
+	t.Run("nil hours", func(t *testing.T) {
+		s := &Schedule{}
+		data, err := s.ExcludedHoursJSON()
+		if err != nil {
+			t.Fatalf("ExcludedHoursJSON failed: %v", err)
+		}
+		if data != nil {
+			t.Errorf("expected nil, got %v", data)
+		}
+	})
+
+	t.Run("round trip", func(t *testing.T) {
+		s := &Schedule{ExcludedHours: []int{9, 10, 11}}
+		data, err := s.ExcludedHoursJSON()
+		if err != nil {
+			t.Fatalf("ExcludedHoursJSON failed: %v", err)
+		}
+
+		s2 := &Schedule{}
+		if err := s2.SetExcludedHours(data); err != nil {
+			t.Fatalf("SetExcludedHours failed: %v", err)
+		}
+		if len(s2.ExcludedHours) != 3 {
+			t.Errorf("expected 3 excluded hours, got %d", len(s2.ExcludedHours))
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Add comprehensive unit tests for API handlers (agents, backups, schedules) with mocked stores
- Add middleware tests covering authentication, rate limiting, and feature gating
- Add model tests for Agent, Backup, and Schedule with JSON serialization
- Add extensive license tests achieving 98.3% code coverage

## Test Plan

- All tests pass with `go test -race -cover ./...`
- `go vet` and `staticcheck` pass with no issues
- License package coverage: 98.3%
- Models coverage: 25.3%
- Middleware coverage: 32.2%
- New handler tests use httptest and mock stores following project patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)