### PR TITLE
Wire DR test runner in routes.go

### DIFF
--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -37,6 +37,8 @@ type Config struct {
 	VerificationTrigger handlers.VerificationTrigger
 	// ReportScheduler for report generation and sending (optional).
 	ReportScheduler *reports.Scheduler
+	// DRTestRunner for triggering DR test execution (optional).
+	DRTestRunner handlers.DRTestRunner
 }
 
 // DefaultConfig returns a Config with sensible defaults for development.
@@ -214,8 +216,8 @@ func NewRouter(
 	drRunbooksHandler := handlers.NewDRRunbooksHandler(database, logger)
 	drRunbooksHandler.RegisterRoutes(apiV1)
 
-	// DR Test routes (runner is nil for now, will be set up when scheduler is integrated)
-	drTestsHandler := handlers.NewDRTestsHandler(database, nil, logger)
+	// DR Test routes
+	drTestsHandler := handlers.NewDRTestsHandler(database, cfg.DRTestRunner, logger)
 	drTestsHandler.RegisterRoutes(apiV1)
 
 	// Agent API routes (API key auth required)


### PR DESCRIPTION
## Summary
- Add DRTestRunner field to Config struct as an optional dependency
- Replace nil runner with cfg.DRTestRunner in NewDRTestsHandler
- Follows existing pattern for optional dependencies like VerificationTrigger and ReportScheduler

## Testing
- All Go vet checks pass
- All affected test suites pass (handlers, dr, backup packages)