### PR TITLE
Add Teams and Discord to notification validation

### DIFF
--- a/internal/api/handlers/notifications.go
+++ b/internal/api/handlers/notifications.go
@@ -596,7 +596,7 @@ func (h *NotificationsHandler) validateWebhookConfig(rawConfig json.RawMessage) 
 // isValidChannelType checks if a channel type is valid.
 func isValidChannelType(t models.NotificationChannelType) bool {
 	switch t {
-	case models.ChannelTypeEmail, models.ChannelTypeSlack, models.ChannelTypeWebhook, models.ChannelTypePagerDuty:
+	case models.ChannelTypeEmail, models.ChannelTypeSlack, models.ChannelTypeWebhook, models.ChannelTypePagerDuty, models.ChannelTypeTeams, models.ChannelTypeDiscord:
 		return true
 	default:
 		return false
@@ -606,7 +606,7 @@ func isValidChannelType(t models.NotificationChannelType) bool {
 // isValidEventType checks if an event type is valid.
 func isValidEventType(t models.NotificationEventType) bool {
 	switch t {
-	case models.EventBackupSuccess, models.EventBackupFailed, models.EventAgentOffline:
+	case models.EventBackupSuccess, models.EventBackupFailed, models.EventAgentOffline, models.EventMaintenanceScheduled:
 		return true
 	default:
 		return false


### PR DESCRIPTION
## Summary

- Add `ChannelTypeTeams` and `ChannelTypeDiscord` to `isValidChannelType()`
- Add `EventMaintenanceScheduled` to `isValidEventType()`

These channel types and event types are already defined in models but weren't being validated by the handler.

## Test plan

- `make test` passes for handler tests (85.3% coverage)
- `go vet ./...` passes