### PR TITLE
Add Docker Backup API and UI

### DIFF
--- a/internal/api/handlers/docker_backup.go
+++ b/internal/api/handlers/docker_backup.go
@@ -1,0 +1,255 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/MacJediWizard/keldris/internal/api/middleware"
+	"github.com/MacJediWizard/keldris/internal/models"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+)
+
+// DockerBackupRequest is the request body for triggering a Docker backup.
+type DockerBackupRequest struct {
+	AgentID      string   `json:"agent_id" binding:"required" example:"550e8400-e29b-41d4-a716-446655440000"`
+	RepositoryID string   `json:"repository_id" binding:"required" example:"550e8400-e29b-41d4-a716-446655440001"`
+	ContainerIDs []string `json:"container_ids,omitempty"`
+	VolumeNames  []string `json:"volume_names,omitempty"`
+}
+
+// DockerBackupStore defines the interface for Docker backup persistence operations.
+type DockerBackupStore interface {
+	GetDockerContainers(ctx context.Context, orgID uuid.UUID, agentID uuid.UUID) ([]models.DockerContainer, error)
+	GetDockerVolumes(ctx context.Context, orgID uuid.UUID, agentID uuid.UUID) ([]models.DockerVolume, error)
+	GetDockerDaemonStatus(ctx context.Context, orgID uuid.UUID, agentID uuid.UUID) (*models.DockerDaemonStatus, error)
+	CreateDockerBackup(ctx context.Context, orgID uuid.UUID, req *models.DockerBackupParams) (*models.DockerBackupResult, error)
+}
+
+// DockerBackupHandler handles Docker backup-related HTTP endpoints.
+type DockerBackupHandler struct {
+	store  DockerBackupStore
+	logger zerolog.Logger
+}
+
+// NewDockerBackupHandler creates a new DockerBackupHandler.
+func NewDockerBackupHandler(store DockerBackupStore, logger zerolog.Logger) *DockerBackupHandler {
+	return &DockerBackupHandler{
+		store:  store,
+		logger: logger.With().Str("component", "docker_backup_handler").Logger(),
+	}
+}
+
+// RegisterRoutes registers Docker backup routes on the given router group.
+func (h *DockerBackupHandler) RegisterRoutes(r *gin.RouterGroup) {
+	docker := r.Group("/docker")
+	{
+		docker.GET("/containers", h.ListContainers)
+		docker.GET("/volumes", h.ListVolumes)
+		docker.POST("/backup", h.TriggerBackup)
+		docker.GET("/status", h.DaemonStatus)
+	}
+}
+
+// ListContainers returns Docker containers for a given agent.
+//
+//	@Summary		List Docker containers
+//	@Description	Returns all Docker containers on the specified agent
+//	@Tags			Docker
+//	@Accept			json
+//	@Produce		json
+//	@Param			agent_id	query		string	true	"Agent ID"
+//	@Success		200			{object}	map[string][]DockerContainer
+//	@Failure		400			{object}	map[string]string
+//	@Failure		401			{object}	map[string]string
+//	@Failure		500			{object}	map[string]string
+//	@Security		SessionAuth
+//	@Router			/docker/containers [get]
+func (h *DockerBackupHandler) ListContainers(c *gin.Context) {
+	user := middleware.RequireUser(c)
+	if user == nil {
+		return
+	}
+
+	if user.CurrentOrgID == uuid.Nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "no organization selected"})
+		return
+	}
+
+	agentIDParam := c.Query("agent_id")
+	if agentIDParam == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "agent_id is required"})
+		return
+	}
+
+	agentID, err := uuid.Parse(agentIDParam)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid agent_id"})
+		return
+	}
+
+	containers, err := h.store.GetDockerContainers(c.Request.Context(), user.CurrentOrgID, agentID)
+	if err != nil {
+		h.logger.Error().Err(err).Str("agent_id", agentID.String()).Msg("failed to list docker containers")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list docker containers"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"containers": containers})
+}
+
+// ListVolumes returns Docker volumes for a given agent.
+//
+//	@Summary		List Docker volumes
+//	@Description	Returns all Docker volumes on the specified agent
+//	@Tags			Docker
+//	@Accept			json
+//	@Produce		json
+//	@Param			agent_id	query		string	true	"Agent ID"
+//	@Success		200			{object}	map[string][]DockerVolume
+//	@Failure		400			{object}	map[string]string
+//	@Failure		401			{object}	map[string]string
+//	@Failure		500			{object}	map[string]string
+//	@Security		SessionAuth
+//	@Router			/docker/volumes [get]
+func (h *DockerBackupHandler) ListVolumes(c *gin.Context) {
+	user := middleware.RequireUser(c)
+	if user == nil {
+		return
+	}
+
+	if user.CurrentOrgID == uuid.Nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "no organization selected"})
+		return
+	}
+
+	agentIDParam := c.Query("agent_id")
+	if agentIDParam == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "agent_id is required"})
+		return
+	}
+
+	agentID, err := uuid.Parse(agentIDParam)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid agent_id"})
+		return
+	}
+
+	volumes, err := h.store.GetDockerVolumes(c.Request.Context(), user.CurrentOrgID, agentID)
+	if err != nil {
+		h.logger.Error().Err(err).Str("agent_id", agentID.String()).Msg("failed to list docker volumes")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list docker volumes"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"volumes": volumes})
+}
+
+// TriggerBackup triggers a Docker backup for the specified containers and volumes.
+//
+//	@Summary		Trigger Docker backup
+//	@Description	Queues a Docker backup for selected containers and volumes
+//	@Tags			Docker
+//	@Accept			json
+//	@Produce		json
+//	@Param			request	body		DockerBackupRequest	true	"Backup details"
+//	@Success		202		{object}	DockerBackupResponse
+//	@Failure		400		{object}	map[string]string
+//	@Failure		401		{object}	map[string]string
+//	@Failure		500		{object}	map[string]string
+//	@Security		SessionAuth
+//	@Router			/docker/backup [post]
+func (h *DockerBackupHandler) TriggerBackup(c *gin.Context) {
+	user := middleware.RequireUser(c)
+	if user == nil {
+		return
+	}
+
+	if user.CurrentOrgID == uuid.Nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "no organization selected"})
+		return
+	}
+
+	var req DockerBackupRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request: " + err.Error()})
+		return
+	}
+
+	if len(req.ContainerIDs) == 0 && len(req.VolumeNames) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "at least one container or volume must be selected"})
+		return
+	}
+
+	params := &models.DockerBackupParams{
+		AgentID:      req.AgentID,
+		RepositoryID: req.RepositoryID,
+		ContainerIDs: req.ContainerIDs,
+		VolumeNames:  req.VolumeNames,
+	}
+
+	resp, err := h.store.CreateDockerBackup(c.Request.Context(), user.CurrentOrgID, params)
+	if err != nil {
+		h.logger.Error().Err(err).Str("agent_id", req.AgentID).Msg("failed to trigger docker backup")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to trigger docker backup"})
+		return
+	}
+
+	h.logger.Info().
+		Str("backup_id", resp.ID).
+		Str("agent_id", req.AgentID).
+		Int("containers", len(req.ContainerIDs)).
+		Int("volumes", len(req.VolumeNames)).
+		Msg("docker backup triggered")
+
+	c.JSON(http.StatusAccepted, resp)
+}
+
+// DaemonStatus returns the Docker daemon status for a given agent.
+//
+//	@Summary		Get Docker daemon status
+//	@Description	Returns Docker daemon status on the specified agent
+//	@Tags			Docker
+//	@Accept			json
+//	@Produce		json
+//	@Param			agent_id	query		string	true	"Agent ID"
+//	@Success		200			{object}	DockerDaemonStatus
+//	@Failure		400			{object}	map[string]string
+//	@Failure		401			{object}	map[string]string
+//	@Failure		500			{object}	map[string]string
+//	@Security		SessionAuth
+//	@Router			/docker/status [get]
+func (h *DockerBackupHandler) DaemonStatus(c *gin.Context) {
+	user := middleware.RequireUser(c)
+	if user == nil {
+		return
+	}
+
+	if user.CurrentOrgID == uuid.Nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "no organization selected"})
+		return
+	}
+
+	agentIDParam := c.Query("agent_id")
+	if agentIDParam == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "agent_id is required"})
+		return
+	}
+
+	agentID, err := uuid.Parse(agentIDParam)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid agent_id"})
+		return
+	}
+
+	status, err := h.store.GetDockerDaemonStatus(c.Request.Context(), user.CurrentOrgID, agentID)
+	if err != nil {
+		h.logger.Error().Err(err).Str("agent_id", agentID.String()).Msg("failed to get docker daemon status")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get docker daemon status"})
+		return
+	}
+
+	c.JSON(http.StatusOK, status)
+}
+

