### PR TITLE
Redact webhook URLs in sender-level logging

### DIFF
--- a/internal/notifications/webhook.go
+++ b/internal/notifications/webhook.go
@@ -56,7 +56,7 @@ func (w *WebhookSender) SetAirGapMode(enabled bool) {
 // URLs should be validated with ValidateWebhookURL before being stored.
 func (w *WebhookSender) Send(ctx context.Context, url string, payload WebhookPayload, secret string) error {
 	if w.airGapMode {
-		w.logger.Warn().Str("url", url).Msg("webhook blocked: air-gap mode enabled")
+		w.logger.Warn().Msg("webhook blocked: air-gap mode enabled")
 		return ErrAirGapBlocked
 	}
 
@@ -80,7 +80,6 @@ func (w *WebhookSender) Send(ctx context.Context, url string, payload WebhookPay
 			}
 			w.logger.Debug().
 				Int("attempt", attempt+1).
-				Str("url", url).
 				Msg("retrying webhook")
 		}
 
@@ -114,7 +113,6 @@ func (w *WebhookSender) doSend(ctx context.Context, url string, body []byte, sec
 
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		w.logger.Info().
-			Str("url", url).
 			Int("status", resp.StatusCode).
 			Msg("webhook notification sent")
 		return nil

--- a/internal/notifications/webhook_test.go
+++ b/internal/notifications/webhook_test.go
@@ -1,6 +1,7 @@
 package notifications
 
 import (
+	"bytes"
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
@@ -177,6 +178,78 @@ func TestWebhookSender_SSRFMetadata(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "blocked") {
 		t.Errorf("expected 'blocked' in error, got: %s", err)
+	}
+}
+
+func TestWebhookSender_URLNotInLogs(t *testing.T) {
+	var logBuf bytes.Buffer
+	logger := zerolog.New(&logBuf)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	sender := NewWebhookSender(logger)
+	sender.validateURL = func(_ string) error { return nil }
+	payload := WebhookPayload{EventType: "test", Timestamp: time.Now(), Data: nil}
+
+	err := sender.Send(context.Background(), server.URL, payload, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	logOutput := logBuf.String()
+	if strings.Contains(logOutput, server.URL) {
+		t.Errorf("log output should not contain webhook URL, got: %s", logOutput)
+	}
+}
+
+func TestWebhookSender_URLNotInLogsAirGap(t *testing.T) {
+	var logBuf bytes.Buffer
+	logger := zerolog.New(&logBuf)
+
+	sender := NewWebhookSender(logger)
+	sender.SetAirGapMode(true)
+
+	webhookURL := "https://hooks.example.com/secret-token/callback"
+	payload := WebhookPayload{EventType: "test", Timestamp: time.Now(), Data: nil}
+
+	_ = sender.Send(context.Background(), webhookURL, payload, "")
+
+	logOutput := logBuf.String()
+	if strings.Contains(logOutput, webhookURL) {
+		t.Errorf("log output should not contain webhook URL, got: %s", logOutput)
+	}
+}
+
+func TestWebhookSender_URLNotInLogsRetry(t *testing.T) {
+	var logBuf bytes.Buffer
+	logger := zerolog.New(&logBuf)
+
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := attempts.Add(1)
+		if n < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	sender := NewWebhookSender(logger)
+	sender.validateURL = func(_ string) error { return nil }
+	payload := WebhookPayload{EventType: "test", Timestamp: time.Now(), Data: nil}
+
+	err := sender.Send(context.Background(), server.URL, payload, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	logOutput := logBuf.String()
+	if strings.Contains(logOutput, server.URL) {
+		t.Errorf("log output should not contain webhook URL during retries, got: %s", logOutput)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Removes webhook URLs from log statements to prevent exposure of auth tokens and secrets
- URLs may contain sensitive authentication information in query parameters or path segments

## Changes
- Remove `Str("url", url)` from air-gap warning log
- Remove URL from retry debug log  
- Remove URL from success info log
- Add three tests verifying URLs don't appear in any log output

## Test Plan
- `make test` passes for notifications package (all new tests included)
- Webhook functionality preserved; only logging changed