### PR TITLE
Add missing database indexes for performance

### DIFF
--- a/internal/db/migrations/035_add_missing_indexes.sql
+++ b/internal/db/migrations/035_add_missing_indexes.sql
@@ -1,0 +1,4 @@
+-- Migration: Add missing indexes for performance
+
+CREATE INDEX IF NOT EXISTS idx_repositories_org_id ON repositories(org_id);
+CREATE INDEX IF NOT EXISTS idx_schedules_agent_id ON schedules(agent_id);


### PR DESCRIPTION
## Summary
Add two missing database indexes to improve query performance on frequently filtered columns.

- Add `idx_repositories_org_id` index on `repositories(org_id)`
- Add `idx_schedules_agent_id` index on `schedules(agent_id)`

## Test plan
- [x] Go vet passes
- [x] All tests pass
- [x] Migration file follows sequential naming convention