### PR TITLE
Add integration tests for internal/db using testcontainers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build dev test lint clean deps swagger swagger-fmt
+.PHONY: all build dev test test-integration lint clean deps swagger swagger-fmt
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
@@ -69,6 +69,9 @@ dev:
 test:
 	go test -race -cover ./...
 	cd web && npx vitest run
+
+test-integration:
+	go test -tags=integration -race -cover -coverprofile=coverage.out -v ./internal/db/...
 
 lint:
 	go vet ./...


### PR DESCRIPTION
## Summary

- Rename store_test.go → store_integration_test.go with //go:build integration tag
- Implement TestMain that starts a single PostgreSQL 15 container shared across all tests
- Add cleanTables helper to truncate tables between tests for isolation
- Add test-integration Makefile target: `go test -tags=integration -v ./internal/db/...`
- Preserves all 64+ existing test functions covering Organizations, Users, Agents, Repositories, Schedules, Backups, Restores, Alerts, Policies, Tags, Notifications, and more

🤖 Generated with [Claude Code](https://claude.com/claude-code)