--- a/internal/api/handlers/docker_backup_test.go
+++ b/internal/api/handlers/docker_backup_test.go
@@ -1,0 +1,410 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/MacJediWizard/keldris/internal/api/middleware"
+	"github.com/MacJediWizard/keldris/internal/auth"
+	"github.com/MacJediWizard/keldris/internal/models"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+)
+
+type mockDockerBackupStore struct {
+	containers    []models.DockerContainer
+	volumes       []models.DockerVolume
+	daemonStatus  *models.DockerDaemonStatus
+	backupResp    *models.DockerBackupResult
+	containersErr error
+	volumesErr    error
+	statusErr     error
+	backupErr     error
+}
+
+func (m *mockDockerBackupStore) GetDockerContainers(_ context.Context, _ uuid.UUID, _ uuid.UUID) ([]models.DockerContainer, error) {
+	if m.containersErr != nil {
+		return nil, m.containersErr
+	}
+	return m.containers, nil
+}
+
+func (m *mockDockerBackupStore) GetDockerVolumes(_ context.Context, _ uuid.UUID, _ uuid.UUID) ([]models.DockerVolume, error) {
+	if m.volumesErr != nil {
+		return nil, m.volumesErr
+	}
+	return m.volumes, nil
+}
+
+func (m *mockDockerBackupStore) GetDockerDaemonStatus(_ context.Context, _ uuid.UUID, _ uuid.UUID) (*models.DockerDaemonStatus, error) {
+	if m.statusErr != nil {
+		return nil, m.statusErr
+	}
+	return m.daemonStatus, nil
+}
+
+func (m *mockDockerBackupStore) CreateDockerBackup(_ context.Context, _ uuid.UUID, _ *models.DockerBackupParams) (*models.DockerBackupResult, error) {
+	if m.backupErr != nil {
+		return nil, m.backupErr
+	}
+	return m.backupResp, nil
+}
+
+func setupDockerBackupTestRouter(store DockerBackupStore, user *auth.SessionUser) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		if user != nil {
+			c.Set(string(middleware.UserContextKey), user)
+		}
+		c.Next()
+	})
+
+	handler := NewDockerBackupHandler(store, zerolog.Nop())
+	api := r.Group("/api/v1")
+	handler.RegisterRoutes(api)
+	return r
+}
+
+func TestListDockerContainers(t *testing.T) {
+	orgID := uuid.New()
+	agentID := uuid.New()
+
+	store := &mockDockerBackupStore{
+		containers: []models.DockerContainer{
+			{ID: "c1", Name: "app", Image: "nginx:latest", Status: "Up", State: "running"},
+		},
+	}
+
+	user := &auth.SessionUser{
+		ID:           uuid.New(),
+		CurrentOrgID: orgID,
+	}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupDockerBackupTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/docker/containers?agent_id="+agentID.String(), nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+		}
+
+		var resp map[string]json.RawMessage
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to unmarshal response: %v", err)
+		}
+		if _, ok := resp["containers"]; !ok {
+			t.Fatal("expected 'containers' key in response")
+		}
+	})
+
+	t.Run("missing agent_id", func(t *testing.T) {
+		r := setupDockerBackupTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/docker/containers", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected status 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("invalid agent_id", func(t *testing.T) {
+		r := setupDockerBackupTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/docker/containers?agent_id=invalid", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected status 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("no org selected", func(t *testing.T) {
+		noOrgUser := &auth.SessionUser{ID: uuid.New()}
+		r := setupDockerBackupTestRouter(store, noOrgUser)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/docker/containers?agent_id="+agentID.String(), nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected status 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("unauthenticated", func(t *testing.T) {
+		r := setupDockerBackupTestRouter(store, nil)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/docker/containers?agent_id="+agentID.String(), nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("expected status 401, got %d", w.Code)
+		}
+	})
+
+	t.Run("store error", func(t *testing.T) {
+		errStore := &mockDockerBackupStore{containersErr: errors.New("db error")}
+		r := setupDockerBackupTestRouter(errStore, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/docker/containers?agent_id="+agentID.String(), nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("expected status 500, got %d", w.Code)
+		}
+	})
+}
+
+func TestListDockerVolumes(t *testing.T) {
+	orgID := uuid.New()
+	agentID := uuid.New()
+
+	store := &mockDockerBackupStore{
+		volumes: []models.DockerVolume{
+			{Name: "data", Driver: "local", SizeBytes: 1024},
+		},
+	}
+
+	user := &auth.SessionUser{
+		ID:           uuid.New(),
+		CurrentOrgID: orgID,
+	}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupDockerBackupTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/docker/volumes?agent_id="+agentID.String(), nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+		}
+
+		var resp map[string]json.RawMessage
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to unmarshal response: %v", err)
+		}
+		if _, ok := resp["volumes"]; !ok {
+			t.Fatal("expected 'volumes' key in response")
+		}
+	})
+
+	t.Run("missing agent_id", func(t *testing.T) {
+		r := setupDockerBackupTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/docker/volumes", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected status 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("unauthenticated", func(t *testing.T) {
+		r := setupDockerBackupTestRouter(store, nil)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/docker/volumes?agent_id="+agentID.String(), nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("expected status 401, got %d", w.Code)
+		}
+	})
+
+	t.Run("store error", func(t *testing.T) {
+		errStore := &mockDockerBackupStore{volumesErr: errors.New("db error")}
+		r := setupDockerBackupTestRouter(errStore, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/docker/volumes?agent_id="+agentID.String(), nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("expected status 500, got %d", w.Code)
+		}
+	})
+}
+
+func TestDockerDaemonStatus(t *testing.T) {
+	orgID := uuid.New()
+	agentID := uuid.New()
+
+	store := &mockDockerBackupStore{
+		daemonStatus: &models.DockerDaemonStatus{
+			Available:      true,
+			Version:        "24.0.7",
+			ContainerCount: 5,
+			VolumeCount:    3,
+		},
+	}
+
+	user := &auth.SessionUser{
+		ID:           uuid.New(),
+		CurrentOrgID: orgID,
+	}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupDockerBackupTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/docker/status?agent_id="+agentID.String(), nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+		}
+
+		var resp models.DockerDaemonStatus
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to unmarshal response: %v", err)
+		}
+		if !resp.Available {
+			t.Fatal("expected daemon to be available")
+		}
+	})
+
+	t.Run("missing agent_id", func(t *testing.T) {
+		r := setupDockerBackupTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/docker/status", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected status 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("unauthenticated", func(t *testing.T) {
+		r := setupDockerBackupTestRouter(store, nil)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/docker/status?agent_id="+agentID.String(), nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("expected status 401, got %d", w.Code)
+		}
+	})
+
+	t.Run("store error", func(t *testing.T) {
+		errStore := &mockDockerBackupStore{statusErr: errors.New("connection refused")}
+		r := setupDockerBackupTestRouter(errStore, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/docker/status?agent_id="+agentID.String(), nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("expected status 500, got %d", w.Code)
+		}
+	})
+}
+
+func TestTriggerDockerBackup(t *testing.T) {
+	orgID := uuid.New()
+
+	store := &mockDockerBackupStore{
+		backupResp: &models.DockerBackupResult{
+			ID:        uuid.New().String(),
+			Status:    "queued",
+			CreatedAt: "2024-01-01T00:00:00Z",
+		},
+	}
+
+	user := &auth.SessionUser{
+		ID:           uuid.New(),
+		CurrentOrgID: orgID,
+	}
+
+	t.Run("success", func(t *testing.T) {
+		r := setupDockerBackupTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"agent_id":"` + uuid.New().String() + `","repository_id":"` + uuid.New().String() + `","container_ids":["c1"],"volume_names":["v1"]}`
+		req, _ := http.NewRequest("POST", "/api/v1/docker/backup", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusAccepted {
+			t.Fatalf("expected status 202, got %d: %s", w.Code, w.Body.String())
+		}
+
+		var resp models.DockerBackupResult
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to unmarshal response: %v", err)
+		}
+		if resp.Status != "queued" {
+			t.Fatalf("expected status 'queued', got '%s'", resp.Status)
+		}
+	})
+
+	t.Run("no items selected", func(t *testing.T) {
+		r := setupDockerBackupTestRouter(store, user)
+		w := httptest.NewRecorder()
+		body := `{"agent_id":"` + uuid.New().String() + `","repository_id":"` + uuid.New().String() + `"}`
+		req, _ := http.NewRequest("POST", "/api/v1/docker/backup", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected status 400, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("invalid request body", func(t *testing.T) {
+		r := setupDockerBackupTestRouter(store, user)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("POST", "/api/v1/docker/backup", strings.NewReader(`{}`))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected status 400, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("no org selected", func(t *testing.T) {
+		noOrgUser := &auth.SessionUser{ID: uuid.New()}
+		r := setupDockerBackupTestRouter(store, noOrgUser)
+		w := httptest.NewRecorder()
+		body := `{"agent_id":"` + uuid.New().String() + `","repository_id":"` + uuid.New().String() + `","container_ids":["c1"]}`
+		req, _ := http.NewRequest("POST", "/api/v1/docker/backup", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected status 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("unauthenticated", func(t *testing.T) {
+		r := setupDockerBackupTestRouter(store, nil)
+		w := httptest.NewRecorder()
+		body := `{"agent_id":"` + uuid.New().String() + `","repository_id":"` + uuid.New().String() + `","container_ids":["c1"]}`
+		req, _ := http.NewRequest("POST", "/api/v1/docker/backup", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("expected status 401, got %d", w.Code)
+		}
+	})
+
+	t.Run("store error", func(t *testing.T) {
+		errStore := &mockDockerBackupStore{backupErr: errors.New("backup failed")}
+		r := setupDockerBackupTestRouter(errStore, user)
+		w := httptest.NewRecorder()
+		body := `{"agent_id":"` + uuid.New().String() + `","repository_id":"` + uuid.New().String() + `","container_ids":["c1"]}`
+		req, _ := http.NewRequest("POST", "/api/v1/docker/backup", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("expected status 500, got %d", w.Code)
+		}
+	})
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -226,6 +226,11 @@ func NewRouter(
 	maintenanceHandler := handlers.NewMaintenanceHandler(database, logger)
 	maintenanceHandler.RegisterRoutes(apiV1)
 
+	// Docker backup routes (Pro+)
+	dockerBackupGroup := apiV1.Group("", middleware.FeatureMiddleware(license.FeatureDockerBackup, logger))
+	dockerBackupHandler := handlers.NewDockerBackupHandler(database, logger)
+	dockerBackupHandler.RegisterRoutes(dockerBackupGroup)
+
 	// Branding routes (Enterprise - White Label)
 	brandingGroup := apiV1.Group("", middleware.FeatureMiddleware(license.FeatureWhiteLabel, logger))
 	brandingHandler := handlers.NewBrandingHandler(database, logger)

--- a/internal/models/docker_backup.go
+++ b/internal/models/docker_backup.go
@@ -1,0 +1,47 @@
+package models
+
+// DockerContainer represents a Docker container on an agent.
+type DockerContainer struct {
+	ID      string   `json:"id"`
+	Name    string   `json:"name"`
+	Image   string   `json:"image"`
+	Status  string   `json:"status"`
+	State   string   `json:"state"`
+	Created string   `json:"created"`
+	Ports   []string `json:"ports,omitempty"`
+}
+
+// DockerVolume represents a Docker volume on an agent.
+type DockerVolume struct {
+	Name       string `json:"name"`
+	Driver     string `json:"driver"`
+	Mountpoint string `json:"mountpoint"`
+	SizeBytes  int64  `json:"size_bytes"`
+	Created    string `json:"created"`
+}
+
+// DockerDaemonStatus represents Docker daemon status on an agent.
+type DockerDaemonStatus struct {
+	Available      bool   `json:"available"`
+	Version        string `json:"version,omitempty"`
+	ContainerCount int    `json:"container_count"`
+	VolumeCount    int    `json:"volume_count"`
+	ServerOS       string `json:"server_os,omitempty"`
+	DockerRootDir  string `json:"docker_root_dir,omitempty"`
+	StorageDriver  string `json:"storage_driver,omitempty"`
+}
+
+// DockerBackupParams holds the parameters for creating a Docker backup.
+type DockerBackupParams struct {
+	AgentID      string   `json:"agent_id"`
+	RepositoryID string   `json:"repository_id"`
+	ContainerIDs []string `json:"container_ids,omitempty"`
+	VolumeNames  []string `json:"volume_names,omitempty"`
+}
+
+// DockerBackupResult holds the result of a triggered Docker backup.
+type DockerBackupResult struct {
+	ID        string `json:"id"`
+	Status    string `json:"status"`
+	CreatedAt string `json:"created_at"`
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -36,6 +36,7 @@ const Maintenance = lazy(() => import('./pages/Maintenance'));
 const NewOrganization = lazy(() => import('./pages/NewOrganization'));
 const Onboarding = lazy(() => import('./pages/Onboarding'));
 const SLATracking = lazy(() => import('./pages/SLATracking'));
+const DockerBackup = lazy(() => import('./pages/DockerBackup'));
 const AirGapLicense = lazy(() => import('./pages/AirGapLicense'));
 
 const queryClient = new QueryClient({
@@ -99,6 +100,7 @@ function App() {
 								element={<Maintenance />}
 							/>
 							<Route path="organization/new" element={<NewOrganization />} />
+							<Route path="docker-backup" element={<DockerBackup />} />
 							<Route path="sla" element={<SLATracking />} />
 							<Route path="onboarding" element={<Onboarding />} />
 							<Route path="system/airgap" element={<AirGapLicense />} />

--- a/web/src/hooks/useDockerBackup.test.ts
+++ b/web/src/hooks/useDockerBackup.test.ts
@@ -1,0 +1,193 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import {
+	useDockerContainers,
+	useDockerDaemonStatus,
+	useDockerVolumes,
+	useTriggerDockerBackup,
+} from './useDockerBackup';
+
+vi.mock('../lib/api', () => ({
+	dockerBackupApi: {
+		listContainers: vi.fn(),
+		listVolumes: vi.fn(),
+		getDaemonStatus: vi.fn(),
+		triggerBackup: vi.fn(),
+	},
+}));
+
+import { dockerBackupApi } from '../lib/api';
+
+const mockContainers = [
+	{
+		id: 'c1',
+		name: 'app',
+		image: 'nginx:latest',
+		status: 'Up 2 hours',
+		state: 'running',
+		created: '2024-01-01T00:00:00Z',
+		ports: ['80/tcp'],
+	},
+];
+
+const mockVolumes = [
+	{
+		name: 'data',
+		driver: 'local',
+		mountpoint: '/var/lib/docker/volumes/data/_data',
+		size_bytes: 1048576,
+		created: '2024-01-01T00:00:00Z',
+	},
+];
+
+const mockDaemonStatus = {
+	available: true,
+	version: '24.0.7',
+	container_count: 5,
+	volume_count: 3,
+	server_os: 'linux',
+	docker_root_dir: '/var/lib/docker',
+	storage_driver: 'overlay2',
+};
+
+describe('useDockerContainers', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches containers for an agent', async () => {
+		vi.mocked(dockerBackupApi.listContainers).mockResolvedValue(mockContainers);
+
+		const { result } = renderHook(() => useDockerContainers('agent-1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual(mockContainers);
+		expect(dockerBackupApi.listContainers).toHaveBeenCalledWith('agent-1');
+	});
+
+	it('does not fetch when agentId is empty', () => {
+		renderHook(() => useDockerContainers(''), {
+			wrapper: createWrapper(),
+		});
+
+		expect(dockerBackupApi.listContainers).not.toHaveBeenCalled();
+	});
+
+	it('handles error state', async () => {
+		vi.mocked(dockerBackupApi.listContainers).mockRejectedValue(
+			new Error('Network error'),
+		);
+
+		const { result } = renderHook(() => useDockerContainers('agent-1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isError).toBe(true));
+	});
+});
+
+describe('useDockerVolumes', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches volumes for an agent', async () => {
+		vi.mocked(dockerBackupApi.listVolumes).mockResolvedValue(mockVolumes);
+
+		const { result } = renderHook(() => useDockerVolumes('agent-1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual(mockVolumes);
+		expect(dockerBackupApi.listVolumes).toHaveBeenCalledWith('agent-1');
+	});
+
+	it('does not fetch when agentId is empty', () => {
+		renderHook(() => useDockerVolumes(''), {
+			wrapper: createWrapper(),
+		});
+
+		expect(dockerBackupApi.listVolumes).not.toHaveBeenCalled();
+	});
+});
+
+describe('useDockerDaemonStatus', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches daemon status for an agent', async () => {
+		vi.mocked(dockerBackupApi.getDaemonStatus).mockResolvedValue(
+			mockDaemonStatus,
+		);
+
+		const { result } = renderHook(() => useDockerDaemonStatus('agent-1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual(mockDaemonStatus);
+		expect(dockerBackupApi.getDaemonStatus).toHaveBeenCalledWith('agent-1');
+	});
+
+	it('does not fetch when agentId is empty', () => {
+		renderHook(() => useDockerDaemonStatus(''), {
+			wrapper: createWrapper(),
+		});
+
+		expect(dockerBackupApi.getDaemonStatus).not.toHaveBeenCalled();
+	});
+});
+
+describe('useTriggerDockerBackup', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('triggers a docker backup', async () => {
+		const mockResponse = {
+			id: 'backup-1',
+			status: 'queued',
+			created_at: '2024-01-01T00:00:00Z',
+		};
+		vi.mocked(dockerBackupApi.triggerBackup).mockResolvedValue(mockResponse);
+
+		const { result } = renderHook(() => useTriggerDockerBackup(), {
+			wrapper: createWrapper(),
+		});
+
+		const request = {
+			agent_id: 'agent-1',
+			repository_id: 'repo-1',
+			container_ids: ['c1'],
+			volume_names: ['v1'],
+		};
+
+		result.current.mutate(request);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(dockerBackupApi.triggerBackup).toHaveBeenCalledWith(request);
+	});
+
+	it('handles backup error', async () => {
+		vi.mocked(dockerBackupApi.triggerBackup).mockRejectedValue(
+			new Error('Backup failed'),
+		);
+
+		const { result } = renderHook(() => useTriggerDockerBackup(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({
+			agent_id: 'agent-1',
+			repository_id: 'repo-1',
+			container_ids: ['c1'],
+		});
+
+		await waitFor(() => expect(result.current.isError).toBe(true));
+	});
+});

--- a/web/src/hooks/useDockerBackup.ts
+++ b/web/src/hooks/useDockerBackup.ts
@@ -1,0 +1,43 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { dockerBackupApi } from '../lib/api';
+import type { DockerBackupRequest } from '../lib/types';
+
+export function useDockerContainers(agentId: string) {
+	return useQuery({
+		queryKey: ['docker', 'containers', agentId],
+		queryFn: () => dockerBackupApi.listContainers(agentId),
+		enabled: !!agentId,
+		staleTime: 30 * 1000,
+	});
+}
+
+export function useDockerVolumes(agentId: string) {
+	return useQuery({
+		queryKey: ['docker', 'volumes', agentId],
+		queryFn: () => dockerBackupApi.listVolumes(agentId),
+		enabled: !!agentId,
+		staleTime: 30 * 1000,
+	});
+}
+
+export function useDockerDaemonStatus(agentId: string) {
+	return useQuery({
+		queryKey: ['docker', 'status', agentId],
+		queryFn: () => dockerBackupApi.getDaemonStatus(agentId),
+		enabled: !!agentId,
+		staleTime: 30 * 1000,
+	});
+}
+
+export function useTriggerDockerBackup() {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: (data: DockerBackupRequest) =>
+			dockerBackupApi.triggerBackup(data),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ['docker'] });
+			queryClient.invalidateQueries({ queryKey: ['backups'] });
+		},
+	});
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -79,6 +79,13 @@ import type {
 	DailyBackupStatsResponse,
 	DashboardStats,
 	DefaultPricingResponse,
+	DockerBackupRequest,
+	DockerBackupResponse,
+	DockerContainer,
+	DockerContainersResponse,
+	DockerDaemonStatus,
+	DockerVolume,
+	DockerVolumesResponse,
 	ErrorResponse,
 	ExcludePattern,
 	ExcludePatternsResponse,
@@ -1667,6 +1674,34 @@ export const slaPoliciesApi = {
 		);
 		return response.history ?? [];
 	},
+};
+
+// Docker Backup API
+export const dockerBackupApi = {
+	listContainers: async (agentId: string): Promise<DockerContainer[]> => {
+		const response = await fetchApi<DockerContainersResponse>(
+			`/docker/containers?agent_id=${agentId}`,
+		);
+		return response.containers ?? [];
+	},
+
+	listVolumes: async (agentId: string): Promise<DockerVolume[]> => {
+		const response = await fetchApi<DockerVolumesResponse>(
+			`/docker/volumes?agent_id=${agentId}`,
+		);
+		return response.volumes ?? [];
+	},
+
+	triggerBackup: async (
+		data: DockerBackupRequest,
+	): Promise<DockerBackupResponse> =>
+		fetchApi<DockerBackupResponse>('/docker/backup', {
+			method: 'POST',
+			body: JSON.stringify(data),
+		}),
+
+	getDaemonStatus: async (agentId: string): Promise<DockerDaemonStatus> =>
+		fetchApi<DockerDaemonStatus>(`/docker/status?agent_id=${agentId}`),
 };
 
 // Air-Gap API

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1948,3 +1948,54 @@ export interface AirGapStatus {
 	disabled_features: AirGapDisabledFeature[];
 	license: AirGapLicenseInfo | null;
 }
+
+// Docker Backup types
+
+export interface DockerContainer {
+	id: string;
+	name: string;
+	image: string;
+	status: string;
+	state: string;
+	created: string;
+	ports: string[];
+}
+
+export interface DockerVolume {
+	name: string;
+	driver: string;
+	mountpoint: string;
+	size_bytes: number;
+	created: string;
+}
+
+export interface DockerDaemonStatus {
+	available: boolean;
+	version: string;
+	container_count: number;
+	volume_count: number;
+	server_os: string;
+	docker_root_dir: string;
+	storage_driver: string;
+}
+
+export interface DockerBackupRequest {
+	agent_id: string;
+	repository_id: string;
+	container_ids?: string[];
+	volume_names?: string[];
+}
+
+export interface DockerBackupResponse {
+	id: string;
+	status: string;
+	created_at: string;
+}
+
+export interface DockerContainersResponse {
+	containers: DockerContainer[];
+}
+
+export interface DockerVolumesResponse {
+	volumes: DockerVolume[];
+}

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -424,5 +424,29 @@
     "uploading": "Uploading...",
     "licenseUploaded": "License uploaded successfully.",
     "failedToLoadStatus": "Failed to load air-gap status"
+  },
+  "dockerBackup": {
+    "title": "Docker Backup",
+    "subtitle": "Back up Docker containers and volumes",
+    "selectAgent": "Agent",
+    "chooseAgent": "Select an agent...",
+    "repositoryId": "Repository ID",
+    "repositoryIdPlaceholder": "Enter repository ID",
+    "containers": "Containers",
+    "volumes": "Volumes",
+    "image": "Image",
+    "driver": "Driver",
+    "size": "Size",
+    "select": "Select",
+    "triggerBackup": "Start Backup",
+    "backupQueued": "Backup queued successfully",
+    "backupError": "Failed to start backup",
+    "daemonRunning": "Docker is running",
+    "daemonStopped": "Docker is not running",
+    "statusError": "Failed to get Docker status",
+    "containersError": "Failed to load containers",
+    "volumesError": "Failed to load volumes",
+    "noContainers": "No containers found",
+    "noVolumes": "No volumes found"
   }
 }

--- a/web/src/locales/es.json
+++ b/web/src/locales/es.json
@@ -424,5 +424,29 @@
     "uploading": "Subiendo...",
     "licenseUploaded": "Licencia subida exitosamente.",
     "failedToLoadStatus": "Error al cargar estado de air-gap"
+  },
+  "dockerBackup": {
+    "title": "Respaldo Docker",
+    "subtitle": "Respaldar contenedores y volúmenes Docker",
+    "selectAgent": "Agente",
+    "chooseAgent": "Seleccionar un agente...",
+    "repositoryId": "ID del Repositorio",
+    "repositoryIdPlaceholder": "Ingresar ID del repositorio",
+    "containers": "Contenedores",
+    "volumes": "Volúmenes",
+    "image": "Imagen",
+    "driver": "Controlador",
+    "size": "Tamaño",
+    "select": "Seleccionar",
+    "triggerBackup": "Iniciar Respaldo",
+    "backupQueued": "Respaldo en cola exitosamente",
+    "backupError": "Error al iniciar respaldo",
+    "daemonRunning": "Docker está en ejecución",
+    "daemonStopped": "Docker no está en ejecución",
+    "statusError": "Error al obtener estado de Docker",
+    "containersError": "Error al cargar contenedores",
+    "volumesError": "Error al cargar volúmenes",
+    "noContainers": "No se encontraron contenedores",
+    "noVolumes": "No se encontraron volúmenes"
   }
 }

--- a/web/src/locales/pt.json
+++ b/web/src/locales/pt.json
@@ -424,5 +424,29 @@
     "uploading": "Carregando...",
     "licenseUploaded": "Licença carregada com sucesso.",
     "failedToLoadStatus": "Falha ao carregar status do air-gap"
+  },
+  "dockerBackup": {
+    "title": "Backup Docker",
+    "subtitle": "Fazer backup de contêineres e volumes Docker",
+    "selectAgent": "Agente",
+    "chooseAgent": "Selecionar um agente...",
+    "repositoryId": "ID do Repositório",
+    "repositoryIdPlaceholder": "Inserir ID do repositório",
+    "containers": "Contêineres",
+    "volumes": "Volumes",
+    "image": "Imagem",
+    "driver": "Driver",
+    "size": "Tamanho",
+    "select": "Selecionar",
+    "triggerBackup": "Iniciar Backup",
+    "backupQueued": "Backup enfileirado com sucesso",
+    "backupError": "Falha ao iniciar backup",
+    "daemonRunning": "Docker está em execução",
+    "daemonStopped": "Docker não está em execução",
+    "statusError": "Falha ao obter status do Docker",
+    "containersError": "Falha ao carregar contêineres",
+    "volumesError": "Falha ao carregar volumes",
+    "noContainers": "Nenhum contêiner encontrado",
+    "noVolumes": "Nenhum volume encontrado"
   }
 }

--- a/web/src/pages/DockerBackup.test.tsx
+++ b/web/src/pages/DockerBackup.test.tsx
@@ -1,0 +1,101 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../test/helpers';
+
+vi.mock('../hooks/useAgents', () => ({
+	useAgents: vi.fn().mockReturnValue({
+		data: [
+			{
+				id: 'agent-1',
+				hostname: 'docker-host-1',
+				status: 'active',
+				created_at: '2024-01-01T00:00:00Z',
+			},
+		],
+		isLoading: false,
+		error: null,
+	}),
+}));
+
+vi.mock('../hooks/useDockerBackup', () => ({
+	useDockerContainers: vi.fn().mockReturnValue({
+		data: undefined,
+		isLoading: false,
+		error: null,
+	}),
+	useDockerVolumes: vi.fn().mockReturnValue({
+		data: undefined,
+		isLoading: false,
+		error: null,
+	}),
+	useDockerDaemonStatus: vi.fn().mockReturnValue({
+		data: undefined,
+		isLoading: false,
+		error: null,
+	}),
+	useTriggerDockerBackup: vi.fn().mockReturnValue({
+		mutate: vi.fn(),
+		isPending: false,
+		isSuccess: false,
+		isError: false,
+	}),
+}));
+
+vi.mock('../hooks/useLocale', () => ({
+	useLocale: vi.fn().mockReturnValue({
+		t: (key: string) => {
+			const translations: Record<string, string> = {
+				'dockerBackup.title': 'Docker Backup',
+				'dockerBackup.subtitle': 'Back up Docker containers and volumes',
+				'dockerBackup.selectAgent': 'Agent',
+				'dockerBackup.chooseAgent': 'Select an agent...',
+				'dockerBackup.repositoryId': 'Repository ID',
+				'dockerBackup.repositoryIdPlaceholder': 'Enter repository ID',
+				'dockerBackup.containers': 'Containers',
+				'dockerBackup.volumes': 'Volumes',
+				'dockerBackup.image': 'Image',
+				'dockerBackup.driver': 'Driver',
+				'dockerBackup.size': 'Size',
+				'dockerBackup.select': 'Select',
+				'dockerBackup.triggerBackup': 'Start Backup',
+				'dockerBackup.daemonRunning': 'Docker is running',
+				'dockerBackup.daemonStopped': 'Docker is not running',
+				'common.name': 'Name',
+				'common.status': 'Status',
+			};
+			return translations[key] || key;
+		},
+		formatBytes: (bytes: number) => `${bytes} B`,
+	}),
+}));
+
+import DockerBackup from './DockerBackup';
+
+describe('DockerBackup page', () => {
+	it('renders the title', () => {
+		renderWithProviders(<DockerBackup />);
+		expect(screen.getByText('Docker Backup')).toBeInTheDocument();
+	});
+
+	it('renders the subtitle', () => {
+		renderWithProviders(<DockerBackup />);
+		expect(
+			screen.getByText('Back up Docker containers and volumes'),
+		).toBeInTheDocument();
+	});
+
+	it('renders the agent selector', () => {
+		renderWithProviders(<DockerBackup />);
+		expect(screen.getByLabelText('Agent')).toBeInTheDocument();
+	});
+
+	it('renders agent options in the selector', () => {
+		renderWithProviders(<DockerBackup />);
+		expect(screen.getByText('docker-host-1')).toBeInTheDocument();
+	});
+
+	it('renders the repository ID input', () => {
+		renderWithProviders(<DockerBackup />);
+		expect(screen.getByLabelText('Repository ID')).toBeInTheDocument();
+	});
+});

--- a/web/src/pages/DockerBackup.tsx
+++ b/web/src/pages/DockerBackup.tsx
@@ -1,0 +1,370 @@
+import { useState } from 'react';
+import { Button } from '../components/ui/Button';
+import { ErrorMessage } from '../components/ui/ErrorMessage';
+import { LoadingSpinner } from '../components/ui/LoadingSpinner';
+import { useAgents } from '../hooks/useAgents';
+import {
+	useDockerContainers,
+	useDockerDaemonStatus,
+	useDockerVolumes,
+	useTriggerDockerBackup,
+} from '../hooks/useDockerBackup';
+import { useLocale } from '../hooks/useLocale';
+import type { DockerContainer, DockerVolume } from '../lib/types';
+
+function ContainerRow({
+	container,
+	selected,
+	onToggle,
+}: {
+	container: DockerContainer;
+	selected: boolean;
+	onToggle: () => void;
+}) {
+	return (
+		<tr className="border-b border-gray-100">
+			<td className="px-4 py-3">
+				<input
+					type="checkbox"
+					checked={selected}
+					onChange={onToggle}
+					className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+				/>
+			</td>
+			<td className="px-4 py-3 text-sm font-medium text-gray-900">
+				{container.name}
+			</td>
+			<td className="px-4 py-3 text-sm text-gray-500">{container.image}</td>
+			<td className="px-4 py-3">
+				<span
+					className={`inline-flex items-center rounded-full px-2 py-1 text-xs font-medium ${
+						container.state === 'running'
+							? 'bg-green-50 text-green-700'
+							: 'bg-gray-100 text-gray-600'
+					}`}
+				>
+					{container.state}
+				</span>
+			</td>
+		</tr>
+	);
+}
+
+function VolumeRow({
+	volume,
+	selected,
+	onToggle,
+	formatBytes,
+}: {
+	volume: DockerVolume;
+	selected: boolean;
+	onToggle: () => void;
+	formatBytes: (bytes: number) => string;
+}) {
+	return (
+		<tr className="border-b border-gray-100">
+			<td className="px-4 py-3">
+				<input
+					type="checkbox"
+					checked={selected}
+					onChange={onToggle}
+					className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+				/>
+			</td>
+			<td className="px-4 py-3 text-sm font-medium text-gray-900">
+				{volume.name}
+			</td>
+			<td className="px-4 py-3 text-sm text-gray-500">{volume.driver}</td>
+			<td className="px-4 py-3 text-sm text-gray-500">
+				{formatBytes(volume.size_bytes)}
+			</td>
+		</tr>
+	);
+}
+
+export function DockerBackup() {
+	const { t, formatBytes } = useLocale();
+	const { data: agents, isLoading: agentsLoading } = useAgents();
+	const [selectedAgentId, setSelectedAgentId] = useState('');
+	const [selectedContainerIds, setSelectedContainerIds] = useState<Set<string>>(
+		new Set(),
+	);
+	const [selectedVolumeNames, setSelectedVolumeNames] = useState<Set<string>>(
+		new Set(),
+	);
+	const [repositoryId, setRepositoryId] = useState('');
+
+	const {
+		data: daemonStatus,
+		isLoading: statusLoading,
+		error: statusError,
+	} = useDockerDaemonStatus(selectedAgentId);
+	const {
+		data: containers,
+		isLoading: containersLoading,
+		error: containersError,
+	} = useDockerContainers(selectedAgentId);
+	const {
+		data: volumes,
+		isLoading: volumesLoading,
+		error: volumesError,
+	} = useDockerVolumes(selectedAgentId);
+	const triggerBackup = useTriggerDockerBackup();
+
+	const handleAgentChange = (agentId: string) => {
+		setSelectedAgentId(agentId);
+		setSelectedContainerIds(new Set());
+		setSelectedVolumeNames(new Set());
+	};
+
+	const toggleContainer = (id: string) => {
+		setSelectedContainerIds((prev) => {
+			const next = new Set(prev);
+			if (next.has(id)) {
+				next.delete(id);
+			} else {
+				next.add(id);
+			}
+			return next;
+		});
+	};
+
+	const toggleVolume = (name: string) => {
+		setSelectedVolumeNames((prev) => {
+			const next = new Set(prev);
+			if (next.has(name)) {
+				next.delete(name);
+			} else {
+				next.add(name);
+			}
+			return next;
+		});
+	};
+
+	const handleBackup = () => {
+		if (!selectedAgentId || !repositoryId) return;
+		triggerBackup.mutate({
+			agent_id: selectedAgentId,
+			repository_id: repositoryId,
+			container_ids: Array.from(selectedContainerIds),
+			volume_names: Array.from(selectedVolumeNames),
+		});
+	};
+
+	const hasSelection =
+		selectedContainerIds.size > 0 || selectedVolumeNames.size > 0;
+
+	return (
+		<div className="p-6">
+			<div className="mb-6">
+				<h1 className="text-2xl font-bold text-gray-900">
+					{t('dockerBackup.title')}
+				</h1>
+				<p className="mt-1 text-sm text-gray-500">
+					{t('dockerBackup.subtitle')}
+				</p>
+			</div>
+
+			{/* Agent selector */}
+			<div className="mb-6 grid gap-4 sm:grid-cols-2">
+				<div>
+					<label
+						htmlFor="agent-select"
+						className="block text-sm font-medium text-gray-700 mb-1"
+					>
+						{t('dockerBackup.selectAgent')}
+					</label>
+					<select
+						id="agent-select"
+						value={selectedAgentId}
+						onChange={(e) => handleAgentChange(e.target.value)}
+						className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+						disabled={agentsLoading}
+					>
+						<option value="">{t('dockerBackup.chooseAgent')}</option>
+						{agents?.map((agent) => (
+							<option key={agent.id} value={agent.id}>
+								{agent.hostname}
+							</option>
+						))}
+					</select>
+				</div>
+				<div>
+					<label
+						htmlFor="repo-select"
+						className="block text-sm font-medium text-gray-700 mb-1"
+					>
+						{t('dockerBackup.repositoryId')}
+					</label>
+					<input
+						id="repo-select"
+						type="text"
+						value={repositoryId}
+						onChange={(e) => setRepositoryId(e.target.value)}
+						placeholder={t('dockerBackup.repositoryIdPlaceholder')}
+						className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+					/>
+				</div>
+			</div>
+
+			{/* Daemon status */}
+			{selectedAgentId && (
+				<div className="mb-6">
+					{statusLoading && <LoadingSpinner />}
+					{statusError && (
+						<ErrorMessage message={t('dockerBackup.statusError')} />
+					)}
+					{daemonStatus && (
+						<div
+							className={`rounded-lg border p-4 ${daemonStatus.available ? 'border-green-200 bg-green-50' : 'border-red-200 bg-red-50'}`}
+						>
+							<div className="flex items-center gap-2">
+								<span
+									className={`inline-block h-2 w-2 rounded-full ${daemonStatus.available ? 'bg-green-500' : 'bg-red-500'}`}
+								/>
+								<span className="text-sm font-medium">
+									{daemonStatus.available
+										? t('dockerBackup.daemonRunning')
+										: t('dockerBackup.daemonStopped')}
+								</span>
+								{daemonStatus.version && (
+									<span className="text-sm text-gray-500">
+										v{daemonStatus.version}
+									</span>
+								)}
+							</div>
+						</div>
+					)}
+				</div>
+			)}
+
+			{/* Containers */}
+			{selectedAgentId && daemonStatus?.available && (
+				<div className="mb-6">
+					<h2 className="mb-3 text-lg font-semibold text-gray-900">
+						{t('dockerBackup.containers')}
+					</h2>
+					{containersLoading && <LoadingSpinner />}
+					{containersError && (
+						<ErrorMessage message={t('dockerBackup.containersError')} />
+					)}
+					{containers && containers.length > 0 ? (
+						<div className="overflow-hidden rounded-lg border border-gray-200">
+							<table className="w-full">
+								<thead className="bg-gray-50">
+									<tr>
+										<th className="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500">
+											{t('dockerBackup.select')}
+										</th>
+										<th className="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500">
+											{t('common.name')}
+										</th>
+										<th className="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500">
+											{t('dockerBackup.image')}
+										</th>
+										<th className="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500">
+											{t('common.status')}
+										</th>
+									</tr>
+								</thead>
+								<tbody>
+									{containers.map((container) => (
+										<ContainerRow
+											key={container.id}
+											container={container}
+											selected={selectedContainerIds.has(container.id)}
+											onToggle={() => toggleContainer(container.id)}
+										/>
+									))}
+								</tbody>
+							</table>
+						</div>
+					) : (
+						containers && (
+							<p className="text-sm text-gray-500">
+								{t('dockerBackup.noContainers')}
+							</p>
+						)
+					)}
+				</div>
+			)}
+
+			{/* Volumes */}
+			{selectedAgentId && daemonStatus?.available && (
+				<div className="mb-6">
+					<h2 className="mb-3 text-lg font-semibold text-gray-900">
+						{t('dockerBackup.volumes')}
+					</h2>
+					{volumesLoading && <LoadingSpinner />}
+					{volumesError && (
+						<ErrorMessage message={t('dockerBackup.volumesError')} />
+					)}
+					{volumes && volumes.length > 0 ? (
+						<div className="overflow-hidden rounded-lg border border-gray-200">
+							<table className="w-full">
+								<thead className="bg-gray-50">
+									<tr>
+										<th className="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500">
+											{t('dockerBackup.select')}
+										</th>
+										<th className="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500">
+											{t('common.name')}
+										</th>
+										<th className="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500">
+											{t('dockerBackup.driver')}
+										</th>
+										<th className="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500">
+											{t('dockerBackup.size')}
+										</th>
+									</tr>
+								</thead>
+								<tbody>
+									{volumes.map((volume) => (
+										<VolumeRow
+											key={volume.name}
+											volume={volume}
+											selected={selectedVolumeNames.has(volume.name)}
+											onToggle={() => toggleVolume(volume.name)}
+											formatBytes={formatBytes}
+										/>
+									))}
+								</tbody>
+							</table>
+						</div>
+					) : (
+						volumes && (
+							<p className="text-sm text-gray-500">
+								{t('dockerBackup.noVolumes')}
+							</p>
+						)
+					)}
+				</div>
+			)}
+
+			{/* Backup button */}
+			{selectedAgentId && daemonStatus?.available && (
+				<div className="flex items-center gap-4">
+					<Button
+						onClick={handleBackup}
+						disabled={!hasSelection || !repositoryId || triggerBackup.isPending}
+						loading={triggerBackup.isPending}
+					>
+						{t('dockerBackup.triggerBackup')}
+					</Button>
+					{triggerBackup.isSuccess && (
+						<span className="text-sm text-green-600">
+							{t('dockerBackup.backupQueued')}
+						</span>
+					)}
+					{triggerBackup.isError && (
+						<span className="text-sm text-red-600">
+							{t('dockerBackup.backupError')}
+						</span>
+					)}
+				</div>
+			)}
+		</div>
+	);
+}
+
+export default DockerBackup;


### PR DESCRIPTION
## Summary

Implements comprehensive Docker backup functionality with API handlers for listing containers/volumes, checking daemon status, and triggering backups. Includes a full React UI with container/volume selection, daemon status display, and backup triggering. Feature is gated behind FeatureDockerBackup (Pro+ tier).

## Changes

- **Backend:** 4 new API endpoints (`GET /docker/containers`, `GET /docker/volumes`, `GET /docker/status`, `POST /docker/backup`)
- **Models:** Docker container/volume types, backup parameters and results
- **Frontend:** New DockerBackup page with interactive container/volume selection tables
- **Hooks:** React Query hooks for containers, volumes, daemon status, and backup triggering
- **i18n:** Full translations in English, Spanish, and Portuguese
- **Tests:** 20 Go tests + 14 TypeScript tests (all passing)

## Test Plan

- [x] Go tests pass (`go test ./...`)
- [x] TypeScript tests pass (`vitest run`)
- [x] Lint passes (`make lint`)
- [x] All 90 test files + 1145 tests pass