### PR TITLE
Add SSRF protection for webhook URLs

### DIFF
--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -181,7 +181,7 @@ func NewRouter(
 	alertsHandler.RegisterRoutes(apiV1)
 
 	notificationsGroup := apiV1.Group("", middleware.FeatureMiddleware(license.FeatureNotificationSlack, logger))
-	notificationsHandler := handlers.NewNotificationsHandler(database, keyManager, logger)
+	notificationsHandler := handlers.NewNotificationsHandlerWithEnv(database, keyManager, logger, cfg.Environment)
 	notificationsHandler.RegisterRoutes(notificationsGroup)
 
 	// Register reports handler if scheduler is available

--- a/internal/notifications/url_validator.go
+++ b/internal/notifications/url_validator.go
@@ -1,0 +1,88 @@
+package notifications
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+)
+
+// blockedCIDRs contains private and reserved IP ranges that must not be used as webhook targets.
+var blockedCIDRs = []string{
+	"10.0.0.0/8",
+	"172.16.0.0/12",
+	"192.168.0.0/16",
+	"127.0.0.0/8",
+	"169.254.0.0/16",
+	"::1/128",
+}
+
+// parsedBlockedNets holds the pre-parsed blocked networks.
+var parsedBlockedNets []*net.IPNet
+
+func init() {
+	for _, cidr := range blockedCIDRs {
+		_, ipNet, err := net.ParseCIDR(cidr)
+		if err != nil {
+			panic(fmt.Sprintf("invalid blocked CIDR %q: %v", cidr, err))
+		}
+		parsedBlockedNets = append(parsedBlockedNets, ipNet)
+	}
+}
+
+// ValidateWebhookURL validates that a webhook URL is safe to call.
+// It blocks private IP ranges, localhost, link-local addresses, and cloud metadata endpoints.
+// When requireHTTPS is true, only HTTPS URLs are allowed.
+func ValidateWebhookURL(urlStr string, requireHTTPS bool) error {
+	if strings.TrimSpace(urlStr) == "" {
+		return fmt.Errorf("webhook URL is required")
+	}
+
+	parsed, err := url.Parse(urlStr)
+	if err != nil {
+		return fmt.Errorf("invalid webhook URL: %w", err)
+	}
+
+	// Validate scheme
+	switch parsed.Scheme {
+	case "https":
+		// always allowed
+	case "http":
+		if requireHTTPS {
+			return fmt.Errorf("webhook URL must use HTTPS")
+		}
+	default:
+		return fmt.Errorf("webhook URL must use HTTP or HTTPS scheme")
+	}
+
+	host := parsed.Hostname()
+	if host == "" {
+		return fmt.Errorf("webhook URL must have a host")
+	}
+
+	// Resolve hostname to IP addresses
+	ips, err := net.LookupHost(host)
+	if err != nil {
+		return fmt.Errorf("failed to resolve webhook host %q: %w", host, err)
+	}
+
+	for _, ipStr := range ips {
+		ip := net.ParseIP(ipStr)
+		if ip == nil {
+			continue
+		}
+
+		for _, blocked := range parsedBlockedNets {
+			if blocked.Contains(ip) {
+				return fmt.Errorf("webhook URL resolves to blocked address %s", ipStr)
+			}
+		}
+
+		// Block unspecified addresses (0.0.0.0, ::)
+		if ip.IsUnspecified() {
+			return fmt.Errorf("webhook URL resolves to blocked address %s", ipStr)
+		}
+	}
+
+	return nil
+}

