### PR TITLE
Add HEALTHCHECK instructions to Dockerfiles

### DIFF
--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -25,4 +25,8 @@ WORKDIR /app
 COPY --from=builder /keldris-agent /usr/local/bin/keldris-agent
 
 USER keldris
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD pgrep keldris-agent || exit 1
+
 ENTRYPOINT ["/usr/local/bin/keldris-agent"]

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -33,4 +33,8 @@ COPY --from=frontend-builder /app/web/dist /app/web/dist
 
 USER keldris
 EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1
+
 ENTRYPOINT ["/app/keldris-server"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -62,6 +62,11 @@ services:
       server:
         condition: service_healthy
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "pgrep", "keldris-agent"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
     profiles:
       - agent
 


### PR DESCRIPTION
Add Docker health checks for both server and agent containers.

- Server container: HTTP health check using wget against /health endpoint
- Agent container: Process health check using pgrep 
- Docker Compose: Added matching health check configuration for agent service

All checks use consistent timing (30s interval, 5s timeout, 3 retries).