### PR TITLE
Add soft delete support for historical records

### DIFF
--- a/internal/db/migrations/029_add_soft_delete.sql
+++ b/internal/db/migrations/029_add_soft_delete.sql
@@ -1,0 +1,11 @@
+-- Migration: Add soft delete support for historical records
+
+ALTER TABLE backups ADD COLUMN deleted_at TIMESTAMPTZ;
+ALTER TABLE dr_tests ADD COLUMN deleted_at TIMESTAMPTZ;
+ALTER TABLE restores ADD COLUMN deleted_at TIMESTAMPTZ;
+ALTER TABLE verifications ADD COLUMN deleted_at TIMESTAMPTZ;
+
+CREATE INDEX idx_backups_deleted ON backups(deleted_at) WHERE deleted_at IS NULL;
+CREATE INDEX idx_dr_tests_deleted ON dr_tests(deleted_at) WHERE deleted_at IS NULL;
+CREATE INDEX idx_restores_deleted ON restores(deleted_at) WHERE deleted_at IS NULL;
+CREATE INDEX idx_verifications_deleted ON verifications(deleted_at) WHERE deleted_at IS NULL;


### PR DESCRIPTION
## Summary

Implements soft delete functionality for audit trail preservation with:
- UpdateSnapshotComment method for editing comment text
- DeleteBackup, DeleteRestore, DeleteVerification, DeleteDRTest soft delete methods
- Migration 029 adding deleted_at columns with efficient partial indexes
- Updated 30+ queries filtering soft-deleted records

## Test plan

- Build passes: `go build ./...`
- Tests pass: `make test`
- All list/get queries updated to filter deleted_at IS NULL
- Soft delete methods check RowsAffected() for not-found errors

🤖 Generated with Claude Code