### PR TITLE
Update Go version requirement from 1.24+ to 1.25.7+

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -7,11 +7,11 @@
 
 | Layer | Technology | Version |
 |-------|------------|---------|
-| Server | Go | 1.24+ |
+| Server | Go | 1.25.7+ |
 | Server Framework | Gin | latest |
 | Database | PostgreSQL | 15+ |
 | ORM | pgx/v5 raw queries | latest |
-| Agent | Go + Cobra | 1.24+ |
+| Agent | Go + Cobra | 1.25.7+ |
 | Frontend | React | 18+ |
 | Frontend Build | Vite | 6+ |
 | Frontend Language | TypeScript (strict) | 5.6+ |


### PR DESCRIPTION
## Summary

Update tech stack documentation in CLAUDE.md to reflect the latest Go version requirement (1.25.7+) for both server and agent components.

## Changes

- Server Go version: 1.24+ → 1.25.7+
- Agent Go + Cobra version: 1.24+ → 1.25.7+