### PR TITLE
Fix documentation links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ docker-compose up -d
 
 You'll need Docker, Go 1.25.7+ (for security patches), PostgreSQL 15+, and an OIDC provider.
 
+For setup guides, see:
+
+- [OIDC Setup Guide](docs/oidc-setup.md) - Configure your identity provider
+- [Agent Installation](docs/agent-installation.md) - Install and configure backup agents
+- [Production Security Guide](docs/production-security.md) - Hardening for production deployments
+
 ---
 
 ## Architecture


### PR DESCRIPTION
## Summary
- Added links to OIDC setup, agent installation, and production security documentation in the Getting Started section
- Provides users with quick access to key setup guides from the main README

## Test plan
- Verify all doc links are valid and render correctly on GitHub
- Check that links point to existing files in the docs/ directory