### PR TITLE
Add docker-compose.images.yml for pre-built images

### DIFF
--- a/docker/docker-compose.images.yml
+++ b/docker/docker-compose.images.yml
@@ -1,0 +1,42 @@
+# Production compose file — uses pre-built images from GHCR.
+# Usage: docker compose -f docker-compose.images.yml up -d
+# For building from source, use: docker compose up -d
+
+services:
+  server:
+    image: ghcr.io/macjediwizard/keldris-server:1.0.0-beta.1
+    env_file: ../.env
+    ports:
+      - "8080:8080"
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: unless-stopped
+
+  db:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_USER: keldris
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-keldris}
+      POSTGRES_DB: keldris
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U keldris"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  agent:
+    image: ghcr.io/macjediwizard/keldris-agent:1.0.0-beta.1
+    profiles: ["agent"]
+    env_file: ../.env
+    volumes:
+      - /path/to/backup:/data:ro
+    depends_on:
+      - server
+    restart: unless-stopped
+
+volumes:
+  postgres_data:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,3 +1,7 @@
+# Development compose file — builds images from source.
+# Usage: docker compose up -d
+# For pre-built images, use: docker compose -f docker-compose.images.yml up -d
+
 services:
   server:
     build:


### PR DESCRIPTION
Support deploying Keldris with pre-built images from GHCR. This adds docker-compose.images.yml alongside the existing development compose file, allowing users to choose between building from source (development) or using pre-built images (production). Usage comments in both files clarify when to use each variant.