### PR TITLE
Fix missing ON DELETE clause in offline_licenses foreign key

### DIFF
--- a/internal/db/migrations/034_fix_offline_licenses_fk.sql
+++ b/internal/db/migrations/034_fix_offline_licenses_fk.sql
@@ -1,0 +1,9 @@
+-- Migration: Fix offline_licenses uploaded_by foreign key to SET NULL on user deletion
+
+ALTER TABLE offline_licenses ALTER COLUMN uploaded_by DROP NOT NULL;
+
+ALTER TABLE offline_licenses DROP CONSTRAINT IF EXISTS offline_licenses_uploaded_by_fkey;
+
+ALTER TABLE offline_licenses
+    ADD CONSTRAINT offline_licenses_uploaded_by_fkey
+    FOREIGN KEY (uploaded_by) REFERENCES users(id) ON DELETE SET NULL;


### PR DESCRIPTION
## Summary
- Fixes the `uploaded_by` foreign key constraint in the `offline_licenses` table to use `ON DELETE SET NULL`
- Removes the restrictive default `ON DELETE RESTRICT` behavior that would block user deletion
- Makes the column nullable to support the SET NULL action

## Test plan
- Run migrations: `make migrate`
- Verify Go tests pass: `make test` (Go tests)