### PR TITLE
Fix encryption TODOs in handlers

### DIFF
--- a/internal/api/handlers/notifications_test.go
+++ b/internal/api/handlers/notifications_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/MacJediWizard/keldris/internal/api/middleware"
 	"github.com/MacJediWizard/keldris/internal/auth"
+	"github.com/MacJediWizard/keldris/internal/crypto"
 	"github.com/MacJediWizard/keldris/internal/models"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -124,7 +125,8 @@ func setupNotificationTestRouter(store NotificationStore, user *auth.SessionUser
 		}
 		c.Next()
 	})
-	handler := NewNotificationsHandler(store, zerolog.Nop())
+	km, _ := crypto.NewKeyManager(make([]byte, 32))
+	handler := NewNotificationsHandler(store, km, zerolog.Nop())
 	api := r.Group("/api/v1")
 	handler.RegisterRoutes(api)
 	return r

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -155,7 +155,7 @@ func NewRouter(
 	alertsHandler := handlers.NewAlertsHandler(database, logger)
 	alertsHandler.RegisterRoutes(apiV1)
 
-	notificationsHandler := handlers.NewNotificationsHandler(database, logger)
+	notificationsHandler := handlers.NewNotificationsHandler(database, keyManager, logger)
 	notificationsHandler.RegisterRoutes(apiV1)
 
 	// Register reports handler if scheduler is available


### PR DESCRIPTION
## Summary
- Implement AES-256-GCM encryption for notification channel configs
- Decrypt repository configs for connection testing
- Inject KeyManager into NotificationsHandler
- Update all handlers and tests

## Test plan
- All Go tests pass
- Handler unit tests verify encryption/decryption flow
- No breaking changes to API contracts