### PR TITLE
Add govulncheck vulnerability scanning to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,12 @@ jobs:
       - name: Run staticcheck
         run: staticcheck ./...
 
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Run govulncheck
+        run: govulncheck ./...
+
       - name: Run tests
         run: go test -race -coverprofile=coverage.out ./...
 


### PR DESCRIPTION
## Summary
Adds govulncheck to the Go job to detect known vulnerabilities in dependencies at build time. The check runs after static analysis and before tests.

## Test plan
- Verify govulncheck installs successfully in CI
- Confirm the scan completes without errors
- Check that the workflow passes with no new vulnerabilities