### PR TITLE
Fix critical notification config decryption bug

### DIFF
--- a/internal/backup/scheduler_test.go
+++ b/internal/backup/scheduler_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/MacJediWizard/keldris/internal/crypto"
 	"github.com/MacJediWizard/keldris/internal/models"
 	"github.com/MacJediWizard/keldris/internal/notifications"
 	"github.com/google/uuid"
@@ -1773,7 +1774,9 @@ func TestScheduler_SendBackupNotification_WithNotifier(t *testing.T) {
 	config := DefaultSchedulerConfig()
 
 	notifStore := &mockNotificationStore{}
-	notifier := notifications.NewService(notifStore, zerolog.Nop())
+	testKey := make([]byte, crypto.KeySize)
+	km, _ := crypto.NewKeyManager(testKey)
+	notifier := notifications.NewService(notifStore, km, zerolog.Nop())
 
 	scheduler := NewScheduler(store, restic, config, notifier, logger)
 
@@ -1816,7 +1819,9 @@ func TestScheduler_SendBackupNotification_WithMinimalBackup(t *testing.T) {
 	config := DefaultSchedulerConfig()
 
 	notifStore := &mockNotificationStore{}
-	notifier := notifications.NewService(notifStore, zerolog.Nop())
+	testKey := make([]byte, crypto.KeySize)
+	km, _ := crypto.NewKeyManager(testKey)
+	notifier := notifications.NewService(notifStore, km, zerolog.Nop())
 
 	scheduler := NewScheduler(store, restic, config, notifier, logger)
 


### PR DESCRIPTION
## Summary

Fixed a critical bug where notification channel configurations were not being decrypted before use. The `ConfigEncrypted` field stores encrypted JSON configs, but they were being unmarshaled directly without decryption, causing all notifications to fail silently.

## Changes

- Added `keyManager` field and parameter to `Service` struct to enable decryption
- Implemented `decryptConfig()` helper method that decrypts encrypted configs using AES-256-GCM then unmarshals them
- Updated all 18 config unmarshaling calls across email, Slack, Teams, Discord, PagerDuty, and webhook senders for backup, agent offline, and maintenance notifications
- Updated test fixtures to properly encrypt configs using test key manager

## Testing

- All notification package tests pass (88.2% coverage)
- All backup scheduler tests pass (85.1% coverage)
- `go vet` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)