### PR TITLE
Add proper SSH host key verification for SFTP backend

### DIFF
--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -213,6 +213,8 @@ export interface SFTPBackendConfig {
 	path: string;
 	password?: string;
 	private_key?: string;
+	host_key?: string;
+	known_hosts_file?: string;
 }
 
 export interface RestBackendConfig {


### PR DESCRIPTION
## Summary

Replaces insecure `ssh.InsecureIgnoreHostKey()` with proper SSH host key verification for SFTP connections. Users can now either provide an explicit host key (base64-encoded public key) or use a known_hosts file for verification.

- Add HostKey and KnownHostsFile fields to SFTP config
- Implement FetchHostKey() helper for UI "Test Connection" flow
- Add 22 comprehensive tests covering all verification scenarios

## Test Plan

- ✅ All 22 SFTP backend tests pass (86.3% coverage)
- ✅ Tests cover: valid keys, mismatched keys, missing keys, known_hosts usage, and FetchHostKey helper
- ✅ go vet passes with no warnings