### PR TITLE
Make session lifetime configurable with secure production defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,7 +21,11 @@ OIDC_REDIRECT_URL=http://localhost:8080/auth/callback
 # Secret key for session cookie encryption (use a random 32+ character string)
 SESSION_SECRET=change-this-to-a-random-32-char-string
 # Session lifetime in seconds (default: 86400 = 24 hours)
+# Production: consider SESSION_MAX_AGE=3600 (1 hour)
 SESSION_MAX_AGE=86400
+# Idle timeout in seconds - session expires after inactivity (default: 1800 = 30 min)
+# Set to 0 to disable idle timeout
+SESSION_IDLE_TIMEOUT=1800
 
 # =========================
 # Encryption

--- a/docs/production-security.md
+++ b/docs/production-security.md
@@ -1,0 +1,67 @@
+# Production Security Recommendations
+
+This guide covers security hardening for production Keldris deployments.
+
+## Session Configuration
+
+Keldris supports two session timeout mechanisms:
+
+- **SESSION_MAX_AGE** - Absolute session lifetime. The session cookie expires after this many seconds regardless of activity.
+- **SESSION_IDLE_TIMEOUT** - Inactivity timeout. The session expires if no requests are made within this window. Set to `0` to disable.
+
+### Development Defaults
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SESSION_MAX_AGE` | `86400` (24h) | Generous for local development |
+| `SESSION_IDLE_TIMEOUT` | `1800` (30m) | Reasonable idle cutoff |
+
+### Production Recommendations
+
+```bash
+# Shorter absolute lifetime limits exposure from stolen sessions
+SESSION_MAX_AGE=3600       # 1 hour
+
+# Aggressive idle timeout for sensitive environments
+SESSION_IDLE_TIMEOUT=900   # 15 minutes
+```
+
+For environments handling sensitive backup data or regulated workloads, consider:
+
+```bash
+SESSION_MAX_AGE=1800       # 30 minutes
+SESSION_IDLE_TIMEOUT=600   # 10 minutes
+```
+
+### How It Works
+
+1. When a user logs in via OIDC, the session cookie is created with `MaxAge` set to `SESSION_MAX_AGE`.
+2. Each authenticated request updates the `last_activity` timestamp in the session.
+3. On subsequent requests, if `last_activity` is older than `SESSION_IDLE_TIMEOUT`, the session is treated as expired and the user must re-authenticate.
+4. The cookie's `MaxAge` provides a hard upper bound - even with continuous activity, the session expires after `SESSION_MAX_AGE` seconds.
+
+## Session Cookie Security
+
+These are enforced by default and cannot be weakened:
+
+- **HttpOnly** - Session cookies are never accessible to JavaScript
+- **SameSite=Lax** - Prevents CSRF in most scenarios
+- **Secure** - Set to `true` in production (requires HTTPS)
+
+## Other Production Settings
+
+```bash
+# Always set to production
+ENV=production
+
+# Use a strong random secret (minimum 32 bytes)
+# Generate with: openssl rand -base64 48
+SESSION_SECRET=<random-value>
+
+# Restrict CORS to your actual frontend domain
+CORS_ORIGINS=https://backups.example.com
+
+# Generate a strong encryption key for data at rest
+# Generate with: openssl rand -hex 32
+ENCRYPTION_KEY=<random-value>
+```

--- a/internal/auth/session_test.go
+++ b/internal/auth/session_test.go
@@ -17,6 +17,9 @@ func TestDefaultSessionConfig(t *testing.T) {
 	if cfg.MaxAge != 86400 {
 		t.Errorf("expected MaxAge 86400, got %d", cfg.MaxAge)
 	}
+	if cfg.IdleTimeout != 1800 {
+		t.Errorf("expected IdleTimeout 1800, got %d", cfg.IdleTimeout)
+	}
 	if !cfg.Secure {
 		t.Error("expected Secure to be true")
 	}
@@ -48,6 +51,25 @@ func newTestSessionStore(t *testing.T) *SessionStore {
 	logger := zerolog.Nop()
 	secret := []byte("test-secret-that-is-at-least-32-bytes-long")
 	cfg := DefaultSessionConfig(secret, false)
+	store, err := NewSessionStore(cfg, logger)
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	return store
+}
+
+func newTestSessionStoreWithIdleTimeout(t *testing.T, idleTimeout int) *SessionStore {
+	t.Helper()
+	logger := zerolog.Nop()
+	cfg := SessionConfig{
+		Secret:      []byte("test-secret-that-is-at-least-32-bytes-long"),
+		MaxAge:      86400,
+		IdleTimeout: idleTimeout,
+		Secure:      false,
+		HTTPOnly:    true,
+		SameSite:    http.SameSiteLaxMode,
+		CookiePath:  "/",
+	}
 	store, err := NewSessionStore(cfg, logger)
 	if err != nil {
 		t.Fatalf("failed to create store: %v", err)
@@ -437,5 +459,198 @@ func TestSessionStore_Save(t *testing.T) {
 	cookies := resp.Cookies()
 	if len(cookies) == 0 {
 		t.Fatal("expected cookie to be set after save")
+	}
+}
+
+func TestSessionStore_IdleTimeout(t *testing.T) {
+	t.Run("session expires after idle timeout", func(t *testing.T) {
+		// Create store with 1-second idle timeout
+		store := newTestSessionStoreWithIdleTimeout(t, 1)
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		w := httptest.NewRecorder()
+		testUser := &SessionUser{
+			ID:          uuid.New(),
+			OIDCSubject: "sub-12345",
+			Email:       "test@example.com",
+		}
+		if err := store.SetUser(req, w, testUser); err != nil {
+			t.Fatalf("failed to set user: %v", err)
+		}
+
+		// Wait for idle timeout to expire
+		time.Sleep(1100 * time.Millisecond)
+
+		resp := w.Result()
+		req2 := httptest.NewRequest(http.MethodGet, "/", nil)
+		for _, cookie := range resp.Cookies() {
+			req2.AddCookie(cookie)
+		}
+
+		// GetUser should fail due to idle timeout
+		_, err := store.GetUser(req2)
+		if err == nil {
+			t.Error("expected error for idle timeout expired session")
+		}
+
+		// IsAuthenticated should also return false
+		if store.IsAuthenticated(req2) {
+			t.Error("expected IsAuthenticated to be false after idle timeout")
+		}
+	})
+
+	t.Run("session valid within idle timeout", func(t *testing.T) {
+		store := newTestSessionStoreWithIdleTimeout(t, 3600)
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		w := httptest.NewRecorder()
+		testUser := &SessionUser{
+			ID:          uuid.New(),
+			OIDCSubject: "sub-12345",
+			Email:       "test@example.com",
+		}
+		if err := store.SetUser(req, w, testUser); err != nil {
+			t.Fatalf("failed to set user: %v", err)
+		}
+
+		resp := w.Result()
+		req2 := httptest.NewRequest(http.MethodGet, "/", nil)
+		for _, cookie := range resp.Cookies() {
+			req2.AddCookie(cookie)
+		}
+
+		user, err := store.GetUser(req2)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if user.ID != testUser.ID {
+			t.Errorf("expected user ID %s, got %s", testUser.ID, user.ID)
+		}
+	})
+
+	t.Run("idle timeout disabled with zero", func(t *testing.T) {
+		store := newTestSessionStoreWithIdleTimeout(t, 0)
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		w := httptest.NewRecorder()
+		testUser := &SessionUser{
+			ID:          uuid.New(),
+			OIDCSubject: "sub-12345",
+			Email:       "test@example.com",
+		}
+		if err := store.SetUser(req, w, testUser); err != nil {
+			t.Fatalf("failed to set user: %v", err)
+		}
+
+		resp := w.Result()
+		req2 := httptest.NewRequest(http.MethodGet, "/", nil)
+		for _, cookie := range resp.Cookies() {
+			req2.AddCookie(cookie)
+		}
+
+		// Should succeed regardless - idle timeout is disabled
+		user, err := store.GetUser(req2)
+		if err != nil {
+			t.Fatalf("unexpected error with idle timeout disabled: %v", err)
+		}
+		if user.ID != testUser.ID {
+			t.Errorf("expected user ID %s, got %s", testUser.ID, user.ID)
+		}
+	})
+}
+
+func TestSessionStore_TouchSession(t *testing.T) {
+	t.Run("touch updates last activity", func(t *testing.T) {
+		store := newTestSessionStoreWithIdleTimeout(t, 2)
+
+		// Set user
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		w := httptest.NewRecorder()
+		testUser := &SessionUser{
+			ID:          uuid.New(),
+			OIDCSubject: "sub-12345",
+			Email:       "test@example.com",
+		}
+		if err := store.SetUser(req, w, testUser); err != nil {
+			t.Fatalf("failed to set user: %v", err)
+		}
+
+		// Wait, then touch the session to keep it alive
+		time.Sleep(1 * time.Second)
+
+		resp := w.Result()
+		req2 := httptest.NewRequest(http.MethodGet, "/", nil)
+		for _, cookie := range resp.Cookies() {
+			req2.AddCookie(cookie)
+		}
+		w2 := httptest.NewRecorder()
+
+		if err := store.TouchSession(req2, w2); err != nil {
+			t.Fatalf("failed to touch session: %v", err)
+		}
+
+		// Wait again, but total time since touch should be within timeout
+		time.Sleep(1 * time.Second)
+
+		resp2 := w2.Result()
+		req3 := httptest.NewRequest(http.MethodGet, "/", nil)
+		for _, cookie := range resp2.Cookies() {
+			req3.AddCookie(cookie)
+		}
+
+		// Session should still be valid because we touched it
+		user, err := store.GetUser(req3)
+		if err != nil {
+			t.Fatalf("unexpected error after touch: %v", err)
+		}
+		if user.ID != testUser.ID {
+			t.Errorf("expected user ID %s, got %s", testUser.ID, user.ID)
+		}
+	})
+
+	t.Run("touch is noop when idle timeout disabled", func(t *testing.T) {
+		store := newTestSessionStoreWithIdleTimeout(t, 0)
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		w := httptest.NewRecorder()
+
+		// Should succeed without error even with no session data
+		if err := store.TouchSession(req, w); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestSessionStore_IdleTimeout_IsAuthenticated(t *testing.T) {
+	store := newTestSessionStoreWithIdleTimeout(t, 1)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	testUser := &SessionUser{
+		ID:          uuid.New(),
+		OIDCSubject: "sub-12345",
+		Email:       "test@example.com",
+	}
+	if err := store.SetUser(req, w, testUser); err != nil {
+		t.Fatalf("failed to set user: %v", err)
+	}
+
+	resp := w.Result()
+	req2 := httptest.NewRequest(http.MethodGet, "/", nil)
+	for _, cookie := range resp.Cookies() {
+		req2.AddCookie(cookie)
+	}
+
+	// Should be authenticated initially
+	if !store.IsAuthenticated(req2) {
+		t.Error("expected IsAuthenticated to be true immediately after login")
+	}
+
+	// Wait for idle timeout
+	time.Sleep(1100 * time.Millisecond)
+
+	// Should no longer be authenticated
+	if store.IsAuthenticated(req2) {
+		t.Error("expected IsAuthenticated to be false after idle timeout")
 	}
 }

--- a/internal/config/server_test.go
+++ b/internal/config/server_test.go
@@ -41,3 +41,79 @@ func TestLoadServerConfig_ValidEnvironments(t *testing.T) {
 		})
 	}
 }
+
+func TestLoadServerConfig_SessionMaxAge(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		t.Setenv("SESSION_MAX_AGE", "")
+		cfg := LoadServerConfig()
+		if cfg.SessionMaxAge != 86400 {
+			t.Errorf("expected default SessionMaxAge 86400, got %d", cfg.SessionMaxAge)
+		}
+	})
+
+	t.Run("custom value", func(t *testing.T) {
+		t.Setenv("SESSION_MAX_AGE", "3600")
+		cfg := LoadServerConfig()
+		if cfg.SessionMaxAge != 3600 {
+			t.Errorf("expected SessionMaxAge 3600, got %d", cfg.SessionMaxAge)
+		}
+	})
+
+	t.Run("invalid value falls back to default", func(t *testing.T) {
+		t.Setenv("SESSION_MAX_AGE", "notanumber")
+		cfg := LoadServerConfig()
+		if cfg.SessionMaxAge != 86400 {
+			t.Errorf("expected default SessionMaxAge 86400 for invalid input, got %d", cfg.SessionMaxAge)
+		}
+	})
+
+	t.Run("negative value falls back to default", func(t *testing.T) {
+		t.Setenv("SESSION_MAX_AGE", "-1")
+		cfg := LoadServerConfig()
+		if cfg.SessionMaxAge != 86400 {
+			t.Errorf("expected default SessionMaxAge 86400 for negative input, got %d", cfg.SessionMaxAge)
+		}
+	})
+}
+
+func TestLoadServerConfig_SessionIdleTimeout(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		t.Setenv("SESSION_IDLE_TIMEOUT", "")
+		cfg := LoadServerConfig()
+		if cfg.SessionIdleTimeout != 1800 {
+			t.Errorf("expected default SessionIdleTimeout 1800, got %d", cfg.SessionIdleTimeout)
+		}
+	})
+
+	t.Run("custom value", func(t *testing.T) {
+		t.Setenv("SESSION_IDLE_TIMEOUT", "900")
+		cfg := LoadServerConfig()
+		if cfg.SessionIdleTimeout != 900 {
+			t.Errorf("expected SessionIdleTimeout 900, got %d", cfg.SessionIdleTimeout)
+		}
+	})
+
+	t.Run("zero disables idle timeout", func(t *testing.T) {
+		t.Setenv("SESSION_IDLE_TIMEOUT", "0")
+		cfg := LoadServerConfig()
+		if cfg.SessionIdleTimeout != 0 {
+			t.Errorf("expected SessionIdleTimeout 0, got %d", cfg.SessionIdleTimeout)
+		}
+	})
+
+	t.Run("invalid value falls back to default", func(t *testing.T) {
+		t.Setenv("SESSION_IDLE_TIMEOUT", "notanumber")
+		cfg := LoadServerConfig()
+		if cfg.SessionIdleTimeout != 1800 {
+			t.Errorf("expected default SessionIdleTimeout 1800 for invalid input, got %d", cfg.SessionIdleTimeout)
+		}
+	})
+
+	t.Run("negative value falls back to default", func(t *testing.T) {
+		t.Setenv("SESSION_IDLE_TIMEOUT", "-1")
+		cfg := LoadServerConfig()
+		if cfg.SessionIdleTimeout != 1800 {
+			t.Errorf("expected default SessionIdleTimeout 1800 for negative input, got %d", cfg.SessionIdleTimeout)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Add configurable session timeout with secure production defaults
- Implement idle timeout tracking and enforcement
- Create production security documentation with hardening recommendations

## Details

**Config Changes:**
- `SESSION_MAX_AGE`: Absolute session lifetime (default: 86400s = 24h, recommended production: 3600s = 1h)
- `SESSION_IDLE_TIMEOUT`: Inactivity timeout (default: 1800s = 30m, can be disabled with 0)

**Idle Timeout Behavior:**
- Last activity timestamp updated on each authenticated request via `TouchSession()`
- GetUser() and IsAuthenticated() check idle timeout before returning
- Sessions expire immediately when idle timeout exceeded, forcing re-authentication
- Middleware automatically touches sessions on authenticated requests

**Testing:**
- Comprehensive tests for timeout behavior including edge cases
- Tests for configuration loading with validation
- Time-based tests verifying session expiry and refresh

## Test Plan

- [x] `go test ./internal/config` - Config loading tests pass
- [x] `go test ./internal/auth` - Session timeout tests pass
- [x] `go test ./internal/api/middleware` - Middleware integration tests pass
- [x] `go vet ./internal/...` - No linting issues