### PR TITLE
Add query string redaction to prevent sensitive data in logs

### DIFF
--- a/internal/api/middleware/logger.go
+++ b/internal/api/middleware/logger.go
@@ -1,11 +1,52 @@
 package middleware
 
 import (
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/rs/zerolog"
 )
+
+// sensitiveParams lists query parameter names whose values must be redacted from logs.
+var sensitiveParams = map[string]bool{
+	"token":    true,
+	"key":      true,
+	"secret":   true,
+	"password": true,
+	"code":     true,
+	"state":    true,
+}
+
+// redactQueryString replaces values of known sensitive query parameters with [REDACTED].
+func redactQueryString(rawQuery string) string {
+	if rawQuery == "" {
+		return ""
+	}
+
+	params, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		return rawQuery
+	}
+
+	redacted := false
+	for name, values := range params {
+		if sensitiveParams[strings.ToLower(name)] {
+			for i := range values {
+				values[i] = "[REDACTED]"
+			}
+			params[name] = values
+			redacted = true
+		}
+	}
+
+	if !redacted {
+		return rawQuery
+	}
+
+	return params.Encode()
+}
 
 // RequestLogger returns a middleware that logs HTTP requests using zerolog.
 func RequestLogger(logger zerolog.Logger) gin.HandlerFunc {
@@ -14,7 +55,7 @@ func RequestLogger(logger zerolog.Logger) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		start := time.Now()
 		path := c.Request.URL.Path
-		query := c.Request.URL.RawQuery
+		query := redactQueryString(c.Request.URL.RawQuery)
 
 		c.Next()
 

--- a/internal/api/middleware/logger_test.go
+++ b/internal/api/middleware/logger_test.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -53,4 +54,76 @@ func TestRequestLogger(t *testing.T) {
 			t.Fatalf("expected status 400, got %d", w.Code)
 		}
 	})
+}
+
+func TestRedactQueryString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantKeys map[string]string // expected key -> value after redaction
+	}{
+		{
+			name:  "empty query",
+			input: "",
+		},
+		{
+			name:     "no sensitive params",
+			input:    "page=1&limit=10",
+			wantKeys: map[string]string{"page": "1", "limit": "10"},
+		},
+		{
+			name:     "single sensitive param",
+			input:    "token=abc123",
+			wantKeys: map[string]string{"token": "[REDACTED]"},
+		},
+		{
+			name:     "multiple sensitive params",
+			input:    "token=abc&secret=xyz&password=hunter2",
+			wantKeys: map[string]string{"token": "[REDACTED]", "secret": "[REDACTED]", "password": "[REDACTED]"},
+		},
+		{
+			name:     "mixed safe and sensitive params",
+			input:    "page=1&token=abc&limit=10&code=authcode",
+			wantKeys: map[string]string{"page": "1", "token": "[REDACTED]", "limit": "10", "code": "[REDACTED]"},
+		},
+		{
+			name:     "all sensitive param names",
+			input:    "token=a&key=b&secret=c&password=d&code=e&state=f",
+			wantKeys: map[string]string{"token": "[REDACTED]", "key": "[REDACTED]", "secret": "[REDACTED]", "password": "[REDACTED]", "code": "[REDACTED]", "state": "[REDACTED]"},
+		},
+		{
+			name:     "case insensitive param names",
+			input:    "Token=abc&KEY=xyz&Secret=123",
+			wantKeys: map[string]string{"Token": "[REDACTED]", "KEY": "[REDACTED]", "Secret": "[REDACTED]"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := redactQueryString(tt.input)
+
+			if tt.input == "" {
+				if result != "" {
+					t.Fatalf("expected empty string, got %q", result)
+				}
+				return
+			}
+
+			parsed, err := url.ParseQuery(result)
+			if err != nil {
+				t.Fatalf("failed to parse redacted query: %v", err)
+			}
+
+			for key, wantVal := range tt.wantKeys {
+				got := parsed.Get(key)
+				if got != wantVal {
+					t.Errorf("param %q: expected %q, got %q", key, wantVal, got)
+				}
+			}
+
+			if len(parsed) != len(tt.wantKeys) {
+				t.Errorf("expected %d params, got %d", len(tt.wantKeys), len(parsed))
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary
- Add `redactQueryString()` function to redact sensitive query parameters before logging
- Redacts: token, key, secret, password, code, state (case-insensitive)
- Applied to HTTP request logging middleware

## Implementation
The middleware now automatically replaces values of sensitive parameters with `[REDACTED]` to prevent accidental credential exposure in logs, while preserving non-sensitive query parameters.

## Testing
Added 7 test cases covering empty queries, no sensitive params, single/multiple sensitive params, mixed safe/sensitive, and case-insensitive matching.