### PR TITLE
Add comprehensive unit tests for API handlers

### DIFF
--- a/internal/api/handlers/alerts_test.go
+++ b/internal/api/handlers/alerts_test.go
@@ -1,0 +1,584 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/MacJediWizard/keldris/internal/api/middleware"
+	"github.com/MacJediWizard/keldris/internal/auth"
+	"github.com/MacJediWizard/keldris/internal/models"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+)
+
+type mockAlertStore struct {
+	alerts      []*models.Alert
+	alertByID   map[uuid.UUID]*models.Alert
+	activeCount int
+	rules       []*models.AlertRule
+	ruleByID    map[uuid.UUID]*models.AlertRule
+	user        *models.User
+	updateErr   error
+	createErr   error
+	deleteErr   error
+}
+
+func (m *mockAlertStore) GetAlertsByOrgID(_ context.Context, orgID uuid.UUID) ([]*models.Alert, error) {
+	var result []*models.Alert
+	for _, a := range m.alerts {
+		if a.OrgID == orgID {
+			result = append(result, a)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockAlertStore) GetActiveAlertsByOrgID(_ context.Context, orgID uuid.UUID) ([]*models.Alert, error) {
+	var result []*models.Alert
+	for _, a := range m.alerts {
+		if a.OrgID == orgID && a.Status == models.AlertStatusActive {
+			result = append(result, a)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockAlertStore) GetActiveAlertCountByOrgID(_ context.Context, _ uuid.UUID) (int, error) {
+	return m.activeCount, nil
+}
+
+func (m *mockAlertStore) GetAlertByID(_ context.Context, id uuid.UUID) (*models.Alert, error) {
+	if a, ok := m.alertByID[id]; ok {
+		return a, nil
+	}
+	return nil, errors.New("alert not found")
+}
+
+func (m *mockAlertStore) UpdateAlert(_ context.Context, _ *models.Alert) error {
+	return m.updateErr
+}
+
+func (m *mockAlertStore) GetAlertRulesByOrgID(_ context.Context, orgID uuid.UUID) ([]*models.AlertRule, error) {
+	var result []*models.AlertRule
+	for _, r := range m.rules {
+		if r.OrgID == orgID {
+			result = append(result, r)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockAlertStore) GetAlertRuleByID(_ context.Context, id uuid.UUID) (*models.AlertRule, error) {
+	if r, ok := m.ruleByID[id]; ok {
+		return r, nil
+	}
+	return nil, errors.New("rule not found")
+}
+
+func (m *mockAlertStore) CreateAlertRule(_ context.Context, _ *models.AlertRule) error {
+	return m.createErr
+}
+
+func (m *mockAlertStore) UpdateAlertRule(_ context.Context, _ *models.AlertRule) error {
+	return m.updateErr
+}
+
+func (m *mockAlertStore) DeleteAlertRule(_ context.Context, _ uuid.UUID) error {
+	return m.deleteErr
+}
+
+func (m *mockAlertStore) GetUserByID(_ context.Context, id uuid.UUID) (*models.User, error) {
+	if m.user != nil && m.user.ID == id {
+		return m.user, nil
+	}
+	return nil, errors.New("user not found")
+}
+
+func setupAlertTestRouter(store AlertStore, user *auth.SessionUser) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		if user != nil {
+			c.Set(string(middleware.UserContextKey), user)
+		}
+		c.Next()
+	})
+	handler := NewAlertsHandler(store, zerolog.Nop())
+	api := r.Group("/api/v1")
+	handler.RegisterRoutes(api)
+	return r
+}
+
+func TestListAlerts(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	alertID := uuid.New()
+
+	alert := &models.Alert{ID: alertID, OrgID: orgID, Status: models.AlertStatusActive, Title: "test"}
+	dbUser := &models.User{ID: userID, OrgID: orgID, Role: models.UserRoleAdmin}
+	store := &mockAlertStore{
+		alerts:    []*models.Alert{alert},
+		alertByID: map[uuid.UUID]*models.Alert{alertID: alert},
+		user:      dbUser,
+	}
+	user := &auth.SessionUser{ID: userID, CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupAlertTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/alerts", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		var resp map[string]json.RawMessage
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to unmarshal: %v", err)
+		}
+		if _, ok := resp["alerts"]; !ok {
+			t.Fatal("expected 'alerts' key")
+		}
+	})
+
+	t.Run("unauthenticated", func(t *testing.T) {
+		r := setupAlertTestRouter(store, nil)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/alerts", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("expected 401, got %d", w.Code)
+		}
+	})
+}
+
+func TestListActiveAlerts(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	dbUser := &models.User{ID: userID, OrgID: orgID, Role: models.UserRoleAdmin}
+	store := &mockAlertStore{user: dbUser}
+	user := &auth.SessionUser{ID: userID, CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupAlertTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/alerts/active", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+	})
+}
+
+func TestAlertCount(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	dbUser := &models.User{ID: userID, OrgID: orgID, Role: models.UserRoleAdmin}
+	store := &mockAlertStore{user: dbUser, activeCount: 3}
+	user := &auth.SessionUser{ID: userID, CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupAlertTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/alerts/count", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+		var resp map[string]int
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to unmarshal: %v", err)
+		}
+		if resp["count"] != 3 {
+			t.Fatalf("expected count 3, got %d", resp["count"])
+		}
+	})
+}
+
+func TestGetAlert(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	alertID := uuid.New()
+
+	alert := &models.Alert{ID: alertID, OrgID: orgID, Status: models.AlertStatusActive, Title: "test"}
+	dbUser := &models.User{ID: userID, OrgID: orgID, Role: models.UserRoleAdmin}
+	store := &mockAlertStore{
+		alertByID: map[uuid.UUID]*models.Alert{alertID: alert},
+		user:      dbUser,
+	}
+	user := &auth.SessionUser{ID: userID, CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupAlertTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/alerts/"+alertID.String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+	})
+
+	t.Run("invalid id", func(t *testing.T) {
+		r := setupAlertTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/alerts/bad-uuid", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		r := setupAlertTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/alerts/"+uuid.New().String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+
+	t.Run("wrong org", func(t *testing.T) {
+		otherUserID := uuid.New()
+		otherUser := &models.User{ID: otherUserID, OrgID: uuid.New(), Role: models.UserRoleAdmin}
+		wrongStore := &mockAlertStore{
+			alertByID: map[uuid.UUID]*models.Alert{alertID: alert},
+			user:      otherUser,
+		}
+		wrongSessionUser := &auth.SessionUser{ID: otherUserID, CurrentOrgID: uuid.New()}
+		r := setupAlertTestRouter(wrongStore, wrongSessionUser)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/alerts/"+alertID.String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+}
+
+func TestAcknowledgeAlert(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	alertID := uuid.New()
+
+	dbUser := &models.User{ID: userID, OrgID: orgID, Role: models.UserRoleAdmin}
+
+	t.Run("success", func(t *testing.T) {
+		alert := &models.Alert{ID: alertID, OrgID: orgID, Status: models.AlertStatusActive}
+		store := &mockAlertStore{
+			alertByID: map[uuid.UUID]*models.Alert{alertID: alert},
+			user:      dbUser,
+		}
+		user := &auth.SessionUser{ID: userID, CurrentOrgID: orgID}
+		r := setupAlertTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("POST", "/api/v1/alerts/"+alertID.String()+"/actions/acknowledge", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("already resolved", func(t *testing.T) {
+		alert := &models.Alert{ID: alertID, OrgID: orgID, Status: models.AlertStatusResolved}
+		store := &mockAlertStore{
+			alertByID: map[uuid.UUID]*models.Alert{alertID: alert},
+			user:      dbUser,
+		}
+		user := &auth.SessionUser{ID: userID, CurrentOrgID: orgID}
+		r := setupAlertTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("POST", "/api/v1/alerts/"+alertID.String()+"/actions/acknowledge", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		store := &mockAlertStore{
+			alertByID: map[uuid.UUID]*models.Alert{},
+			user:      dbUser,
+		}
+		user := &auth.SessionUser{ID: userID, CurrentOrgID: orgID}
+		r := setupAlertTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("POST", "/api/v1/alerts/"+uuid.New().String()+"/actions/acknowledge", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+}
+
+func TestResolveAlert(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	alertID := uuid.New()
+	dbUser := &models.User{ID: userID, OrgID: orgID, Role: models.UserRoleAdmin}
+
+	t.Run("success", func(t *testing.T) {
+		alert := &models.Alert{ID: alertID, OrgID: orgID, Status: models.AlertStatusActive}
+		store := &mockAlertStore{
+			alertByID: map[uuid.UUID]*models.Alert{alertID: alert},
+			user:      dbUser,
+		}
+		user := &auth.SessionUser{ID: userID, CurrentOrgID: orgID}
+		r := setupAlertTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("POST", "/api/v1/alerts/"+alertID.String()+"/actions/resolve", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+	})
+
+	t.Run("already resolved idempotent", func(t *testing.T) {
+		alert := &models.Alert{ID: alertID, OrgID: orgID, Status: models.AlertStatusResolved}
+		store := &mockAlertStore{
+			alertByID: map[uuid.UUID]*models.Alert{alertID: alert},
+			user:      dbUser,
+		}
+		user := &auth.SessionUser{ID: userID, CurrentOrgID: orgID}
+		r := setupAlertTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("POST", "/api/v1/alerts/"+alertID.String()+"/actions/resolve", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+	})
+}
+
+func TestListAlertRules(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	ruleID := uuid.New()
+
+	rule := &models.AlertRule{ID: ruleID, OrgID: orgID, Name: "test-rule", Type: models.AlertTypeAgentOffline}
+	dbUser := &models.User{ID: userID, OrgID: orgID, Role: models.UserRoleAdmin}
+	store := &mockAlertStore{
+		rules:    []*models.AlertRule{rule},
+		ruleByID: map[uuid.UUID]*models.AlertRule{ruleID: rule},
+		user:     dbUser,
+	}
+	user := &auth.SessionUser{ID: userID, CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupAlertTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/alert-rules", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+	})
+}
+
+func TestCreateAlertRule(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	dbUser := &models.User{ID: userID, OrgID: orgID, Role: models.UserRoleAdmin}
+	store := &mockAlertStore{
+		ruleByID: map[uuid.UUID]*models.AlertRule{},
+		user:     dbUser,
+	}
+	user := &auth.SessionUser{ID: userID, CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupAlertTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"name":"offline-rule","type":"agent_offline","enabled":true,"config":{"offline_threshold_minutes":15}}`
+		req, _ := http.NewRequest("POST", "/api/v1/alert-rules", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusCreated {
+			t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("invalid type", func(t *testing.T) {
+		r := setupAlertTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"name":"bad-rule","type":"invalid_type","enabled":true,"config":{}}`
+		req, _ := http.NewRequest("POST", "/api/v1/alert-rules", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("missing name", func(t *testing.T) {
+		r := setupAlertTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"type":"agent_offline","config":{}}`
+		req, _ := http.NewRequest("POST", "/api/v1/alert-rules", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("store error", func(t *testing.T) {
+		errStore := &mockAlertStore{
+			ruleByID:  map[uuid.UUID]*models.AlertRule{},
+			user:      dbUser,
+			createErr: errors.New("db error"),
+		}
+		r := setupAlertTestRouter(errStore, user)
+		w := httptest.NewRecorder()
+		body := `{"name":"fail","type":"agent_offline","config":{"offline_threshold_minutes":15}}`
+		req, _ := http.NewRequest("POST", "/api/v1/alert-rules", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("expected 500, got %d", w.Code)
+		}
+	})
+}
+
+func TestGetAlertRule(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	ruleID := uuid.New()
+
+	rule := &models.AlertRule{ID: ruleID, OrgID: orgID, Name: "test-rule", Type: models.AlertTypeAgentOffline}
+	dbUser := &models.User{ID: userID, OrgID: orgID, Role: models.UserRoleAdmin}
+	store := &mockAlertStore{
+		ruleByID: map[uuid.UUID]*models.AlertRule{ruleID: rule},
+		user:     dbUser,
+	}
+	user := &auth.SessionUser{ID: userID, CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupAlertTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/alert-rules/"+ruleID.String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		r := setupAlertTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/alert-rules/"+uuid.New().String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+
+	t.Run("wrong org", func(t *testing.T) {
+		otherUserID := uuid.New()
+		otherUser := &models.User{ID: otherUserID, OrgID: uuid.New(), Role: models.UserRoleAdmin}
+		wrongStore := &mockAlertStore{
+			ruleByID: map[uuid.UUID]*models.AlertRule{ruleID: rule},
+			user:     otherUser,
+		}
+		wrongSessionUser := &auth.SessionUser{ID: otherUserID, CurrentOrgID: uuid.New()}
+		r := setupAlertTestRouter(wrongStore, wrongSessionUser)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/alert-rules/"+ruleID.String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+}
+
+func TestUpdateAlertRule(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	ruleID := uuid.New()
+
+	rule := &models.AlertRule{ID: ruleID, OrgID: orgID, Name: "test-rule", Type: models.AlertTypeAgentOffline}
+	dbUser := &models.User{ID: userID, OrgID: orgID, Role: models.UserRoleAdmin}
+	store := &mockAlertStore{
+		ruleByID: map[uuid.UUID]*models.AlertRule{ruleID: rule},
+		user:     dbUser,
+	}
+	user := &auth.SessionUser{ID: userID, CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupAlertTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"name":"updated-rule"}`
+		req, _ := http.NewRequest("PUT", "/api/v1/alert-rules/"+ruleID.String(), strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		r := setupAlertTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"name":"nope"}`
+		req, _ := http.NewRequest("PUT", "/api/v1/alert-rules/"+uuid.New().String(), strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+}
+
+func TestDeleteAlertRule(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	ruleID := uuid.New()
+
+	rule := &models.AlertRule{ID: ruleID, OrgID: orgID, Name: "test-rule"}
+	dbUser := &models.User{ID: userID, OrgID: orgID, Role: models.UserRoleAdmin}
+	store := &mockAlertStore{
+		ruleByID: map[uuid.UUID]*models.AlertRule{ruleID: rule},
+		user:     dbUser,
+	}
+	user := &auth.SessionUser{ID: userID, CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupAlertTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/v1/alert-rules/"+ruleID.String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		r := setupAlertTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/v1/alert-rules/"+uuid.New().String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+
+	t.Run("store error", func(t *testing.T) {
+		errStore := &mockAlertStore{
+			ruleByID:  map[uuid.UUID]*models.AlertRule{ruleID: rule},
+			user:      dbUser,
+			deleteErr: errors.New("db error"),
+		}
+		r := setupAlertTestRouter(errStore, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/v1/alert-rules/"+ruleID.String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("expected 500, got %d", w.Code)
+		}
+	})
+}

--- a/internal/api/handlers/audit_logs_test.go
+++ b/internal/api/handlers/audit_logs_test.go
@@ -1,0 +1,247 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/MacJediWizard/keldris/internal/api/middleware"
+	"github.com/MacJediWizard/keldris/internal/auth"
+	"github.com/MacJediWizard/keldris/internal/db"
+	"github.com/MacJediWizard/keldris/internal/models"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+)
+
+type mockAuditLogStore struct {
+	logs      []*models.AuditLog
+	logByID   map[uuid.UUID]*models.AuditLog
+	count     int64
+	user      *models.User
+	createErr error
+}
+
+func (m *mockAuditLogStore) GetAuditLogsByOrgID(_ context.Context, orgID uuid.UUID, _ db.AuditLogFilter) ([]*models.AuditLog, error) {
+	var result []*models.AuditLog
+	for _, l := range m.logs {
+		if l.OrgID == orgID {
+			result = append(result, l)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockAuditLogStore) GetAuditLogByID(_ context.Context, id uuid.UUID) (*models.AuditLog, error) {
+	if l, ok := m.logByID[id]; ok {
+		return l, nil
+	}
+	return nil, errors.New("audit log not found")
+}
+
+func (m *mockAuditLogStore) CreateAuditLog(_ context.Context, _ *models.AuditLog) error {
+	return m.createErr
+}
+
+func (m *mockAuditLogStore) CountAuditLogsByOrgID(_ context.Context, _ uuid.UUID, _ db.AuditLogFilter) (int64, error) {
+	return m.count, nil
+}
+
+func (m *mockAuditLogStore) GetUserByID(_ context.Context, id uuid.UUID) (*models.User, error) {
+	if m.user != nil && m.user.ID == id {
+		return m.user, nil
+	}
+	return nil, errors.New("user not found")
+}
+
+func setupAuditLogTestRouter(store AuditLogStore, user *auth.SessionUser) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		if user != nil {
+			c.Set(string(middleware.UserContextKey), user)
+		}
+		c.Next()
+	})
+	handler := NewAuditLogsHandler(store, zerolog.Nop())
+	api := r.Group("/api/v1")
+	handler.RegisterRoutes(api)
+	return r
+}
+
+func TestListAuditLogs(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	logID := uuid.New()
+
+	auditLog := &models.AuditLog{ID: logID, OrgID: orgID, Action: models.AuditActionCreate, ResourceType: "agent", Result: models.AuditResultSuccess}
+	dbUser := &models.User{ID: userID, OrgID: orgID, Role: models.UserRoleAdmin}
+	store := &mockAuditLogStore{
+		logs:    []*models.AuditLog{auditLog},
+		logByID: map[uuid.UUID]*models.AuditLog{logID: auditLog},
+		count:   1,
+		user:    dbUser,
+	}
+	user := &auth.SessionUser{ID: userID, CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupAuditLogTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/audit-logs", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		var resp AuditLogListResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to unmarshal: %v", err)
+		}
+		if resp.TotalCount != 1 {
+			t.Fatalf("expected total_count 1, got %d", resp.TotalCount)
+		}
+	})
+
+	t.Run("with filters", func(t *testing.T) {
+		r := setupAuditLogTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/audit-logs?action=create&resource_type=agent&limit=10&offset=0", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+	})
+
+	t.Run("unauthenticated", func(t *testing.T) {
+		r := setupAuditLogTestRouter(store, nil)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/audit-logs", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("expected 401, got %d", w.Code)
+		}
+	})
+}
+
+func TestGetAuditLog(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	logID := uuid.New()
+
+	auditLog := &models.AuditLog{ID: logID, OrgID: orgID, Action: models.AuditActionCreate, ResourceType: "agent"}
+	dbUser := &models.User{ID: userID, OrgID: orgID, Role: models.UserRoleAdmin}
+	store := &mockAuditLogStore{
+		logByID: map[uuid.UUID]*models.AuditLog{logID: auditLog},
+		user:    dbUser,
+	}
+	user := &auth.SessionUser{ID: userID, CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupAuditLogTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/audit-logs/"+logID.String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+	})
+
+	t.Run("invalid id", func(t *testing.T) {
+		r := setupAuditLogTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/audit-logs/bad-uuid", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		r := setupAuditLogTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/audit-logs/"+uuid.New().String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+
+	t.Run("wrong org", func(t *testing.T) {
+		otherUserID := uuid.New()
+		otherUser := &models.User{ID: otherUserID, OrgID: uuid.New(), Role: models.UserRoleAdmin}
+		wrongStore := &mockAuditLogStore{
+			logByID: map[uuid.UUID]*models.AuditLog{logID: auditLog},
+			user:    otherUser,
+		}
+		wrongSessionUser := &auth.SessionUser{ID: otherUserID, CurrentOrgID: uuid.New()}
+		r := setupAuditLogTestRouter(wrongStore, wrongSessionUser)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/audit-logs/"+logID.String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+}
+
+func TestExportAuditLogsCSV(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	dbUser := &models.User{ID: userID, OrgID: orgID, Role: models.UserRoleAdmin}
+	store := &mockAuditLogStore{
+		logs: []*models.AuditLog{},
+		user: dbUser,
+	}
+	user := &auth.SessionUser{ID: userID, CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupAuditLogTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/audit-logs/export/csv", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+		ct := w.Header().Get("Content-Type")
+		if ct != "text/csv" {
+			t.Fatalf("expected Content-Type text/csv, got %s", ct)
+		}
+	})
+
+	t.Run("unauthenticated", func(t *testing.T) {
+		r := setupAuditLogTestRouter(store, nil)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/audit-logs/export/csv", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("expected 401, got %d", w.Code)
+		}
+	})
+}
+
+func TestExportAuditLogsJSON(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	dbUser := &models.User{ID: userID, OrgID: orgID, Role: models.UserRoleAdmin}
+	store := &mockAuditLogStore{
+		logs: []*models.AuditLog{},
+		user: dbUser,
+	}
+	user := &auth.SessionUser{ID: userID, CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupAuditLogTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/audit-logs/export/json", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+		ct := w.Header().Get("Content-Type")
+		if ct != "application/json" {
+			t.Fatalf("expected Content-Type application/json, got %s", ct)
+		}
+	})
+}

--- a/internal/api/handlers/notifications_test.go
+++ b/internal/api/handlers/notifications_test.go
@@ -1,0 +1,531 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/MacJediWizard/keldris/internal/api/middleware"
+	"github.com/MacJediWizard/keldris/internal/auth"
+	"github.com/MacJediWizard/keldris/internal/models"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+)
+
+type mockNotificationStore struct {
+	channels    []*models.NotificationChannel
+	channelByID map[uuid.UUID]*models.NotificationChannel
+	preferences []*models.NotificationPreference
+	logs        []*models.NotificationLog
+	user        *models.User
+	createChanErr error
+	updateChanErr error
+	deleteChanErr error
+	createPrefErr error
+	updatePrefErr error
+	deletePrefErr error
+}
+
+func (m *mockNotificationStore) GetUserByID(_ context.Context, id uuid.UUID) (*models.User, error) {
+	if m.user != nil && m.user.ID == id {
+		return m.user, nil
+	}
+	return nil, errors.New("user not found")
+}
+
+func (m *mockNotificationStore) GetNotificationChannelsByOrgID(_ context.Context, orgID uuid.UUID) ([]*models.NotificationChannel, error) {
+	var result []*models.NotificationChannel
+	for _, ch := range m.channels {
+		if ch.OrgID == orgID {
+			result = append(result, ch)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockNotificationStore) GetNotificationChannelByID(_ context.Context, id uuid.UUID) (*models.NotificationChannel, error) {
+	if ch, ok := m.channelByID[id]; ok {
+		return ch, nil
+	}
+	return nil, errors.New("channel not found")
+}
+
+func (m *mockNotificationStore) CreateNotificationChannel(_ context.Context, _ *models.NotificationChannel) error {
+	return m.createChanErr
+}
+
+func (m *mockNotificationStore) UpdateNotificationChannel(_ context.Context, _ *models.NotificationChannel) error {
+	return m.updateChanErr
+}
+
+func (m *mockNotificationStore) DeleteNotificationChannel(_ context.Context, _ uuid.UUID) error {
+	return m.deleteChanErr
+}
+
+func (m *mockNotificationStore) GetNotificationPreferencesByOrgID(_ context.Context, orgID uuid.UUID) ([]*models.NotificationPreference, error) {
+	var result []*models.NotificationPreference
+	for _, p := range m.preferences {
+		if p.OrgID == orgID {
+			result = append(result, p)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockNotificationStore) GetNotificationPreferencesByChannelID(_ context.Context, channelID uuid.UUID) ([]*models.NotificationPreference, error) {
+	var result []*models.NotificationPreference
+	for _, p := range m.preferences {
+		if p.ChannelID == channelID {
+			result = append(result, p)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockNotificationStore) CreateNotificationPreference(_ context.Context, _ *models.NotificationPreference) error {
+	return m.createPrefErr
+}
+
+func (m *mockNotificationStore) UpdateNotificationPreference(_ context.Context, _ *models.NotificationPreference) error {
+	return m.updatePrefErr
+}
+
+func (m *mockNotificationStore) DeleteNotificationPreference(_ context.Context, _ uuid.UUID) error {
+	return m.deletePrefErr
+}
+
+func (m *mockNotificationStore) GetNotificationLogsByOrgID(_ context.Context, _ uuid.UUID, _ int) ([]*models.NotificationLog, error) {
+	return m.logs, nil
+}
+
+func setupNotificationTestRouter(store NotificationStore, user *auth.SessionUser) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		if user != nil {
+			c.Set(string(middleware.UserContextKey), user)
+		}
+		c.Next()
+	})
+	handler := NewNotificationsHandler(store, zerolog.Nop())
+	api := r.Group("/api/v1")
+	handler.RegisterRoutes(api)
+	return r
+}
+
+func TestListChannels(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	channelID := uuid.New()
+
+	channel := &models.NotificationChannel{ID: channelID, OrgID: orgID, Name: "slack", Type: models.ChannelTypeSlack, Enabled: true}
+	dbUser := &models.User{ID: userID, OrgID: orgID, Role: models.UserRoleAdmin}
+	store := &mockNotificationStore{
+		channels:    []*models.NotificationChannel{channel},
+		channelByID: map[uuid.UUID]*models.NotificationChannel{channelID: channel},
+		user:        dbUser,
+	}
+	user := &auth.SessionUser{ID: userID, CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupNotificationTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/notifications/channels", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+		var resp map[string]json.RawMessage
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to unmarshal: %v", err)
+		}
+		if _, ok := resp["channels"]; !ok {
+			t.Fatal("expected 'channels' key")
+		}
+	})
+
+	t.Run("unauthenticated", func(t *testing.T) {
+		r := setupNotificationTestRouter(store, nil)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/notifications/channels", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("expected 401, got %d", w.Code)
+		}
+	})
+}
+
+func TestGetChannel(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	channelID := uuid.New()
+
+	channel := &models.NotificationChannel{ID: channelID, OrgID: orgID, Name: "slack"}
+	dbUser := &models.User{ID: userID, OrgID: orgID, Role: models.UserRoleAdmin}
+	store := &mockNotificationStore{
+		channelByID: map[uuid.UUID]*models.NotificationChannel{channelID: channel},
+		user:        dbUser,
+	}
+	user := &auth.SessionUser{ID: userID, CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupNotificationTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/notifications/channels/"+channelID.String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("invalid id", func(t *testing.T) {
+		r := setupNotificationTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/notifications/channels/bad-uuid", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		r := setupNotificationTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/notifications/channels/"+uuid.New().String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+
+	t.Run("wrong org", func(t *testing.T) {
+		otherUserID := uuid.New()
+		otherUser := &models.User{ID: otherUserID, OrgID: uuid.New(), Role: models.UserRoleAdmin}
+		wrongStore := &mockNotificationStore{
+			channelByID: map[uuid.UUID]*models.NotificationChannel{channelID: channel},
+			user:        otherUser,
+		}
+		wrongSessionUser := &auth.SessionUser{ID: otherUserID, CurrentOrgID: uuid.New()}
+		r := setupNotificationTestRouter(wrongStore, wrongSessionUser)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/notifications/channels/"+channelID.String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+}
+
+func TestCreateChannel(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	dbUser := &models.User{ID: userID, OrgID: orgID, Role: models.UserRoleAdmin}
+	store := &mockNotificationStore{
+		channelByID: map[uuid.UUID]*models.NotificationChannel{},
+		user:        dbUser,
+	}
+	user := &auth.SessionUser{ID: userID, CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupNotificationTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"name":"test-slack","type":"slack","config":{"webhook_url":"https://hooks.slack.com/test"}}`
+		req, _ := http.NewRequest("POST", "/api/v1/notifications/channels", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusCreated {
+			t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("missing name", func(t *testing.T) {
+		r := setupNotificationTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"type":"slack","config":{}}`
+		req, _ := http.NewRequest("POST", "/api/v1/notifications/channels", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("invalid channel type", func(t *testing.T) {
+		r := setupNotificationTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"name":"bad","type":"invalid_type","config":{}}`
+		req, _ := http.NewRequest("POST", "/api/v1/notifications/channels", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("store error", func(t *testing.T) {
+		errStore := &mockNotificationStore{
+			channelByID:   map[uuid.UUID]*models.NotificationChannel{},
+			user:          dbUser,
+			createChanErr: errors.New("db error"),
+		}
+		r := setupNotificationTestRouter(errStore, user)
+		w := httptest.NewRecorder()
+		body := `{"name":"fail","type":"slack","config":{"webhook_url":"https://x"}}`
+		req, _ := http.NewRequest("POST", "/api/v1/notifications/channels", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("expected 500, got %d", w.Code)
+		}
+	})
+}
+
+func TestUpdateChannel(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	channelID := uuid.New()
+
+	channel := &models.NotificationChannel{ID: channelID, OrgID: orgID, Name: "slack", Enabled: true}
+	dbUser := &models.User{ID: userID, OrgID: orgID, Role: models.UserRoleAdmin}
+	store := &mockNotificationStore{
+		channelByID: map[uuid.UUID]*models.NotificationChannel{channelID: channel},
+		user:        dbUser,
+	}
+	user := &auth.SessionUser{ID: userID, CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupNotificationTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"name":"updated-slack"}`
+		req, _ := http.NewRequest("PUT", "/api/v1/notifications/channels/"+channelID.String(), strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		r := setupNotificationTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"name":"nope"}`
+		req, _ := http.NewRequest("PUT", "/api/v1/notifications/channels/"+uuid.New().String(), strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+}
+
+func TestDeleteChannel(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	channelID := uuid.New()
+
+	channel := &models.NotificationChannel{ID: channelID, OrgID: orgID, Name: "slack"}
+	dbUser := &models.User{ID: userID, OrgID: orgID, Role: models.UserRoleAdmin}
+	store := &mockNotificationStore{
+		channelByID: map[uuid.UUID]*models.NotificationChannel{channelID: channel},
+		user:        dbUser,
+	}
+	user := &auth.SessionUser{ID: userID, CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupNotificationTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/v1/notifications/channels/"+channelID.String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		r := setupNotificationTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/v1/notifications/channels/"+uuid.New().String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+
+	t.Run("store error", func(t *testing.T) {
+		errStore := &mockNotificationStore{
+			channelByID:   map[uuid.UUID]*models.NotificationChannel{channelID: channel},
+			user:          dbUser,
+			deleteChanErr: errors.New("db error"),
+		}
+		r := setupNotificationTestRouter(errStore, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/v1/notifications/channels/"+channelID.String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("expected 500, got %d", w.Code)
+		}
+	})
+}
+
+func TestListPreferences(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	dbUser := &models.User{ID: userID, OrgID: orgID, Role: models.UserRoleAdmin}
+	store := &mockNotificationStore{user: dbUser}
+	user := &auth.SessionUser{ID: userID, CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupNotificationTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/notifications/preferences", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+	})
+}
+
+func TestCreatePreference(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	channelID := uuid.New()
+
+	channel := &models.NotificationChannel{ID: channelID, OrgID: orgID, Name: "slack"}
+	dbUser := &models.User{ID: userID, OrgID: orgID, Role: models.UserRoleAdmin}
+	store := &mockNotificationStore{
+		channelByID: map[uuid.UUID]*models.NotificationChannel{channelID: channel},
+		user:        dbUser,
+	}
+	user := &auth.SessionUser{ID: userID, CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupNotificationTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"channel_id":"` + channelID.String() + `","event_type":"backup_success","enabled":true}`
+		req, _ := http.NewRequest("POST", "/api/v1/notifications/preferences", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusCreated {
+			t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("invalid event type", func(t *testing.T) {
+		r := setupNotificationTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"channel_id":"` + channelID.String() + `","event_type":"invalid_event","enabled":true}`
+		req, _ := http.NewRequest("POST", "/api/v1/notifications/preferences", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("channel not found", func(t *testing.T) {
+		r := setupNotificationTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"channel_id":"` + uuid.New().String() + `","event_type":"backup_success","enabled":true}`
+		req, _ := http.NewRequest("POST", "/api/v1/notifications/preferences", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+}
+
+func TestUpdatePreference(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	prefID := uuid.New()
+
+	pref := &models.NotificationPreference{ID: prefID, OrgID: orgID, Enabled: true}
+	dbUser := &models.User{ID: userID, OrgID: orgID, Role: models.UserRoleAdmin}
+	store := &mockNotificationStore{
+		preferences: []*models.NotificationPreference{pref},
+		user:        dbUser,
+	}
+	user := &auth.SessionUser{ID: userID, CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupNotificationTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"enabled":false}`
+		req, _ := http.NewRequest("PUT", "/api/v1/notifications/preferences/"+prefID.String(), strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		r := setupNotificationTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"enabled":false}`
+		req, _ := http.NewRequest("PUT", "/api/v1/notifications/preferences/"+uuid.New().String(), strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+}
+
+func TestDeletePreference(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	prefID := uuid.New()
+
+	pref := &models.NotificationPreference{ID: prefID, OrgID: orgID, Enabled: true}
+	dbUser := &models.User{ID: userID, OrgID: orgID, Role: models.UserRoleAdmin}
+	store := &mockNotificationStore{
+		preferences: []*models.NotificationPreference{pref},
+		user:        dbUser,
+	}
+	user := &auth.SessionUser{ID: userID, CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupNotificationTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/v1/notifications/preferences/"+prefID.String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		r := setupNotificationTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/v1/notifications/preferences/"+uuid.New().String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+}
+
+func TestListLogs(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	dbUser := &models.User{ID: userID, OrgID: orgID, Role: models.UserRoleAdmin}
+	store := &mockNotificationStore{user: dbUser, logs: []*models.NotificationLog{}}
+	user := &auth.SessionUser{ID: userID, CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupNotificationTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/notifications/logs", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+	})
+}

--- a/internal/api/handlers/organizations_test.go
+++ b/internal/api/handlers/organizations_test.go
@@ -1,0 +1,885 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MacJediWizard/keldris/internal/api/middleware"
+	"github.com/MacJediWizard/keldris/internal/auth"
+	"github.com/MacJediWizard/keldris/internal/models"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+)
+
+type mockOrgStore struct {
+	orgs            []*models.Organization
+	orgByID         map[uuid.UUID]*models.Organization
+	orgBySlug       map[string]*models.Organization
+	memberships     map[string]*models.OrgMembership // key: "userID|orgID"
+	membersByOrg    map[uuid.UUID][]*models.OrgMembershipWithUser
+	membersByUser   []*models.OrgMembership
+	invitations     []*models.OrgInvitationWithDetails
+	invByToken      map[string]*models.OrgInvitation
+	user            *models.User
+	createOrgErr    error
+	updateOrgErr    error
+	deleteOrgErr    error
+	createMemberErr error
+	updateMemberErr error
+	deleteMemberErr error
+	createInvErr    error
+	deleteInvErr    error
+	acceptInvErr    error
+}
+
+func membershipKey(userID, orgID uuid.UUID) string {
+	return userID.String() + "|" + orgID.String()
+}
+
+func (m *mockOrgStore) GetOrganizationByID(_ context.Context, id uuid.UUID) (*models.Organization, error) {
+	if o, ok := m.orgByID[id]; ok {
+		return o, nil
+	}
+	return nil, errors.New("organization not found")
+}
+
+func (m *mockOrgStore) GetOrganizationBySlug(_ context.Context, slug string) (*models.Organization, error) {
+	if o, ok := m.orgBySlug[slug]; ok {
+		return o, nil
+	}
+	return nil, errors.New("organization not found")
+}
+
+func (m *mockOrgStore) CreateOrganization(_ context.Context, _ *models.Organization) error {
+	return m.createOrgErr
+}
+
+func (m *mockOrgStore) UpdateOrganization(_ context.Context, _ *models.Organization) error {
+	return m.updateOrgErr
+}
+
+func (m *mockOrgStore) DeleteOrganization(_ context.Context, _ uuid.UUID) error {
+	return m.deleteOrgErr
+}
+
+func (m *mockOrgStore) GetUserOrganizations(_ context.Context, _ uuid.UUID) ([]*models.Organization, error) {
+	return m.orgs, nil
+}
+
+func (m *mockOrgStore) GetMembershipByUserAndOrg(_ context.Context, userID, orgID uuid.UUID) (*models.OrgMembership, error) {
+	key := membershipKey(userID, orgID)
+	if mem, ok := m.memberships[key]; ok {
+		return mem, nil
+	}
+	return nil, errors.New("membership not found")
+}
+
+func (m *mockOrgStore) GetMembershipsByUserID(_ context.Context, _ uuid.UUID) ([]*models.OrgMembership, error) {
+	return m.membersByUser, nil
+}
+
+func (m *mockOrgStore) GetMembershipsByOrgID(_ context.Context, orgID uuid.UUID) ([]*models.OrgMembershipWithUser, error) {
+	if members, ok := m.membersByOrg[orgID]; ok {
+		return members, nil
+	}
+	return nil, nil
+}
+
+func (m *mockOrgStore) CreateMembership(_ context.Context, _ *models.OrgMembership) error {
+	return m.createMemberErr
+}
+
+func (m *mockOrgStore) UpdateMembership(_ context.Context, _ *models.OrgMembership) error {
+	return m.updateMemberErr
+}
+
+func (m *mockOrgStore) DeleteMembership(_ context.Context, _, _ uuid.UUID) error {
+	return m.deleteMemberErr
+}
+
+func (m *mockOrgStore) CreateInvitation(_ context.Context, _ *models.OrgInvitation) error {
+	return m.createInvErr
+}
+
+func (m *mockOrgStore) GetInvitationByToken(_ context.Context, token string) (*models.OrgInvitation, error) {
+	if inv, ok := m.invByToken[token]; ok {
+		return inv, nil
+	}
+	return nil, errors.New("invitation not found")
+}
+
+func (m *mockOrgStore) GetPendingInvitationsByOrgID(_ context.Context, _ uuid.UUID) ([]*models.OrgInvitationWithDetails, error) {
+	return m.invitations, nil
+}
+
+func (m *mockOrgStore) GetPendingInvitationsByEmail(_ context.Context, _ string) ([]*models.OrgInvitationWithDetails, error) {
+	return nil, nil
+}
+
+func (m *mockOrgStore) AcceptInvitation(_ context.Context, _ uuid.UUID) error {
+	return m.acceptInvErr
+}
+
+func (m *mockOrgStore) DeleteInvitation(_ context.Context, _ uuid.UUID) error {
+	return m.deleteInvErr
+}
+
+func (m *mockOrgStore) GetUserByID(_ context.Context, id uuid.UUID) (*models.User, error) {
+	if m.user != nil && m.user.ID == id {
+		return m.user, nil
+	}
+	return nil, errors.New("user not found")
+}
+
+func setupOrgTestRouter(store *mockOrgStore, user *auth.SessionUser) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		if user != nil {
+			c.Set(string(middleware.UserContextKey), user)
+		}
+		c.Next()
+	})
+	rbac := auth.NewRBAC(store)
+	handler := NewOrganizationsHandler(store, nil, rbac, zerolog.Nop())
+	api := r.Group("/api/v1")
+	handler.RegisterRoutes(api)
+	return r
+}
+
+func TestListOrganizations(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+
+	org := &models.Organization{ID: orgID, Name: "Test Org", Slug: "test-org"}
+
+	store := &mockOrgStore{
+		orgs:    []*models.Organization{org},
+		orgByID: map[uuid.UUID]*models.Organization{orgID: org},
+		memberships: map[string]*models.OrgMembership{
+			membershipKey(userID, orgID): {ID: uuid.New(), UserID: userID, OrgID: orgID, Role: models.OrgRoleOwner},
+		},
+	}
+	user := &auth.SessionUser{ID: userID, CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupOrgTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/organizations", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		var resp map[string]json.RawMessage
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to unmarshal: %v", err)
+		}
+		if _, ok := resp["organizations"]; !ok {
+			t.Fatal("expected 'organizations' key")
+		}
+	})
+
+	t.Run("unauthenticated", func(t *testing.T) {
+		r := setupOrgTestRouter(store, nil)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/organizations", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("expected 401, got %d", w.Code)
+		}
+	})
+}
+
+func TestCreateOrganization(t *testing.T) {
+	userID := uuid.New()
+	orgID := uuid.New()
+
+	store := &mockOrgStore{
+		orgByID:   map[uuid.UUID]*models.Organization{},
+		orgBySlug: map[string]*models.Organization{},
+		memberships: map[string]*models.OrgMembership{
+			membershipKey(userID, orgID): {ID: uuid.New(), UserID: userID, OrgID: orgID, Role: models.OrgRoleOwner},
+		},
+	}
+	user := &auth.SessionUser{ID: userID, CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupOrgTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"name":"New Org","slug":"neworg"}`
+		req, _ := http.NewRequest("POST", "/api/v1/organizations", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusCreated {
+			t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("invalid body", func(t *testing.T) {
+		r := setupOrgTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{}`
+		req, _ := http.NewRequest("POST", "/api/v1/organizations", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("slug exists", func(t *testing.T) {
+		existingOrg := &models.Organization{ID: uuid.New(), Name: "Existing", Slug: "existing"}
+		slugStore := &mockOrgStore{
+			orgByID:     map[uuid.UUID]*models.Organization{},
+			orgBySlug:   map[string]*models.Organization{"existing": existingOrg},
+			memberships: map[string]*models.OrgMembership{},
+		}
+		r := setupOrgTestRouter(slugStore, user)
+		w := httptest.NewRecorder()
+		body := `{"name":"Another","slug":"existing"}`
+		req, _ := http.NewRequest("POST", "/api/v1/organizations", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusConflict {
+			t.Fatalf("expected 409, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("unauthenticated", func(t *testing.T) {
+		r := setupOrgTestRouter(store, nil)
+		w := httptest.NewRecorder()
+		body := `{"name":"Fail","slug":"fail"}`
+		req, _ := http.NewRequest("POST", "/api/v1/organizations", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("expected 401, got %d", w.Code)
+		}
+	})
+}
+
+func TestGetCurrentOrganization(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	org := &models.Organization{ID: orgID, Name: "Current Org", Slug: "current"}
+
+	store := &mockOrgStore{
+		orgByID: map[uuid.UUID]*models.Organization{orgID: org},
+		memberships: map[string]*models.OrgMembership{
+			membershipKey(userID, orgID): {ID: uuid.New(), UserID: userID, OrgID: orgID, Role: models.OrgRoleOwner},
+		},
+	}
+
+	t.Run("success", func(t *testing.T) {
+		user := &auth.SessionUser{ID: userID, CurrentOrgID: orgID, CurrentOrgRole: "owner"}
+		r := setupOrgTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/organizations/current", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("no org selected", func(t *testing.T) {
+		noOrgUser := &auth.SessionUser{ID: userID}
+		r := setupOrgTestRouter(store, noOrgUser)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/organizations/current", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+}
+
+func TestGetOrganization(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	org := &models.Organization{ID: orgID, Name: "Test Org", Slug: "test"}
+
+	store := &mockOrgStore{
+		orgByID: map[uuid.UUID]*models.Organization{orgID: org},
+		memberships: map[string]*models.OrgMembership{
+			membershipKey(userID, orgID): {ID: uuid.New(), UserID: userID, OrgID: orgID, Role: models.OrgRoleMember},
+		},
+	}
+	user := &auth.SessionUser{ID: userID, CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupOrgTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/organizations/"+orgID.String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("invalid id", func(t *testing.T) {
+		r := setupOrgTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/organizations/bad-uuid", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("not a member", func(t *testing.T) {
+		otherUser := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: uuid.New()}
+		r := setupOrgTestRouter(store, otherUser)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/organizations/"+orgID.String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("expected 403, got %d", w.Code)
+		}
+	})
+}
+
+func TestUpdateOrganization(t *testing.T) {
+	orgID := uuid.New()
+	ownerID := uuid.New()
+	memberID := uuid.New()
+	org := &models.Organization{ID: orgID, Name: "Old Name", Slug: "oldslug"}
+
+	store := &mockOrgStore{
+		orgByID:   map[uuid.UUID]*models.Organization{orgID: org},
+		orgBySlug: map[string]*models.Organization{},
+		memberships: map[string]*models.OrgMembership{
+			membershipKey(ownerID, orgID):  {ID: uuid.New(), UserID: ownerID, OrgID: orgID, Role: models.OrgRoleOwner},
+			membershipKey(memberID, orgID): {ID: uuid.New(), UserID: memberID, OrgID: orgID, Role: models.OrgRoleMember},
+		},
+	}
+
+	t.Run("success as owner", func(t *testing.T) {
+		ownerUser := &auth.SessionUser{ID: ownerID, CurrentOrgID: orgID}
+		r := setupOrgTestRouter(store, ownerUser)
+		w := httptest.NewRecorder()
+		body := `{"name":"New Name"}`
+		req, _ := http.NewRequest("PUT", "/api/v1/organizations/"+orgID.String(), strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("permission denied for member", func(t *testing.T) {
+		memberUser := &auth.SessionUser{ID: memberID, CurrentOrgID: orgID}
+		r := setupOrgTestRouter(store, memberUser)
+		w := httptest.NewRecorder()
+		body := `{"name":"Should Fail"}`
+		req, _ := http.NewRequest("PUT", "/api/v1/organizations/"+orgID.String(), strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("invalid id", func(t *testing.T) {
+		ownerUser := &auth.SessionUser{ID: ownerID, CurrentOrgID: orgID}
+		r := setupOrgTestRouter(store, ownerUser)
+		w := httptest.NewRecorder()
+		body := `{"name":"Test"}`
+		req, _ := http.NewRequest("PUT", "/api/v1/organizations/bad-uuid", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+}
+
+func TestDeleteOrganization(t *testing.T) {
+	orgID := uuid.New()
+	ownerID := uuid.New()
+	memberID := uuid.New()
+
+	org := &models.Organization{ID: orgID, Name: "Delete Me", Slug: "deleteme"}
+
+	store := &mockOrgStore{
+		orgByID: map[uuid.UUID]*models.Organization{orgID: org},
+		memberships: map[string]*models.OrgMembership{
+			membershipKey(ownerID, orgID):  {ID: uuid.New(), UserID: ownerID, OrgID: orgID, Role: models.OrgRoleOwner},
+			membershipKey(memberID, orgID): {ID: uuid.New(), UserID: memberID, OrgID: orgID, Role: models.OrgRoleMember},
+		},
+	}
+
+	t.Run("success as owner", func(t *testing.T) {
+		ownerUser := &auth.SessionUser{ID: ownerID, CurrentOrgID: orgID}
+		r := setupOrgTestRouter(store, ownerUser)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/v1/organizations/"+orgID.String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("permission denied for member", func(t *testing.T) {
+		memberUser := &auth.SessionUser{ID: memberID, CurrentOrgID: orgID}
+		r := setupOrgTestRouter(store, memberUser)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/v1/organizations/"+orgID.String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("invalid id", func(t *testing.T) {
+		ownerUser := &auth.SessionUser{ID: ownerID, CurrentOrgID: orgID}
+		r := setupOrgTestRouter(store, ownerUser)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/v1/organizations/bad-uuid", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("store error", func(t *testing.T) {
+		errStore := &mockOrgStore{
+			orgByID: map[uuid.UUID]*models.Organization{orgID: org},
+			memberships: map[string]*models.OrgMembership{
+				membershipKey(ownerID, orgID): {ID: uuid.New(), UserID: ownerID, OrgID: orgID, Role: models.OrgRoleOwner},
+			},
+			deleteOrgErr: errors.New("db error"),
+		}
+		ownerUser := &auth.SessionUser{ID: ownerID, CurrentOrgID: orgID}
+		r := setupOrgTestRouter(errStore, ownerUser)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/v1/organizations/"+orgID.String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("expected 500, got %d", w.Code)
+		}
+	})
+}
+
+func TestListMembers(t *testing.T) {
+	orgID := uuid.New()
+	ownerID := uuid.New()
+
+	store := &mockOrgStore{
+		orgByID: map[uuid.UUID]*models.Organization{},
+		memberships: map[string]*models.OrgMembership{
+			membershipKey(ownerID, orgID): {ID: uuid.New(), UserID: ownerID, OrgID: orgID, Role: models.OrgRoleOwner},
+		},
+		membersByOrg: map[uuid.UUID][]*models.OrgMembershipWithUser{
+			orgID: {{ID: uuid.New(), UserID: ownerID, OrgID: orgID, Role: models.OrgRoleOwner, Email: "owner@test.com"}},
+		},
+	}
+
+	t.Run("success", func(t *testing.T) {
+		user := &auth.SessionUser{ID: ownerID, CurrentOrgID: orgID}
+		r := setupOrgTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/organizations/"+orgID.String()+"/members", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("permission denied", func(t *testing.T) {
+		nonMember := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: uuid.New()}
+		r := setupOrgTestRouter(store, nonMember)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/organizations/"+orgID.String()+"/members", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("expected 403, got %d", w.Code)
+		}
+	})
+
+	t.Run("invalid id", func(t *testing.T) {
+		user := &auth.SessionUser{ID: ownerID, CurrentOrgID: orgID}
+		r := setupOrgTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/organizations/bad-uuid/members", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+}
+
+func TestRemoveMember(t *testing.T) {
+	orgID := uuid.New()
+	ownerID := uuid.New()
+	memberID := uuid.New()
+
+	store := &mockOrgStore{
+		orgByID: map[uuid.UUID]*models.Organization{},
+		memberships: map[string]*models.OrgMembership{
+			membershipKey(ownerID, orgID):  {ID: uuid.New(), UserID: ownerID, OrgID: orgID, Role: models.OrgRoleOwner},
+			membershipKey(memberID, orgID): {ID: uuid.New(), UserID: memberID, OrgID: orgID, Role: models.OrgRoleMember},
+		},
+		membersByOrg: map[uuid.UUID][]*models.OrgMembershipWithUser{
+			orgID: {
+				{ID: uuid.New(), UserID: ownerID, OrgID: orgID, Role: models.OrgRoleOwner},
+				{ID: uuid.New(), UserID: memberID, OrgID: orgID, Role: models.OrgRoleMember},
+			},
+		},
+	}
+	ownerUser := &auth.SessionUser{ID: ownerID, CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupOrgTestRouter(store, ownerUser)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/v1/organizations/"+orgID.String()+"/members/"+memberID.String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("cannot remove last owner", func(t *testing.T) {
+		r := setupOrgTestRouter(store, ownerUser)
+		w := httptest.NewRecorder()
+		// Another owner user trying to remove the only owner
+		// The owner is trying to leave (self-removal), and they are the last owner
+		req, _ := http.NewRequest("DELETE", "/api/v1/organizations/"+orgID.String()+"/members/"+ownerID.String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("invalid org id", func(t *testing.T) {
+		r := setupOrgTestRouter(store, ownerUser)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/v1/organizations/bad-uuid/members/"+memberID.String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("invalid user id", func(t *testing.T) {
+		r := setupOrgTestRouter(store, ownerUser)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/v1/organizations/"+orgID.String()+"/members/bad-uuid", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+}
+
+func TestListInvitations(t *testing.T) {
+	orgID := uuid.New()
+	ownerID := uuid.New()
+
+	store := &mockOrgStore{
+		orgByID: map[uuid.UUID]*models.Organization{},
+		memberships: map[string]*models.OrgMembership{
+			membershipKey(ownerID, orgID): {ID: uuid.New(), UserID: ownerID, OrgID: orgID, Role: models.OrgRoleOwner},
+		},
+		invitations: []*models.OrgInvitationWithDetails{},
+	}
+
+	t.Run("success", func(t *testing.T) {
+		user := &auth.SessionUser{ID: ownerID, CurrentOrgID: orgID}
+		r := setupOrgTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/organizations/"+orgID.String()+"/invitations", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("permission denied", func(t *testing.T) {
+		nonMember := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: uuid.New()}
+		r := setupOrgTestRouter(store, nonMember)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/organizations/"+orgID.String()+"/invitations", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("expected 403, got %d", w.Code)
+		}
+	})
+}
+
+func TestCreateInvitation(t *testing.T) {
+	orgID := uuid.New()
+	ownerID := uuid.New()
+
+	store := &mockOrgStore{
+		orgByID: map[uuid.UUID]*models.Organization{},
+		memberships: map[string]*models.OrgMembership{
+			membershipKey(ownerID, orgID): {ID: uuid.New(), UserID: ownerID, OrgID: orgID, Role: models.OrgRoleOwner},
+		},
+	}
+
+	t.Run("success", func(t *testing.T) {
+		user := &auth.SessionUser{ID: ownerID, CurrentOrgID: orgID}
+		r := setupOrgTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"email":"invite@test.com","role":"member"}`
+		req, _ := http.NewRequest("POST", "/api/v1/organizations/"+orgID.String()+"/invitations", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusCreated {
+			t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("permission denied", func(t *testing.T) {
+		nonMember := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: uuid.New()}
+		r := setupOrgTestRouter(store, nonMember)
+		w := httptest.NewRecorder()
+		body := `{"email":"invite@test.com","role":"member"}`
+		req, _ := http.NewRequest("POST", "/api/v1/organizations/"+orgID.String()+"/invitations", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("expected 403, got %d", w.Code)
+		}
+	})
+
+	t.Run("invalid body", func(t *testing.T) {
+		user := &auth.SessionUser{ID: ownerID, CurrentOrgID: orgID}
+		r := setupOrgTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{}`
+		req, _ := http.NewRequest("POST", "/api/v1/organizations/"+orgID.String()+"/invitations", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+}
+
+func TestDeleteInvitation(t *testing.T) {
+	orgID := uuid.New()
+	ownerID := uuid.New()
+	invID := uuid.New()
+
+	store := &mockOrgStore{
+		orgByID: map[uuid.UUID]*models.Organization{},
+		memberships: map[string]*models.OrgMembership{
+			membershipKey(ownerID, orgID): {ID: uuid.New(), UserID: ownerID, OrgID: orgID, Role: models.OrgRoleOwner},
+		},
+	}
+
+	t.Run("success", func(t *testing.T) {
+		user := &auth.SessionUser{ID: ownerID, CurrentOrgID: orgID}
+		r := setupOrgTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/v1/organizations/"+orgID.String()+"/invitations/"+invID.String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("invalid org id", func(t *testing.T) {
+		user := &auth.SessionUser{ID: ownerID, CurrentOrgID: orgID}
+		r := setupOrgTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/v1/organizations/bad-uuid/invitations/"+invID.String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("invalid invitation id", func(t *testing.T) {
+		user := &auth.SessionUser{ID: ownerID, CurrentOrgID: orgID}
+		r := setupOrgTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/v1/organizations/"+orgID.String()+"/invitations/bad-uuid", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("permission denied", func(t *testing.T) {
+		nonMember := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: uuid.New()}
+		r := setupOrgTestRouter(store, nonMember)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/v1/organizations/"+orgID.String()+"/invitations/"+invID.String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("expected 403, got %d", w.Code)
+		}
+	})
+}
+
+func TestAcceptInvitation(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	invID := uuid.New()
+
+	inv := &models.OrgInvitation{
+		ID:        invID,
+		OrgID:     orgID,
+		Email:     "user@test.com",
+		Role:      models.OrgRoleMember,
+		Token:     "valid-token",
+		InvitedBy: uuid.New(),
+		ExpiresAt: time.Now().Add(24 * time.Hour),
+	}
+
+	org := &models.Organization{ID: orgID, Name: "Test", Slug: "test"}
+
+	store := &mockOrgStore{
+		orgByID:     map[uuid.UUID]*models.Organization{orgID: org},
+		memberships: map[string]*models.OrgMembership{},
+		invByToken:  map[string]*models.OrgInvitation{"valid-token": inv},
+	}
+	user := &auth.SessionUser{ID: userID, Email: "user@test.com", CurrentOrgID: uuid.New()}
+
+	t.Run("not found", func(t *testing.T) {
+		r := setupOrgTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"token":"invalid-token"}`
+		req, _ := http.NewRequest("POST", "/api/v1/invitations/accept", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("wrong email", func(t *testing.T) {
+		wrongEmailUser := &auth.SessionUser{ID: userID, Email: "other@test.com", CurrentOrgID: uuid.New()}
+		r := setupOrgTestRouter(store, wrongEmailUser)
+		w := httptest.NewRecorder()
+		body := `{"token":"valid-token"}`
+		req, _ := http.NewRequest("POST", "/api/v1/invitations/accept", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("invalid body", func(t *testing.T) {
+		r := setupOrgTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{}`
+		req, _ := http.NewRequest("POST", "/api/v1/invitations/accept", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("unauthenticated", func(t *testing.T) {
+		r := setupOrgTestRouter(store, nil)
+		w := httptest.NewRecorder()
+		body := `{"token":"valid-token"}`
+		req, _ := http.NewRequest("POST", "/api/v1/invitations/accept", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("expected 401, got %d", w.Code)
+		}
+	})
+
+	t.Run("expired invitation", func(t *testing.T) {
+		expiredInv := &models.OrgInvitation{
+			ID:        uuid.New(),
+			OrgID:     orgID,
+			Email:     "user@test.com",
+			Role:      models.OrgRoleMember,
+			Token:     "expired-token",
+			InvitedBy: uuid.New(),
+			ExpiresAt: time.Now().Add(-24 * time.Hour),
+		}
+		expiredStore := &mockOrgStore{
+			orgByID:     map[uuid.UUID]*models.Organization{orgID: org},
+			memberships: map[string]*models.OrgMembership{},
+			invByToken:  map[string]*models.OrgInvitation{"expired-token": expiredInv},
+		}
+		r := setupOrgTestRouter(expiredStore, user)
+		w := httptest.NewRecorder()
+		body := `{"token":"expired-token"}`
+		req, _ := http.NewRequest("POST", "/api/v1/invitations/accept", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusGone {
+			t.Fatalf("expected 410, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+}
+
+func TestUpdateMember(t *testing.T) {
+	orgID := uuid.New()
+	ownerID := uuid.New()
+	targetID := uuid.New()
+
+	store := &mockOrgStore{
+		orgByID: map[uuid.UUID]*models.Organization{},
+		memberships: map[string]*models.OrgMembership{
+			membershipKey(ownerID, orgID):  {ID: uuid.New(), UserID: ownerID, OrgID: orgID, Role: models.OrgRoleOwner},
+			membershipKey(targetID, orgID): {ID: uuid.New(), UserID: targetID, OrgID: orgID, Role: models.OrgRoleMember},
+		},
+	}
+	ownerUser := &auth.SessionUser{ID: ownerID, CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupOrgTestRouter(store, ownerUser)
+		w := httptest.NewRecorder()
+		body := `{"role":"admin"}`
+		req, _ := http.NewRequest("PUT", "/api/v1/organizations/"+orgID.String()+"/members/"+targetID.String(), strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("invalid body", func(t *testing.T) {
+		r := setupOrgTestRouter(store, ownerUser)
+		w := httptest.NewRecorder()
+		body := `{}`
+		req, _ := http.NewRequest("PUT", "/api/v1/organizations/"+orgID.String()+"/members/"+targetID.String(), strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("invalid org id", func(t *testing.T) {
+		r := setupOrgTestRouter(store, ownerUser)
+		w := httptest.NewRecorder()
+		body := `{"role":"admin"}`
+		req, _ := http.NewRequest("PUT", "/api/v1/organizations/bad-uuid/members/"+targetID.String(), strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("invalid user id", func(t *testing.T) {
+		r := setupOrgTestRouter(store, ownerUser)
+		w := httptest.NewRecorder()
+		body := `{"role":"admin"}`
+		req, _ := http.NewRequest("PUT", "/api/v1/organizations/"+orgID.String()+"/members/bad-uuid", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+}

--- a/internal/api/handlers/policies_test.go
+++ b/internal/api/handlers/policies_test.go
@@ -1,0 +1,446 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/MacJediWizard/keldris/internal/api/middleware"
+	"github.com/MacJediWizard/keldris/internal/auth"
+	"github.com/MacJediWizard/keldris/internal/models"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+)
+
+type mockPolicyStore struct {
+	policies     []*models.Policy
+	policyByID   map[uuid.UUID]*models.Policy
+	schedules    []*models.Schedule
+	agents       []*models.Agent
+	agentByID    map[uuid.UUID]*models.Agent
+	repo         *models.Repository
+	createErr    error
+	updateErr    error
+	deleteErr    error
+	createSchedErr error
+}
+
+func (m *mockPolicyStore) GetPoliciesByOrgID(_ context.Context, orgID uuid.UUID) ([]*models.Policy, error) {
+	var result []*models.Policy
+	for _, p := range m.policies {
+		if p.OrgID == orgID {
+			result = append(result, p)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockPolicyStore) GetPolicyByID(_ context.Context, id uuid.UUID) (*models.Policy, error) {
+	if p, ok := m.policyByID[id]; ok {
+		return p, nil
+	}
+	return nil, errors.New("policy not found")
+}
+
+func (m *mockPolicyStore) CreatePolicy(_ context.Context, _ *models.Policy) error {
+	return m.createErr
+}
+
+func (m *mockPolicyStore) UpdatePolicy(_ context.Context, _ *models.Policy) error {
+	return m.updateErr
+}
+
+func (m *mockPolicyStore) DeletePolicy(_ context.Context, _ uuid.UUID) error {
+	return m.deleteErr
+}
+
+func (m *mockPolicyStore) GetSchedulesByPolicyID(_ context.Context, _ uuid.UUID) ([]*models.Schedule, error) {
+	return m.schedules, nil
+}
+
+func (m *mockPolicyStore) GetAgentByID(_ context.Context, id uuid.UUID) (*models.Agent, error) {
+	if a, ok := m.agentByID[id]; ok {
+		return a, nil
+	}
+	return nil, errors.New("agent not found")
+}
+
+func (m *mockPolicyStore) GetAgentsByOrgID(_ context.Context, orgID uuid.UUID) ([]*models.Agent, error) {
+	var result []*models.Agent
+	for _, a := range m.agents {
+		if a.OrgID == orgID {
+			result = append(result, a)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockPolicyStore) GetRepositoryByID(_ context.Context, id uuid.UUID) (*models.Repository, error) {
+	if m.repo != nil && m.repo.ID == id {
+		return m.repo, nil
+	}
+	return nil, errors.New("repository not found")
+}
+
+func (m *mockPolicyStore) CreateSchedule(_ context.Context, _ *models.Schedule) error {
+	return m.createSchedErr
+}
+
+func setupPolicyTestRouter(store PolicyStore, user *auth.SessionUser) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		if user != nil {
+			c.Set(string(middleware.UserContextKey), user)
+		}
+		c.Next()
+	})
+	handler := NewPoliciesHandler(store, zerolog.Nop())
+	api := r.Group("/api/v1")
+	handler.RegisterRoutes(api)
+	return r
+}
+
+func TestListPolicies(t *testing.T) {
+	orgID := uuid.New()
+	policyID := uuid.New()
+	policy := &models.Policy{ID: policyID, OrgID: orgID, Name: "default"}
+	store := &mockPolicyStore{
+		policies:   []*models.Policy{policy},
+		policyByID: map[uuid.UUID]*models.Policy{policyID: policy},
+	}
+	user := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupPolicyTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/policies", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+		var resp map[string]json.RawMessage
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to unmarshal: %v", err)
+		}
+		if _, ok := resp["policies"]; !ok {
+			t.Fatal("expected 'policies' key")
+		}
+	})
+
+	t.Run("no org", func(t *testing.T) {
+		noOrgUser := &auth.SessionUser{ID: uuid.New()}
+		r := setupPolicyTestRouter(store, noOrgUser)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/policies", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("unauthenticated", func(t *testing.T) {
+		r := setupPolicyTestRouter(store, nil)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/policies", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("expected 401, got %d", w.Code)
+		}
+	})
+}
+
+func TestGetPolicy(t *testing.T) {
+	orgID := uuid.New()
+	policyID := uuid.New()
+	policy := &models.Policy{ID: policyID, OrgID: orgID, Name: "default"}
+	store := &mockPolicyStore{
+		policyByID: map[uuid.UUID]*models.Policy{policyID: policy},
+	}
+	user := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupPolicyTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/policies/"+policyID.String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+	})
+
+	t.Run("invalid id", func(t *testing.T) {
+		r := setupPolicyTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/policies/bad-uuid", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		r := setupPolicyTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/policies/"+uuid.New().String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+
+	t.Run("wrong org", func(t *testing.T) {
+		wrongUser := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: uuid.New()}
+		r := setupPolicyTestRouter(store, wrongUser)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/policies/"+policyID.String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+}
+
+func TestCreatePolicy(t *testing.T) {
+	orgID := uuid.New()
+	store := &mockPolicyStore{policyByID: map[uuid.UUID]*models.Policy{}}
+	user := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupPolicyTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"name":"daily-backup","cron_expression":"0 2 * * *","paths":["/home"]}`
+		req, _ := http.NewRequest("POST", "/api/v1/policies", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusCreated {
+			t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("missing name", func(t *testing.T) {
+		r := setupPolicyTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"cron_expression":"0 2 * * *"}`
+		req, _ := http.NewRequest("POST", "/api/v1/policies", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("store error", func(t *testing.T) {
+		errStore := &mockPolicyStore{policyByID: map[uuid.UUID]*models.Policy{}, createErr: errors.New("db error")}
+		r := setupPolicyTestRouter(errStore, user)
+		w := httptest.NewRecorder()
+		body := `{"name":"fail"}`
+		req, _ := http.NewRequest("POST", "/api/v1/policies", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("expected 500, got %d", w.Code)
+		}
+	})
+}
+
+func TestUpdatePolicy(t *testing.T) {
+	orgID := uuid.New()
+	policyID := uuid.New()
+	policy := &models.Policy{ID: policyID, OrgID: orgID, Name: "default"}
+	store := &mockPolicyStore{
+		policyByID: map[uuid.UUID]*models.Policy{policyID: policy},
+	}
+	user := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupPolicyTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"name":"updated"}`
+		req, _ := http.NewRequest("PUT", "/api/v1/policies/"+policyID.String(), strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		r := setupPolicyTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"name":"nope"}`
+		req, _ := http.NewRequest("PUT", "/api/v1/policies/"+uuid.New().String(), strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+
+	t.Run("wrong org", func(t *testing.T) {
+		wrongUser := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: uuid.New()}
+		r := setupPolicyTestRouter(store, wrongUser)
+		w := httptest.NewRecorder()
+		body := `{"name":"nope"}`
+		req, _ := http.NewRequest("PUT", "/api/v1/policies/"+policyID.String(), strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+}
+
+func TestDeletePolicy(t *testing.T) {
+	orgID := uuid.New()
+	policyID := uuid.New()
+	policy := &models.Policy{ID: policyID, OrgID: orgID, Name: "default"}
+	store := &mockPolicyStore{
+		policyByID: map[uuid.UUID]*models.Policy{policyID: policy},
+	}
+	user := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupPolicyTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/v1/policies/"+policyID.String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		r := setupPolicyTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/v1/policies/"+uuid.New().String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+
+	t.Run("store error", func(t *testing.T) {
+		errStore := &mockPolicyStore{
+			policyByID: map[uuid.UUID]*models.Policy{policyID: policy},
+			deleteErr:  errors.New("db error"),
+		}
+		r := setupPolicyTestRouter(errStore, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/v1/policies/"+policyID.String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("expected 500, got %d", w.Code)
+		}
+	})
+}
+
+func TestPolicyListSchedules(t *testing.T) {
+	orgID := uuid.New()
+	policyID := uuid.New()
+	policy := &models.Policy{ID: policyID, OrgID: orgID, Name: "default"}
+	store := &mockPolicyStore{
+		policyByID: map[uuid.UUID]*models.Policy{policyID: policy},
+		schedules:  []*models.Schedule{},
+	}
+	user := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupPolicyTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/policies/"+policyID.String()+"/schedules", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+	})
+
+	t.Run("policy not found", func(t *testing.T) {
+		r := setupPolicyTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/policies/"+uuid.New().String()+"/schedules", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+}
+
+func TestApplyPolicy(t *testing.T) {
+	orgID := uuid.New()
+	policyID := uuid.New()
+	agentID := uuid.New()
+	repoID := uuid.New()
+
+	policy := &models.Policy{ID: policyID, OrgID: orgID, Name: "daily", CronExpression: "0 2 * * *", Paths: []string{"/data"}}
+	agent := &models.Agent{ID: agentID, OrgID: orgID, Hostname: "server-1"}
+	repo := &models.Repository{ID: repoID, OrgID: orgID, Name: "s3-backup", Type: models.RepositoryTypeS3}
+
+	store := &mockPolicyStore{
+		policyByID: map[uuid.UUID]*models.Policy{policyID: policy},
+		agentByID:  map[uuid.UUID]*models.Agent{agentID: agent},
+		agents:     []*models.Agent{agent},
+		repo:       repo,
+	}
+	user := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupPolicyTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"agent_ids":["` + agentID.String() + `"],"repository_id":"` + repoID.String() + `"}`
+		req, _ := http.NewRequest("POST", "/api/v1/policies/"+policyID.String()+"/apply", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusCreated {
+			t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+		}
+		var resp ApplyPolicyResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to unmarshal: %v", err)
+		}
+		if resp.SchedulesCreated != 1 {
+			t.Fatalf("expected 1 schedule created, got %d", resp.SchedulesCreated)
+		}
+	})
+
+	t.Run("missing body", func(t *testing.T) {
+		r := setupPolicyTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{}`
+		req, _ := http.NewRequest("POST", "/api/v1/policies/"+policyID.String()+"/apply", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("policy not found", func(t *testing.T) {
+		r := setupPolicyTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"agent_ids":["` + agentID.String() + `"],"repository_id":"` + repoID.String() + `"}`
+		req, _ := http.NewRequest("POST", "/api/v1/policies/"+uuid.New().String()+"/apply", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+
+	t.Run("repo not found", func(t *testing.T) {
+		r := setupPolicyTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"agent_ids":["` + agentID.String() + `"],"repository_id":"` + uuid.New().String() + `"}`
+		req, _ := http.NewRequest("POST", "/api/v1/policies/"+policyID.String()+"/apply", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+}

--- a/internal/api/handlers/reports_test.go
+++ b/internal/api/handlers/reports_test.go
@@ -1,0 +1,450 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MacJediWizard/keldris/internal/api/middleware"
+	"github.com/MacJediWizard/keldris/internal/auth"
+	"github.com/MacJediWizard/keldris/internal/models"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+)
+
+type mockReportStore struct {
+	schedules    []*models.ReportSchedule
+	scheduleByID map[uuid.UUID]*models.ReportSchedule
+	history      []*models.ReportHistory
+	historyByID  map[uuid.UUID]*models.ReportHistory
+	user         *models.User
+	createErr    error
+	updateErr    error
+	deleteErr    error
+}
+
+func (m *mockReportStore) GetUserByID(_ context.Context, id uuid.UUID) (*models.User, error) {
+	if m.user != nil && m.user.ID == id {
+		return m.user, nil
+	}
+	return nil, errors.New("user not found")
+}
+
+func (m *mockReportStore) GetReportSchedulesByOrgID(_ context.Context, orgID uuid.UUID) ([]*models.ReportSchedule, error) {
+	var result []*models.ReportSchedule
+	for _, s := range m.schedules {
+		if s.OrgID == orgID {
+			result = append(result, s)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockReportStore) GetReportScheduleByID(_ context.Context, id uuid.UUID) (*models.ReportSchedule, error) {
+	if s, ok := m.scheduleByID[id]; ok {
+		return s, nil
+	}
+	return nil, errors.New("report schedule not found")
+}
+
+func (m *mockReportStore) CreateReportSchedule(_ context.Context, _ *models.ReportSchedule) error {
+	return m.createErr
+}
+
+func (m *mockReportStore) UpdateReportSchedule(_ context.Context, _ *models.ReportSchedule) error {
+	return m.updateErr
+}
+
+func (m *mockReportStore) DeleteReportSchedule(_ context.Context, _ uuid.UUID) error {
+	return m.deleteErr
+}
+
+func (m *mockReportStore) GetReportHistoryByOrgID(_ context.Context, orgID uuid.UUID, _ int) ([]*models.ReportHistory, error) {
+	var result []*models.ReportHistory
+	for _, h := range m.history {
+		if h.OrgID == orgID {
+			result = append(result, h)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockReportStore) GetReportHistoryByID(_ context.Context, id uuid.UUID) (*models.ReportHistory, error) {
+	if h, ok := m.historyByID[id]; ok {
+		return h, nil
+	}
+	return nil, errors.New("report history not found")
+}
+
+func setupReportTestRouter(store ReportStore, user *auth.SessionUser) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		if user != nil {
+			c.Set(string(middleware.UserContextKey), user)
+		}
+		c.Next()
+	})
+	// Pass nil scheduler - basic CRUD tests don't need it
+	handler := NewReportsHandler(store, nil, zerolog.Nop())
+	api := r.Group("/api/v1")
+	handler.RegisterRoutes(api)
+	return r
+}
+
+func TestListReportSchedules(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	scheduleID := uuid.New()
+
+	schedule := &models.ReportSchedule{
+		ID:         scheduleID,
+		OrgID:      orgID,
+		Name:       "weekly-report",
+		Frequency:  models.ReportFrequencyWeekly,
+		Recipients: []string{"admin@example.com"},
+	}
+	dbUser := &models.User{ID: userID, OrgID: orgID, Role: models.UserRoleAdmin}
+	store := &mockReportStore{
+		schedules:    []*models.ReportSchedule{schedule},
+		scheduleByID: map[uuid.UUID]*models.ReportSchedule{scheduleID: schedule},
+		user:         dbUser,
+	}
+	user := &auth.SessionUser{ID: userID, CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupReportTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/reports/schedules", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+		var resp map[string]json.RawMessage
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to unmarshal: %v", err)
+		}
+		if _, ok := resp["schedules"]; !ok {
+			t.Fatal("expected 'schedules' key")
+		}
+	})
+
+	t.Run("unauthenticated", func(t *testing.T) {
+		r := setupReportTestRouter(store, nil)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/reports/schedules", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("expected 401, got %d", w.Code)
+		}
+	})
+}
+
+func TestGetReportSchedule(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	scheduleID := uuid.New()
+
+	schedule := &models.ReportSchedule{ID: scheduleID, OrgID: orgID, Name: "weekly-report"}
+	dbUser := &models.User{ID: userID, OrgID: orgID, Role: models.UserRoleAdmin}
+	store := &mockReportStore{
+		scheduleByID: map[uuid.UUID]*models.ReportSchedule{scheduleID: schedule},
+		user:         dbUser,
+	}
+	user := &auth.SessionUser{ID: userID, CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupReportTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/reports/schedules/"+scheduleID.String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+	})
+
+	t.Run("invalid id", func(t *testing.T) {
+		r := setupReportTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/reports/schedules/bad-uuid", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		r := setupReportTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/reports/schedules/"+uuid.New().String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+
+	t.Run("wrong org", func(t *testing.T) {
+		otherUserID := uuid.New()
+		otherUser := &models.User{ID: otherUserID, OrgID: uuid.New(), Role: models.UserRoleAdmin}
+		wrongStore := &mockReportStore{
+			scheduleByID: map[uuid.UUID]*models.ReportSchedule{scheduleID: schedule},
+			user:         otherUser,
+		}
+		wrongSessionUser := &auth.SessionUser{ID: otherUserID, CurrentOrgID: uuid.New()}
+		r := setupReportTestRouter(wrongStore, wrongSessionUser)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/reports/schedules/"+scheduleID.String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+}
+
+func TestCreateReportSchedule(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	dbUser := &models.User{ID: userID, OrgID: orgID, Role: models.UserRoleAdmin}
+	store := &mockReportStore{
+		scheduleByID: map[uuid.UUID]*models.ReportSchedule{},
+		user:         dbUser,
+	}
+	user := &auth.SessionUser{ID: userID, CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupReportTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"name":"daily-report","frequency":"daily","recipients":["admin@example.com"]}`
+		req, _ := http.NewRequest("POST", "/api/v1/reports/schedules", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusCreated {
+			t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("missing name", func(t *testing.T) {
+		r := setupReportTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"frequency":"daily","recipients":["a@b.com"]}`
+		req, _ := http.NewRequest("POST", "/api/v1/reports/schedules", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("invalid frequency", func(t *testing.T) {
+		r := setupReportTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"name":"bad","frequency":"hourly","recipients":["a@b.com"]}`
+		req, _ := http.NewRequest("POST", "/api/v1/reports/schedules", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("store error", func(t *testing.T) {
+		errStore := &mockReportStore{
+			scheduleByID: map[uuid.UUID]*models.ReportSchedule{},
+			user:         dbUser,
+			createErr:    errors.New("db error"),
+		}
+		r := setupReportTestRouter(errStore, user)
+		w := httptest.NewRecorder()
+		body := `{"name":"fail","frequency":"daily","recipients":["a@b.com"]}`
+		req, _ := http.NewRequest("POST", "/api/v1/reports/schedules", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("expected 500, got %d", w.Code)
+		}
+	})
+}
+
+func TestUpdateReportSchedule(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	scheduleID := uuid.New()
+
+	schedule := &models.ReportSchedule{ID: scheduleID, OrgID: orgID, Name: "weekly-report", Frequency: models.ReportFrequencyWeekly}
+	dbUser := &models.User{ID: userID, OrgID: orgID, Role: models.UserRoleAdmin}
+	store := &mockReportStore{
+		scheduleByID: map[uuid.UUID]*models.ReportSchedule{scheduleID: schedule},
+		user:         dbUser,
+	}
+	user := &auth.SessionUser{ID: userID, CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupReportTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"name":"updated-report"}`
+		req, _ := http.NewRequest("PUT", "/api/v1/reports/schedules/"+scheduleID.String(), strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		r := setupReportTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"name":"nope"}`
+		req, _ := http.NewRequest("PUT", "/api/v1/reports/schedules/"+uuid.New().String(), strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+
+	t.Run("wrong org", func(t *testing.T) {
+		otherUserID := uuid.New()
+		otherUser := &models.User{ID: otherUserID, OrgID: uuid.New(), Role: models.UserRoleAdmin}
+		wrongStore := &mockReportStore{
+			scheduleByID: map[uuid.UUID]*models.ReportSchedule{scheduleID: schedule},
+			user:         otherUser,
+		}
+		wrongSessionUser := &auth.SessionUser{ID: otherUserID, CurrentOrgID: uuid.New()}
+		r := setupReportTestRouter(wrongStore, wrongSessionUser)
+		w := httptest.NewRecorder()
+		body := `{"name":"nope"}`
+		req, _ := http.NewRequest("PUT", "/api/v1/reports/schedules/"+scheduleID.String(), strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+}
+
+func TestDeleteReportSchedule(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	scheduleID := uuid.New()
+
+	schedule := &models.ReportSchedule{ID: scheduleID, OrgID: orgID, Name: "weekly-report"}
+	dbUser := &models.User{ID: userID, OrgID: orgID, Role: models.UserRoleAdmin}
+	store := &mockReportStore{
+		scheduleByID: map[uuid.UUID]*models.ReportSchedule{scheduleID: schedule},
+		user:         dbUser,
+	}
+	user := &auth.SessionUser{ID: userID, CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupReportTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/v1/reports/schedules/"+scheduleID.String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		r := setupReportTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/v1/reports/schedules/"+uuid.New().String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+
+	t.Run("store error", func(t *testing.T) {
+		errStore := &mockReportStore{
+			scheduleByID: map[uuid.UUID]*models.ReportSchedule{scheduleID: schedule},
+			user:         dbUser,
+			deleteErr:    errors.New("db error"),
+		}
+		r := setupReportTestRouter(errStore, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/v1/reports/schedules/"+scheduleID.String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("expected 500, got %d", w.Code)
+		}
+	})
+}
+
+func TestListReportHistory(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	dbUser := &models.User{ID: userID, OrgID: orgID, Role: models.UserRoleAdmin}
+	store := &mockReportStore{
+		history: []*models.ReportHistory{},
+		user:    dbUser,
+	}
+	user := &auth.SessionUser{ID: userID, CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupReportTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/reports/history", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+	})
+}
+
+func TestGetReportHistoryEntry(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	historyID := uuid.New()
+
+	entry := &models.ReportHistory{ID: historyID, OrgID: orgID, ReportType: "daily", PeriodStart: time.Now(), PeriodEnd: time.Now()}
+	dbUser := &models.User{ID: userID, OrgID: orgID, Role: models.UserRoleAdmin}
+	store := &mockReportStore{
+		historyByID: map[uuid.UUID]*models.ReportHistory{historyID: entry},
+		user:        dbUser,
+	}
+	user := &auth.SessionUser{ID: userID, CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupReportTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/reports/history/"+historyID.String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		r := setupReportTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/reports/history/"+uuid.New().String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+
+	t.Run("wrong org", func(t *testing.T) {
+		otherUserID := uuid.New()
+		otherUser := &models.User{ID: otherUserID, OrgID: uuid.New(), Role: models.UserRoleAdmin}
+		wrongStore := &mockReportStore{
+			historyByID: map[uuid.UUID]*models.ReportHistory{historyID: entry},
+			user:        otherUser,
+		}
+		wrongSessionUser := &auth.SessionUser{ID: otherUserID, CurrentOrgID: uuid.New()}
+		r := setupReportTestRouter(wrongStore, wrongSessionUser)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/reports/history/"+historyID.String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+}

--- a/internal/api/handlers/repositories_test.go
+++ b/internal/api/handlers/repositories_test.go
@@ -1,0 +1,387 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/MacJediWizard/keldris/internal/api/middleware"
+	"github.com/MacJediWizard/keldris/internal/auth"
+	"github.com/MacJediWizard/keldris/internal/models"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+)
+
+type mockRepositoryStore struct {
+	repos      []*models.Repository
+	repoByID   map[uuid.UUID]*models.Repository
+	user       *models.User
+	repoKey    *models.RepositoryKey
+	repoKeys   []*models.RepositoryKey
+	createErr  error
+	updateErr  error
+	deleteErr  error
+}
+
+func (m *mockRepositoryStore) GetRepositoriesByOrgID(_ context.Context, orgID uuid.UUID) ([]*models.Repository, error) {
+	var result []*models.Repository
+	for _, r := range m.repos {
+		if r.OrgID == orgID {
+			result = append(result, r)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockRepositoryStore) GetRepositoryByID(_ context.Context, id uuid.UUID) (*models.Repository, error) {
+	if r, ok := m.repoByID[id]; ok {
+		return r, nil
+	}
+	return nil, errors.New("repository not found")
+}
+
+func (m *mockRepositoryStore) CreateRepository(_ context.Context, _ *models.Repository) error {
+	return m.createErr
+}
+
+func (m *mockRepositoryStore) UpdateRepository(_ context.Context, _ *models.Repository) error {
+	return m.updateErr
+}
+
+func (m *mockRepositoryStore) DeleteRepository(_ context.Context, _ uuid.UUID) error {
+	return m.deleteErr
+}
+
+func (m *mockRepositoryStore) GetUserByID(_ context.Context, id uuid.UUID) (*models.User, error) {
+	if m.user != nil && m.user.ID == id {
+		return m.user, nil
+	}
+	return nil, errors.New("user not found")
+}
+
+func (m *mockRepositoryStore) CreateRepositoryKey(_ context.Context, _ *models.RepositoryKey) error {
+	return nil
+}
+
+func (m *mockRepositoryStore) GetRepositoryKeyByRepositoryID(_ context.Context, repoID uuid.UUID) (*models.RepositoryKey, error) {
+	if m.repoKey != nil && m.repoKey.RepositoryID == repoID {
+		return m.repoKey, nil
+	}
+	return nil, errors.New("key not found")
+}
+
+func (m *mockRepositoryStore) GetRepositoryKeysWithEscrowByOrgID(_ context.Context, _ uuid.UUID) ([]*models.RepositoryKey, error) {
+	return m.repoKeys, nil
+}
+
+func setupRepositoryTestRouter(store RepositoryStore, user *auth.SessionUser) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		if user != nil {
+			c.Set(string(middleware.UserContextKey), user)
+		}
+		c.Next()
+	})
+	// Pass nil keyManager - List/Get/Delete tests don't need encryption
+	handler := NewRepositoriesHandler(store, nil, zerolog.Nop())
+	api := r.Group("/api/v1")
+	handler.RegisterRoutes(api)
+	return r
+}
+
+func TestListRepositories(t *testing.T) {
+	orgID := uuid.New()
+	repoID := uuid.New()
+	repo := &models.Repository{ID: repoID, OrgID: orgID, Name: "s3-backup", Type: models.RepositoryTypeS3}
+
+	store := &mockRepositoryStore{
+		repos:    []*models.Repository{repo},
+		repoByID: map[uuid.UUID]*models.Repository{repoID: repo},
+	}
+	user := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupRepositoryTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/repositories", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+		var resp map[string]json.RawMessage
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to unmarshal: %v", err)
+		}
+		if _, ok := resp["repositories"]; !ok {
+			t.Fatal("expected 'repositories' key")
+		}
+	})
+
+	t.Run("no org", func(t *testing.T) {
+		noOrgUser := &auth.SessionUser{ID: uuid.New()}
+		r := setupRepositoryTestRouter(store, noOrgUser)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/repositories", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("unauthenticated", func(t *testing.T) {
+		r := setupRepositoryTestRouter(store, nil)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/repositories", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("expected 401, got %d", w.Code)
+		}
+	})
+}
+
+func TestGetRepository(t *testing.T) {
+	orgID := uuid.New()
+	repoID := uuid.New()
+	repo := &models.Repository{ID: repoID, OrgID: orgID, Name: "s3-backup", Type: models.RepositoryTypeS3}
+
+	store := &mockRepositoryStore{
+		repoByID: map[uuid.UUID]*models.Repository{repoID: repo},
+	}
+	user := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupRepositoryTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/repositories/"+repoID.String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+	})
+
+	t.Run("invalid id", func(t *testing.T) {
+		r := setupRepositoryTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/repositories/bad-uuid", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		r := setupRepositoryTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/repositories/"+uuid.New().String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+
+	t.Run("wrong org", func(t *testing.T) {
+		wrongUser := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: uuid.New()}
+		r := setupRepositoryTestRouter(store, wrongUser)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/repositories/"+repoID.String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+}
+
+func TestDeleteRepository(t *testing.T) {
+	orgID := uuid.New()
+	repoID := uuid.New()
+	repo := &models.Repository{ID: repoID, OrgID: orgID, Name: "s3-backup", Type: models.RepositoryTypeS3}
+
+	store := &mockRepositoryStore{
+		repoByID: map[uuid.UUID]*models.Repository{repoID: repo},
+	}
+	user := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupRepositoryTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/v1/repositories/"+repoID.String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+	})
+
+	t.Run("invalid id", func(t *testing.T) {
+		r := setupRepositoryTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/v1/repositories/bad-uuid", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		r := setupRepositoryTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/v1/repositories/"+uuid.New().String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+
+	t.Run("wrong org", func(t *testing.T) {
+		wrongUser := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: uuid.New()}
+		r := setupRepositoryTestRouter(store, wrongUser)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/v1/repositories/"+repoID.String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+
+	t.Run("store error", func(t *testing.T) {
+		errStore := &mockRepositoryStore{
+			repoByID:  map[uuid.UUID]*models.Repository{repoID: repo},
+			deleteErr: errors.New("db error"),
+		}
+		r := setupRepositoryTestRouter(errStore, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/v1/repositories/"+repoID.String(), nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("expected 500, got %d", w.Code)
+		}
+	})
+}
+
+func TestTestRepository(t *testing.T) {
+	orgID := uuid.New()
+	repoID := uuid.New()
+	repo := &models.Repository{ID: repoID, OrgID: orgID, Name: "s3-backup", Type: models.RepositoryTypeS3}
+
+	store := &mockRepositoryStore{
+		repoByID: map[uuid.UUID]*models.Repository{repoID: repo},
+	}
+	user := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupRepositoryTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("POST", "/api/v1/repositories/"+repoID.String()+"/test", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		r := setupRepositoryTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("POST", "/api/v1/repositories/"+uuid.New().String()+"/test", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+
+	t.Run("wrong org", func(t *testing.T) {
+		wrongUser := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: uuid.New()}
+		r := setupRepositoryTestRouter(store, wrongUser)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("POST", "/api/v1/repositories/"+repoID.String()+"/test", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+}
+
+func TestRecoverKey(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	repoID := uuid.New()
+
+	repo := &models.Repository{ID: repoID, OrgID: orgID, Name: "s3-backup"}
+	adminUser := &models.User{ID: userID, OrgID: orgID, Role: models.UserRoleAdmin}
+
+	store := &mockRepositoryStore{
+		repoByID: map[uuid.UUID]*models.Repository{repoID: repo},
+		user:     adminUser,
+		repoKey: &models.RepositoryKey{
+			RepositoryID:       repoID,
+			EscrowEnabled:      true,
+			EscrowEncryptedKey: []byte("encrypted-key"),
+		},
+	}
+	user := &auth.SessionUser{ID: userID, CurrentOrgID: orgID}
+
+	t.Run("forbidden for non-admin", func(t *testing.T) {
+		viewerUserID := uuid.New()
+		viewerUser := &models.User{ID: viewerUserID, OrgID: orgID, Role: models.UserRoleViewer}
+		viewerStore := &mockRepositoryStore{
+			repoByID: map[uuid.UUID]*models.Repository{repoID: repo},
+			user:     viewerUser,
+		}
+		viewerSessionUser := &auth.SessionUser{ID: viewerUserID, CurrentOrgID: orgID}
+		r := setupRepositoryTestRouter(viewerStore, viewerSessionUser)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/repositories/"+repoID.String()+"/key/recover", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		r := setupRepositoryTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/repositories/"+uuid.New().String()+"/key/recover", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+
+	t.Run("escrow not enabled", func(t *testing.T) {
+		noEscrowStore := &mockRepositoryStore{
+			repoByID: map[uuid.UUID]*models.Repository{repoID: repo},
+			user:     adminUser,
+			repoKey: &models.RepositoryKey{
+				RepositoryID:  repoID,
+				EscrowEnabled: false,
+			},
+		}
+		r := setupRepositoryTestRouter(noEscrowStore, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/repositories/"+repoID.String()+"/key/recover", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("wrong org", func(t *testing.T) {
+		otherUserID := uuid.New()
+		otherUser := &models.User{ID: otherUserID, OrgID: uuid.New(), Role: models.UserRoleAdmin}
+		wrongStore := &mockRepositoryStore{
+			repoByID: map[uuid.UUID]*models.Repository{repoID: repo},
+			user:     otherUser,
+		}
+		wrongSessionUser := &auth.SessionUser{ID: otherUserID, CurrentOrgID: uuid.New()}
+		r := setupRepositoryTestRouter(wrongStore, wrongSessionUser)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/repositories/"+repoID.String()+"/key/recover", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+}

--- a/internal/api/handlers/search_test.go
+++ b/internal/api/handlers/search_test.go
@@ -1,0 +1,183 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/MacJediWizard/keldris/internal/api/middleware"
+	"github.com/MacJediWizard/keldris/internal/auth"
+	"github.com/MacJediWizard/keldris/internal/db"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+)
+
+type mockSearchStore struct {
+	results   []db.SearchResult
+	searchErr error
+}
+
+func (m *mockSearchStore) Search(_ context.Context, _ uuid.UUID, _ db.SearchFilter) ([]db.SearchResult, error) {
+	if m.searchErr != nil {
+		return nil, m.searchErr
+	}
+	return m.results, nil
+}
+
+func setupSearchTestRouter(store SearchStore, user *auth.SessionUser) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		if user != nil {
+			c.Set(string(middleware.UserContextKey), user)
+		}
+		c.Next()
+	})
+	handler := NewSearchHandler(store, zerolog.Nop())
+	api := r.Group("/api/v1")
+	handler.RegisterRoutes(api)
+	return r
+}
+
+func TestSearch(t *testing.T) {
+	orgID := uuid.New()
+	store := &mockSearchStore{
+		results: []db.SearchResult{
+			{Type: "agent", ID: uuid.New().String(), Name: "test-agent"},
+		},
+	}
+	user := &auth.SessionUser{
+		ID:           uuid.New(),
+		CurrentOrgID: orgID,
+	}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupSearchTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/search?q=test", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+		}
+
+		var resp map[string]json.RawMessage
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to unmarshal response: %v", err)
+		}
+		if _, ok := resp["results"]; !ok {
+			t.Fatal("expected 'results' key in response")
+		}
+		if _, ok := resp["query"]; !ok {
+			t.Fatal("expected 'query' key in response")
+		}
+		if _, ok := resp["total"]; !ok {
+			t.Fatal("expected 'total' key in response")
+		}
+	})
+
+	t.Run("missing query", func(t *testing.T) {
+		r := setupSearchTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/search", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected status 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("no org selected", func(t *testing.T) {
+		noOrgUser := &auth.SessionUser{ID: uuid.New()}
+		r := setupSearchTestRouter(store, noOrgUser)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/search?q=test", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected status 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("unauthenticated", func(t *testing.T) {
+		r := setupSearchTestRouter(store, nil)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/search?q=test", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("expected status 401, got %d", w.Code)
+		}
+	})
+
+	t.Run("store error", func(t *testing.T) {
+		errStore := &mockSearchStore{searchErr: errors.New("db error")}
+		r := setupSearchTestRouter(errStore, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/search?q=test", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("expected status 500, got %d", w.Code)
+		}
+	})
+
+	t.Run("with filters", func(t *testing.T) {
+		r := setupSearchTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/search?q=test&types=agent,backup&status=active&limit=5", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("invalid limit", func(t *testing.T) {
+		r := setupSearchTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/search?q=test&limit=999", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected status 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("invalid tag_ids", func(t *testing.T) {
+		r := setupSearchTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/search?q=test&tag_ids=not-a-uuid", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected status 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("invalid date_from", func(t *testing.T) {
+		r := setupSearchTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/search?q=test&date_from=not-a-date", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected status 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("invalid size_min", func(t *testing.T) {
+		r := setupSearchTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/search?q=test&size_min=abc", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected status 400, got %d", w.Code)
+		}
+	})
+}

--- a/internal/api/handlers/tags_test.go
+++ b/internal/api/handlers/tags_test.go
@@ -1,0 +1,512 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/MacJediWizard/keldris/internal/api/middleware"
+	"github.com/MacJediWizard/keldris/internal/auth"
+	"github.com/MacJediWizard/keldris/internal/models"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+)
+
+type mockTagStore struct {
+	tags         []*models.Tag
+	tagByID      map[uuid.UUID]*models.Tag
+	backupTags   []*models.Tag
+	backup       *models.Backup
+	agent        *models.Agent
+	createErr    error
+	updateErr    error
+	deleteErr    error
+	setTagsErr   error
+}
+
+func (m *mockTagStore) GetTagsByOrgID(_ context.Context, orgID uuid.UUID) ([]*models.Tag, error) {
+	var result []*models.Tag
+	for _, t := range m.tags {
+		if t.OrgID == orgID {
+			result = append(result, t)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockTagStore) GetTagByID(_ context.Context, id uuid.UUID) (*models.Tag, error) {
+	if t, ok := m.tagByID[id]; ok {
+		return t, nil
+	}
+	return nil, errors.New("tag not found")
+}
+
+func (m *mockTagStore) CreateTag(_ context.Context, _ *models.Tag) error {
+	return m.createErr
+}
+
+func (m *mockTagStore) UpdateTag(_ context.Context, _ *models.Tag) error {
+	return m.updateErr
+}
+
+func (m *mockTagStore) DeleteTag(_ context.Context, _ uuid.UUID) error {
+	return m.deleteErr
+}
+
+func (m *mockTagStore) GetTagsByBackupID(_ context.Context, _ uuid.UUID) ([]*models.Tag, error) {
+	return m.backupTags, nil
+}
+
+func (m *mockTagStore) SetBackupTags(_ context.Context, _ uuid.UUID, _ []uuid.UUID) error {
+	return m.setTagsErr
+}
+
+func (m *mockTagStore) GetBackupByID(_ context.Context, id uuid.UUID) (*models.Backup, error) {
+	if m.backup != nil && m.backup.ID == id {
+		return m.backup, nil
+	}
+	return nil, errors.New("backup not found")
+}
+
+func (m *mockTagStore) GetAgentByID(_ context.Context, id uuid.UUID) (*models.Agent, error) {
+	if m.agent != nil && m.agent.ID == id {
+		return m.agent, nil
+	}
+	return nil, errors.New("agent not found")
+}
+
+func setupTagTestRouter(store TagStore, user *auth.SessionUser) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		if user != nil {
+			c.Set(string(middleware.UserContextKey), user)
+		}
+		c.Next()
+	})
+	handler := NewTagsHandler(store, zerolog.Nop())
+	api := r.Group("/api/v1")
+	handler.RegisterRoutes(api)
+	return r
+}
+
+func TestListTags(t *testing.T) {
+	orgID := uuid.New()
+	tagID := uuid.New()
+	tag := &models.Tag{ID: tagID, OrgID: orgID, Name: "production", Color: "#ff0000"}
+	store := &mockTagStore{
+		tags:    []*models.Tag{tag},
+		tagByID: map[uuid.UUID]*models.Tag{tagID: tag},
+	}
+	user := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupTagTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/tags", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", w.Code)
+		}
+
+		var resp map[string]json.RawMessage
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to unmarshal: %v", err)
+		}
+		if _, ok := resp["tags"]; !ok {
+			t.Fatal("expected 'tags' key in response")
+		}
+	})
+
+	t.Run("no org", func(t *testing.T) {
+		noOrgUser := &auth.SessionUser{ID: uuid.New()}
+		r := setupTagTestRouter(store, noOrgUser)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/tags", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("unauthenticated", func(t *testing.T) {
+		r := setupTagTestRouter(store, nil)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/tags", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("expected 401, got %d", w.Code)
+		}
+	})
+}
+
+func TestGetTag(t *testing.T) {
+	orgID := uuid.New()
+	tagID := uuid.New()
+	tag := &models.Tag{ID: tagID, OrgID: orgID, Name: "production"}
+	store := &mockTagStore{
+		tagByID: map[uuid.UUID]*models.Tag{tagID: tag},
+	}
+	user := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupTagTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/tags/"+tagID.String(), nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+	})
+
+	t.Run("invalid id", func(t *testing.T) {
+		r := setupTagTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/tags/not-uuid", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		r := setupTagTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/tags/"+uuid.New().String(), nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+
+	t.Run("wrong org", func(t *testing.T) {
+		wrongUser := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: uuid.New()}
+		r := setupTagTestRouter(store, wrongUser)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/tags/"+tagID.String(), nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+}
+
+func TestCreateTag(t *testing.T) {
+	orgID := uuid.New()
+	store := &mockTagStore{tagByID: map[uuid.UUID]*models.Tag{}}
+	user := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupTagTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"name":"staging","color":"#00ff00"}`
+		req, _ := http.NewRequest("POST", "/api/v1/tags", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusCreated {
+			t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("missing name", func(t *testing.T) {
+		r := setupTagTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"color":"#00ff00"}`
+		req, _ := http.NewRequest("POST", "/api/v1/tags", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("store error", func(t *testing.T) {
+		errStore := &mockTagStore{tagByID: map[uuid.UUID]*models.Tag{}, createErr: errors.New("db error")}
+		r := setupTagTestRouter(errStore, user)
+		w := httptest.NewRecorder()
+		body := `{"name":"fail"}`
+		req, _ := http.NewRequest("POST", "/api/v1/tags", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("expected 500, got %d", w.Code)
+		}
+	})
+}
+
+func TestUpdateTag(t *testing.T) {
+	orgID := uuid.New()
+	tagID := uuid.New()
+	tag := &models.Tag{ID: tagID, OrgID: orgID, Name: "production"}
+	store := &mockTagStore{
+		tagByID: map[uuid.UUID]*models.Tag{tagID: tag},
+	}
+	user := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupTagTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"name":"staging"}`
+		req, _ := http.NewRequest("PUT", "/api/v1/tags/"+tagID.String(), strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		r := setupTagTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"name":"staging"}`
+		req, _ := http.NewRequest("PUT", "/api/v1/tags/"+uuid.New().String(), strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+
+	t.Run("wrong org", func(t *testing.T) {
+		wrongUser := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: uuid.New()}
+		r := setupTagTestRouter(store, wrongUser)
+		w := httptest.NewRecorder()
+		body := `{"name":"staging"}`
+		req, _ := http.NewRequest("PUT", "/api/v1/tags/"+tagID.String(), strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+
+	t.Run("store error", func(t *testing.T) {
+		errStore := &mockTagStore{
+			tagByID:   map[uuid.UUID]*models.Tag{tagID: tag},
+			updateErr: errors.New("db error"),
+		}
+		r := setupTagTestRouter(errStore, user)
+		w := httptest.NewRecorder()
+		body := `{"name":"staging"}`
+		req, _ := http.NewRequest("PUT", "/api/v1/tags/"+tagID.String(), strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("expected 500, got %d", w.Code)
+		}
+	})
+}
+
+func TestDeleteTag(t *testing.T) {
+	orgID := uuid.New()
+	tagID := uuid.New()
+	tag := &models.Tag{ID: tagID, OrgID: orgID, Name: "production"}
+	store := &mockTagStore{
+		tagByID: map[uuid.UUID]*models.Tag{tagID: tag},
+	}
+	user := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupTagTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/v1/tags/"+tagID.String(), nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+	})
+
+	t.Run("invalid id", func(t *testing.T) {
+		r := setupTagTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/v1/tags/bad-uuid", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		r := setupTagTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/v1/tags/"+uuid.New().String(), nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+
+	t.Run("wrong org", func(t *testing.T) {
+		wrongUser := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: uuid.New()}
+		r := setupTagTestRouter(store, wrongUser)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/v1/tags/"+tagID.String(), nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+
+	t.Run("store error", func(t *testing.T) {
+		errStore := &mockTagStore{
+			tagByID:   map[uuid.UUID]*models.Tag{tagID: tag},
+			deleteErr: errors.New("db error"),
+		}
+		r := setupTagTestRouter(errStore, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/v1/tags/"+tagID.String(), nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("expected 500, got %d", w.Code)
+		}
+	})
+}
+
+func TestGetBackupTags(t *testing.T) {
+	orgID := uuid.New()
+	agentID := uuid.New()
+	backupID := uuid.New()
+	tagID := uuid.New()
+
+	tag := &models.Tag{ID: tagID, OrgID: orgID, Name: "important"}
+	backup := &models.Backup{ID: backupID, AgentID: agentID}
+	agent := &models.Agent{ID: agentID, OrgID: orgID}
+
+	store := &mockTagStore{
+		tagByID:    map[uuid.UUID]*models.Tag{tagID: tag},
+		backupTags: []*models.Tag{tag},
+		backup:     backup,
+		agent:      agent,
+	}
+	user := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupTagTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/backups/"+backupID.String()+"/tags", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("backup not found", func(t *testing.T) {
+		r := setupTagTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/backups/"+uuid.New().String()+"/tags", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+
+	t.Run("wrong org", func(t *testing.T) {
+		wrongUser := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: uuid.New()}
+		r := setupTagTestRouter(store, wrongUser)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/backups/"+backupID.String()+"/tags", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+}
+
+func TestSetBackupTags(t *testing.T) {
+	orgID := uuid.New()
+	agentID := uuid.New()
+	backupID := uuid.New()
+	tagID := uuid.New()
+
+	tag := &models.Tag{ID: tagID, OrgID: orgID, Name: "important"}
+	backup := &models.Backup{ID: backupID, AgentID: agentID}
+	agent := &models.Agent{ID: agentID, OrgID: orgID}
+
+	store := &mockTagStore{
+		tagByID:    map[uuid.UUID]*models.Tag{tagID: tag},
+		backupTags: []*models.Tag{tag},
+		backup:     backup,
+		agent:      agent,
+	}
+	user := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: orgID}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupTagTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"tag_ids":["` + tagID.String() + `"]}`
+		req, _ := http.NewRequest("POST", "/api/v1/backups/"+backupID.String()+"/tags", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("invalid tag id in request", func(t *testing.T) {
+		r := setupTagTestRouter(store, user)
+		w := httptest.NewRecorder()
+		// Tag that doesn't exist in our org
+		body := `{"tag_ids":["` + uuid.New().String() + `"]}`
+		req, _ := http.NewRequest("POST", "/api/v1/backups/"+backupID.String()+"/tags", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("backup not found", func(t *testing.T) {
+		r := setupTagTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"tag_ids":["` + tagID.String() + `"]}`
+		req, _ := http.NewRequest("POST", "/api/v1/backups/"+uuid.New().String()+"/tags", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+
+	t.Run("missing body", func(t *testing.T) {
+		r := setupTagTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{}`
+		req, _ := http.NewRequest("POST", "/api/v1/backups/"+backupID.String()+"/tags", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+}

--- a/internal/api/handlers/test_helpers.go
+++ b/internal/api/handlers/test_helpers.go
@@ -1,0 +1,70 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	"github.com/MacJediWizard/keldris/internal/api/middleware"
+	"github.com/MacJediWizard/keldris/internal/auth"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+// TestUser creates a SessionUser for testing with a given org.
+func TestUser(orgID uuid.UUID) *auth.SessionUser {
+	return &auth.SessionUser{
+		ID:             uuid.New(),
+		Email:          "test@example.com",
+		Name:           "Test User",
+		CurrentOrgID:   orgID,
+		CurrentOrgRole: "admin",
+	}
+}
+
+// TestUserNoOrg creates a SessionUser with no organization selected.
+func TestUserNoOrg() *auth.SessionUser {
+	return &auth.SessionUser{
+		ID:    uuid.New(),
+		Email: "test@example.com",
+		Name:  "Test User",
+	}
+}
+
+// InjectUser returns gin middleware that injects a SessionUser into context.
+func InjectUser(user *auth.SessionUser) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if user != nil {
+			c.Set(string(middleware.UserContextKey), user)
+		}
+		c.Next()
+	}
+}
+
+// JSONRequest creates an HTTP request with JSON content type.
+func JSONRequest(method, path, body string) *http.Request {
+	req, _ := http.NewRequest(method, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+// AuthenticatedRequest creates a GET request (no body needed).
+func AuthenticatedRequest(method, path string) *http.Request {
+	req, _ := http.NewRequest(method, path, nil)
+	return req
+}
+
+// SetupTestRouter creates a test gin engine with optional user injection.
+func SetupTestRouter(user *auth.SessionUser) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(InjectUser(user))
+	return r
+}
+
+// DoRequest performs a request and returns the recorder.
+func DoRequest(r *gin.Engine, req *http.Request) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}


### PR DESCRIPTION
## Summary

Add comprehensive unit tests for the API handlers package targeting 85%+ coverage. Includes new test files for 11 handlers and expansions to existing tests.

## Changes

- Create 9 new test files (alerts, audit_logs, notifications, organizations, policies, reports, repositories, search, tags)
- Create test_helpers.go with reusable testing utilities
- Expand agents_test.go with 7 new test functions for previously untested methods
- Implement 86 total test functions covering success paths, error handling, and authorization checks
- All 86 tests pass with 28.8% overall package coverage
- Targeted handlers achieve 60-92% coverage (search 92%, agents 83%, tags 82%, policies 77%, etc.)

## Test Coverage

- **agents.go**: 83.0% - Tests for Heartbeat, RotateAPIKey, RevokeAPIKey, Stats, Backups, Schedules, HealthHistory
- **organizations.go**: 70.9% - Tests for CRUD operations, member management, and invitations
- **search.go**: 92.5% - Tests for search with various filters and validations
- **tags.go**: 82.2% - Tests for tag operations and backup tag associations
- **policies.go**: 77.1% - Tests for policy CRUD and scheduling
- **notifications.go**: 73.7% - Tests for channels, preferences, and logs
- **alerts.go**: 69.0% - Tests for alert operations and rules
- **audit_logs.go**: 64.7% - Tests for listing, retrieval, and exports
- **reports.go**: 63.1% - Tests for schedule and history operations (SendReport/PreviewReport need scheduler)
- **repositories.go**: 62.2% - Tests for CRUD and key recovery (Create/Update need keyManager)
- **auth.go**: 0% - Requires OIDC/session provider integration

## Testing

```bash
go test ./internal/api/handlers/... -v
# 86 tests pass
# coverage: 28.8% of statements
```