### PR TITLE
Update Alpine base image to 3.21

### DIFF
--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -16,7 +16,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
     -o /keldris-agent ./cmd/keldris-agent
 
 # Final image - minimal with restic
-FROM alpine:3.19
+FROM alpine:3.21
 RUN apk add --no-cache ca-certificates tzdata restic
 RUN adduser -D -u 1000 keldris
 WORKDIR /app

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -22,7 +22,7 @@ RUN CGO_ENABLED=0 go build \
     -o /keldris-server ./cmd/keldris-server
 
 # Final image
-FROM alpine:3.19
+FROM alpine:3.21
 RUN apk add --no-cache ca-certificates tzdata
 RUN adduser -D -u 1000 keldris
 WORKDIR /app


### PR DESCRIPTION
Update Docker base images to Alpine 3.21 for security and performance improvements.

- Updates both server and agent Dockerfile base images from alpine:3.19 to alpine:3.21
- Go tests pass with the updated base image
- No breaking changes to build process or runtime dependencies

Ready to merge when CI passes.