### PR TITLE
Add HTTP server timeouts to prevent slowloris attacks

### DIFF
--- a/cmd/keldris-server/main.go
+++ b/cmd/keldris-server/main.go
@@ -208,6 +208,8 @@ func run() int {
 		Addr:              listenAddr,
 		Handler:           router.Engine,
 		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      60 * time.Second,
 	}
 
 	// Start server in background


### PR DESCRIPTION
## Summary
- Added ReadTimeout: 30s to prevent slow request body attacks
- Added WriteTimeout: 60s to prevent slow response writes
- Complements existing ReadHeaderTimeout: 10s to defend against slowloris-style attacks

## Test plan
- Go vet passes
- All Go tests pass (85%+ coverage maintained)

🤖 Generated with Claude Code