--- a/internal/notifications/url_validator_test.go
+++ b/internal/notifications/url_validator_test.go
@@ -1,0 +1,201 @@
+package notifications
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestValidateWebhookURL(t *testing.T) {
+	// Start a local HTTPS-less test server to get a resolvable non-private URL
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	t.Run("empty URL", func(t *testing.T) {
+		err := ValidateWebhookURL("", false)
+		if err == nil {
+			t.Fatal("expected error for empty URL")
+		}
+		if !strings.Contains(err.Error(), "required") {
+			t.Errorf("expected 'required' in error, got: %s", err)
+		}
+	})
+
+	t.Run("whitespace only URL", func(t *testing.T) {
+		err := ValidateWebhookURL("   ", false)
+		if err == nil {
+			t.Fatal("expected error for whitespace URL")
+		}
+	})
+
+	t.Run("invalid URL", func(t *testing.T) {
+		err := ValidateWebhookURL("://not-a-url", false)
+		if err == nil {
+			t.Fatal("expected error for invalid URL")
+		}
+	})
+
+	t.Run("non-http scheme", func(t *testing.T) {
+		err := ValidateWebhookURL("ftp://example.com/hook", false)
+		if err == nil {
+			t.Fatal("expected error for ftp scheme")
+		}
+		if !strings.Contains(err.Error(), "HTTP or HTTPS") {
+			t.Errorf("expected scheme error, got: %s", err)
+		}
+	})
+
+	t.Run("http allowed when HTTPS not required", func(t *testing.T) {
+		// Use the test server URL which is HTTP and resolves to 127.0.0.1
+		// This will be blocked by private IP check, so we just test scheme separately
+		err := ValidateWebhookURL("http://example.com/hook", false)
+		// This should pass scheme validation (may fail on DNS in CI, but scheme is fine)
+		if err != nil && strings.Contains(err.Error(), "HTTPS") {
+			t.Errorf("http should be allowed when requireHTTPS is false, got: %s", err)
+		}
+	})
+
+	t.Run("http blocked when HTTPS required", func(t *testing.T) {
+		err := ValidateWebhookURL("http://example.com/hook", true)
+		if err == nil {
+			t.Fatal("expected error for http when HTTPS required")
+		}
+		if !strings.Contains(err.Error(), "must use HTTPS") {
+			t.Errorf("expected HTTPS error, got: %s", err)
+		}
+	})
+
+	t.Run("https allowed when HTTPS required", func(t *testing.T) {
+		err := ValidateWebhookURL("https://example.com/hook", true)
+		if err != nil {
+			t.Errorf("expected no error for https URL, got: %s", err)
+		}
+	})
+
+	t.Run("block localhost 127.0.0.1", func(t *testing.T) {
+		err := ValidateWebhookURL("http://127.0.0.1/hook", false)
+		if err == nil {
+			t.Fatal("expected error for localhost IP")
+		}
+		if !strings.Contains(err.Error(), "blocked") {
+			t.Errorf("expected 'blocked' in error, got: %s", err)
+		}
+	})
+
+	t.Run("block localhost 127.0.0.2", func(t *testing.T) {
+		err := ValidateWebhookURL("http://127.0.0.2/hook", false)
+		if err == nil {
+			t.Fatal("expected error for 127.0.0.2")
+		}
+		if !strings.Contains(err.Error(), "blocked") {
+			t.Errorf("expected 'blocked' in error, got: %s", err)
+		}
+	})
+
+	t.Run("block 10.x.x.x", func(t *testing.T) {
+		err := ValidateWebhookURL("http://10.0.0.1/hook", false)
+		if err == nil {
+			t.Fatal("expected error for 10.x.x.x range")
+		}
+		if !strings.Contains(err.Error(), "blocked") {
+			t.Errorf("expected 'blocked' in error, got: %s", err)
+		}
+	})
+
+	t.Run("block 172.16.x.x", func(t *testing.T) {
+		err := ValidateWebhookURL("http://172.16.0.1/hook", false)
+		if err == nil {
+			t.Fatal("expected error for 172.16.x.x range")
+		}
+		if !strings.Contains(err.Error(), "blocked") {
+			t.Errorf("expected 'blocked' in error, got: %s", err)
+		}
+	})
+
+	t.Run("block 192.168.x.x", func(t *testing.T) {
+		err := ValidateWebhookURL("http://192.168.1.1/hook", false)
+		if err == nil {
+			t.Fatal("expected error for 192.168.x.x range")
+		}
+		if !strings.Contains(err.Error(), "blocked") {
+			t.Errorf("expected 'blocked' in error, got: %s", err)
+		}
+	})
+
+	t.Run("block link-local 169.254.x.x", func(t *testing.T) {
+		err := ValidateWebhookURL("http://169.254.1.1/hook", false)
+		if err == nil {
+			t.Fatal("expected error for link-local range")
+		}
+		if !strings.Contains(err.Error(), "blocked") {
+			t.Errorf("expected 'blocked' in error, got: %s", err)
+		}
+	})
+
+	t.Run("block metadata endpoint 169.254.169.254", func(t *testing.T) {
+		err := ValidateWebhookURL("http://169.254.169.254/latest/meta-data/", false)
+		if err == nil {
+			t.Fatal("expected error for metadata endpoint")
+		}
+		if !strings.Contains(err.Error(), "blocked") {
+			t.Errorf("expected 'blocked' in error, got: %s", err)
+		}
+	})
+
+	t.Run("block localhost hostname", func(t *testing.T) {
+		err := ValidateWebhookURL("http://localhost/hook", false)
+		if err == nil {
+			t.Fatal("expected error for localhost hostname")
+		}
+		if !strings.Contains(err.Error(), "blocked") {
+			t.Errorf("expected 'blocked' in error, got: %s", err)
+		}
+	})
+
+	t.Run("no host", func(t *testing.T) {
+		err := ValidateWebhookURL("http:///hook", false)
+		if err == nil {
+			t.Fatal("expected error for URL without host")
+		}
+		if !strings.Contains(err.Error(), "must have a host") {
+			t.Errorf("expected host error, got: %s", err)
+		}
+	})
+
+	t.Run("unresolvable host", func(t *testing.T) {
+		err := ValidateWebhookURL("https://this-host-does-not-exist-keldris-test.invalid/hook", false)
+		if err == nil {
+			t.Fatal("expected error for unresolvable host")
+		}
+		if !strings.Contains(err.Error(), "resolve") {
+			t.Errorf("expected resolve error, got: %s", err)
+		}
+	})
+
+	t.Run("valid public HTTPS URL", func(t *testing.T) {
+		err := ValidateWebhookURL("https://example.com/webhook", false)
+		if err != nil {
+			t.Errorf("expected no error for valid public URL, got: %s", err)
+		}
+	})
+
+	t.Run("valid public HTTPS URL with port", func(t *testing.T) {
+		err := ValidateWebhookURL("https://example.com:8443/webhook", true)
+		if err != nil {
+			t.Errorf("expected no error for valid public URL with port, got: %s", err)
+		}
+	})
+
+	t.Run("block IPv6 loopback", func(t *testing.T) {
+		err := ValidateWebhookURL("http://[::1]/hook", false)
+		if err == nil {
+			t.Fatal("expected error for IPv6 loopback")
+		}
+		if !strings.Contains(err.Error(), "blocked") {
+			t.Errorf("expected 'blocked' in error, got: %s", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Implements Server-Side Request Forgery (SSRF) protection for webhook URLs to prevent exploitation of internal network resources. Validates URLs against private IP ranges, localhost, link-local addresses, and cloud metadata endpoints at both the API boundary and webhook send time for defense in depth.

## Changes

- **url_validator.go**: New SSRF validation module blocking private IPs (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16), localhost (127.0.0.0/8, ::1), link-local (169.254.0.0/16), and metadata endpoints
- **handlers/notifications.go**: Validates webhook URLs on create/update with HTTPS enforcement in production/staging
- **webhook.go**: Defense-in-depth validation before sending webhooks
- **Routes**: Environment-aware handler initialization for HTTPS enforcement
- **Tests**: 17 new test cases covering all blocked IP ranges and validation scenarios

## Test Plan

- All existing tests pass (notifications, handlers, service)
- New SSRF validator tests: empty URLs, invalid schemes, all blocked IP ranges, IPv6 loopback, unresolvable hosts
- Service webhook tests updated to work with validation via test factories
- `go test ./internal/notifications/... -v` passes
- `go test ./internal/api/handlers/... -v` passes