### PR TITLE
Add security response headers middleware

### DIFF
--- a/internal/api/middleware/security_headers.go
+++ b/internal/api/middleware/security_headers.go
@@ -1,0 +1,26 @@
+package middleware
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+// SecurityHeaders returns a middleware that sets security-related HTTP response headers.
+func SecurityHeaders() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Header("X-Frame-Options", "DENY")
+		c.Header("X-Content-Type-Options", "nosniff")
+		c.Header("X-XSS-Protection", "1; mode=block")
+		c.Header("Referrer-Policy", "strict-origin-when-cross-origin")
+		c.Header("Permissions-Policy", "geolocation=(), microphone=(), camera=()")
+
+		// HSTS - only in production with TLS
+		if c.Request.TLS != nil {
+			c.Header("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+		}
+
+		// CSP - restrictive default
+		c.Header("Content-Security-Policy", "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'")
+
+		c.Next()
+	}
+}

--- a/internal/api/middleware/security_headers_test.go
+++ b/internal/api/middleware/security_headers_test.go
@@ -1,0 +1,71 @@
+package middleware
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestSecurityHeaders_AllHeadersSet(t *testing.T) {
+	mw := SecurityHeaders()
+
+	r := gin.New()
+	r.Use(mw)
+	r.GET("/test", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/test", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	expected := map[string]string{
+		"X-Frame-Options":        "DENY",
+		"X-Content-Type-Options": "nosniff",
+		"X-XSS-Protection":      "1; mode=block",
+		"Referrer-Policy":        "strict-origin-when-cross-origin",
+		"Permissions-Policy":     "geolocation=(), microphone=(), camera=()",
+		"Content-Security-Policy": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'",
+	}
+
+	for header, want := range expected {
+		if got := w.Header().Get(header); got != want {
+			t.Errorf("expected %s %q, got %q", header, want, got)
+		}
+	}
+
+	// HSTS should NOT be set without TLS
+	if got := w.Header().Get("Strict-Transport-Security"); got != "" {
+		t.Errorf("expected no Strict-Transport-Security without TLS, got %q", got)
+	}
+}
+
+func TestSecurityHeaders_HSTSOnlyWithTLS(t *testing.T) {
+	mw := SecurityHeaders()
+
+	r := gin.New()
+	r.Use(mw)
+	r.GET("/test", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/test", nil)
+	req.TLS = &tls.ConnectionState{}
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	if got := w.Header().Get("Strict-Transport-Security"); got != "max-age=31536000; includeSubDomains" {
+		t.Errorf("expected HSTS header with TLS, got %q", got)
+	}
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -75,6 +75,7 @@ func NewRouter(
 	// Global middleware
 	r.Engine.Use(gin.Recovery())
 	r.Engine.Use(middleware.RequestLogger(logger))
+	r.Engine.Use(middleware.SecurityHeaders())
 	r.Engine.Use(middleware.CORS(cfg.AllowedOrigins))
 
 	// Rate limiting


### PR DESCRIPTION
## Summary
Add a new middleware that sets security-related HTTP response headers to harden the API against common web vulnerabilities.

## Changes
- Implement `SecurityHeaders()` middleware with X-Frame-Options, X-Content-Type-Options, X-XSS-Protection, and other defensive headers
- Include CSP with restrictive defaults to mitigate XSS attacks
- Conditionally set HSTS only when TLS is present to avoid issues in non-HTTPS environments
- Integrate middleware into the global middleware chain before CORS

## Testing
- TestSecurityHeaders_AllHeadersSet verifies all headers are present and correct
- TestSecurityHeaders_HSTSOnlyWithTLS confirms HSTS is only set with TLS connections

🤖 Generated with Claude Code