### PR TITLE
Document Go 1.25.7+ runtime requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ cp .env.example .env
 docker-compose up -d
 ```
 
-You'll need Docker, PostgreSQL 15+, and an OIDC provider.
+You'll need Docker, Go 1.25.7+ (for security patches), PostgreSQL 15+, and an OIDC provider.
 
 ---
 

--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -1,5 +1,6 @@
+# SECURITY: Requires Go 1.25.7+ for stdlib vulnerability fixes
 # Build Go agent
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25.7-alpine AS builder
 RUN apk add --no-cache git ca-certificates
 WORKDIR /app
 COPY go.mod go.sum ./

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -6,8 +6,9 @@ RUN npm ci
 COPY web/ ./
 RUN npm run build
 
+# SECURITY: Requires Go 1.25.7+ for stdlib vulnerability fixes
 # Build Go server
-FROM golang:1.24-alpine AS go-builder
+FROM golang:1.25.7-alpine AS go-builder
 RUN apk add --no-cache git ca-certificates
 WORKDIR /app
 COPY go.mod go.sum ./

--- a/docs/infrastructure-requirements.md
+++ b/docs/infrastructure-requirements.md
@@ -1,0 +1,63 @@
+# Infrastructure Requirements
+
+## Go Runtime
+
+**Minimum version: Go 1.25.7+**
+
+Go 1.25.7 or later is required for production deployments. Earlier versions contain stdlib vulnerabilities that affect Keldris server and agent binaries.
+
+### Patched Vulnerabilities
+
+| ID | Summary |
+|----|---------|
+| GO-2026-4341 | stdlib vulnerability patched in Go 1.25.7 |
+| GO-2026-4340 | stdlib vulnerability patched in Go 1.25.7 |
+| GO-2026-4337 | stdlib vulnerability patched in Go 1.25.7 |
+
+All three are standard library vulnerabilities that affect any Go binary compiled with earlier toolchains. Upgrading the Go compiler and rebuilding is the only remediation.
+
+### Upgrading in Docker
+
+Update the builder stage base image in your Dockerfiles:
+
+```dockerfile
+# Before
+FROM golang:1.24-alpine AS builder
+
+# After
+FROM golang:1.25.7-alpine AS builder
+```
+
+Both `docker/Dockerfile.server` and `docker/Dockerfile.agent` must be updated. After changing the base image, rebuild:
+
+```bash
+docker build -f docker/Dockerfile.server -t keldris-server .
+docker build -f docker/Dockerfile.agent -t keldris-agent .
+```
+
+### Upgrading in CI/CD
+
+Update the Go version in your CI/CD pipeline configuration:
+
+1. **GitHub Actions** - Update `go-version` in workflow files:
+   ```yaml
+   - uses: actions/setup-go@v5
+     with:
+       go-version: '1.25.7'
+   ```
+
+2. **GitLab CI** - Update the image tag:
+   ```yaml
+   image: golang:1.25.7-alpine
+   ```
+
+3. **Local development** - Update via your package manager or download from https://go.dev/dl/:
+   ```bash
+   # macOS (Homebrew)
+   brew upgrade go
+
+   # Verify
+   go version
+   ```
+
+Ensure all environments (development, CI, staging, production) use Go 1.25.7+ to avoid shipping binaries with known vulnerabilities.


### PR DESCRIPTION
## Summary
- Add infrastructure-requirements.md documenting Go 1.25.7+ minimum version
- Update Dockerfiles to Go 1.25.7-alpine with security comments
- Document three stdlib vulnerabilities (GO-2026-4341, GO-2026-4340, GO-2026-4337)
- Provide upgrade instructions for Docker, GitHub Actions, GitLab CI, and local dev

## Test plan
- Verify Docker builds succeed with new Go version
- Check README mentions Go 1.25.7+ requirement
- Confirm docs/infrastructure-requirements.md provides complete upgrade guidance