### PR TITLE
Audit fixes: backup verify, notification rule scoping, dark mode

### DIFF
--- a/internal/api/handlers/database_backup.go
+++ b/internal/api/handlers/database_backup.go
@@ -249,9 +249,13 @@ func (h *DatabaseBackupHandler) VerifyBackup(c *gin.Context) {
 		return
 	}
 
-	// Mark as verified in database
 	if err := h.store.MarkDatabaseBackupVerified(c.Request.Context(), backupID); err != nil {
 		h.logger.Error().Err(err).Msg("failed to mark backup as verified")
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error":    "verification succeeded but failed to persist verification status",
+			"verified": true,
+		})
+		return
 	}
 
 	c.JSON(http.StatusOK, gin.H{

--- a/internal/api/handlers/notification_rules.go
+++ b/internal/api/handlers/notification_rules.go
@@ -21,7 +21,7 @@ type NotificationRuleStore interface {
 	GetEnabledRulesByTriggerType(ctx context.Context, orgID uuid.UUID, triggerType models.RuleTriggerType) ([]*models.NotificationRule, error)
 	CreateNotificationRule(ctx context.Context, rule *models.NotificationRule) error
 	UpdateNotificationRule(ctx context.Context, rule *models.NotificationRule) error
-	DeleteNotificationRule(ctx context.Context, id uuid.UUID) error
+	DeleteNotificationRule(ctx context.Context, id, orgID uuid.UUID) error
 	GetRecentEventsForRule(ctx context.Context, ruleID uuid.UUID, limit int) ([]*models.NotificationRuleEvent, error)
 	GetRecentExecutionsForRule(ctx context.Context, ruleID uuid.UUID, limit int) ([]*models.NotificationRuleExecution, error)
 	GetNotificationChannelByID(ctx context.Context, id uuid.UUID) (*models.NotificationChannel, error)
@@ -286,7 +286,7 @@ func (h *NotificationRulesHandler) DeleteRule(c *gin.Context) {
 		return
 	}
 
-	if err := h.store.DeleteNotificationRule(c.Request.Context(), id); err != nil {
+	if err := h.store.DeleteNotificationRule(c.Request.Context(), id, user.CurrentOrgID); err != nil {
 		h.logger.Error().Err(err).Str("rule_id", id.String()).Msg("failed to delete notification rule")
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete notification rule"})
 		return

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -390,10 +390,10 @@ func NewRouter(
 	notificationsHandler := handlers.NewNotificationsHandlerWithEnv(database, keyManager, featureChecker, logger, cfg.Environment)
 	notificationsHandler.RegisterRoutes(apiV1)
 
-	// Notification rules (feature gated - requires Pro+ for notification automation)
-	notificationRulesGroup := apiV1.Group("", middleware.FeatureMiddleware(license.FeatureNotificationSlack, logger))
+	// Notification rules — per-channel feature gating happens when the underlying
+	// notification channel is created, so the rules CRUD itself isn't gated here.
 	notificationRulesHandler := handlers.NewNotificationRulesHandler(database, keyManager, logger)
-	notificationRulesHandler.RegisterRoutes(notificationRulesGroup)
+	notificationRulesHandler.RegisterRoutes(apiV1)
 
 	// Reports (feature gated - requires Pro+)
 	if cfg.ReportScheduler != nil {

--- a/internal/db/notification_rules.go
+++ b/internal/db/notification_rules.go
@@ -135,9 +135,9 @@ func (db *DB) UpdateNotificationRule(ctx context.Context, rule *models.Notificat
 	return nil
 }
 
-// DeleteNotificationRule deletes a notification rule.
-func (db *DB) DeleteNotificationRule(ctx context.Context, id uuid.UUID) error {
-	_, err := db.Pool.Exec(ctx, `DELETE FROM notification_rules WHERE id = $1`, id)
+// DeleteNotificationRule deletes a notification rule scoped to its org.
+func (db *DB) DeleteNotificationRule(ctx context.Context, id, orgID uuid.UUID) error {
+	_, err := db.Pool.Exec(ctx, `DELETE FROM notification_rules WHERE id = $1 AND org_id = $2`, id, orgID)
 	if err != nil {
 		return fmt.Errorf("delete notification rule: %w", err)
 	}

--- a/internal/notifications/rules.go
+++ b/internal/notifications/rules.go
@@ -20,7 +20,7 @@ type RuleStore interface {
 	GetEnabledRulesByTriggerType(ctx context.Context, orgID uuid.UUID, triggerType models.RuleTriggerType) ([]*models.NotificationRule, error)
 	CreateNotificationRule(ctx context.Context, rule *models.NotificationRule) error
 	UpdateNotificationRule(ctx context.Context, rule *models.NotificationRule) error
-	DeleteNotificationRule(ctx context.Context, id uuid.UUID) error
+	DeleteNotificationRule(ctx context.Context, id, orgID uuid.UUID) error
 
 	// Events
 	CreateNotificationRuleEvent(ctx context.Context, event *models.NotificationRuleEvent) error

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -1041,7 +1041,7 @@ function Sidebar() {
 					</span>
 					{hasNewVersion && (
 						<span className="px-1.5 py-0.5 text-[10px] font-medium bg-indigo-600 text-white rounded-full">
-							v{latestVersion} available
+							{t('common.versionAvailable', { version: latestVersion })}
 						</span>
 					)}
 				</Link>
@@ -1179,7 +1179,7 @@ function HelpMenu({ onShowShortcuts }: { onShowShortcuts: () => void }) {
 			<button
 				type="button"
 				onClick={() => setShowDropdown(!showDropdown)}
-				className="p-2 text-gray-500 hover:text-gray-700 rounded-lg hover:bg-gray-100"
+				className="p-2 text-gray-500 hover:text-gray-700 rounded-lg hover:bg-gray-100 dark:text-gray-400 dark:hover:text-gray-200 dark:hover:bg-gray-700"
 				aria-label={t('help.title')}
 			>
 				<svg
@@ -1198,9 +1198,9 @@ function HelpMenu({ onShowShortcuts }: { onShowShortcuts: () => void }) {
 				</svg>
 			</button>
 			{showDropdown && (
-				<div className="absolute right-0 mt-2 w-64 bg-white rounded-lg shadow-lg border border-gray-200 py-1 z-50">
-					<div className="px-4 py-2 border-b border-gray-100">
-						<p className="text-sm font-semibold text-gray-900">
+				<div className="absolute right-0 mt-2 w-64 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 py-1 z-50">
+					<div className="px-4 py-2 border-b border-gray-100 dark:border-gray-700">
+						<p className="text-sm font-semibold text-gray-900 dark:text-gray-100">
 							{t('help.title')}
 						</p>
 					</div>
@@ -1210,30 +1210,32 @@ function HelpMenu({ onShowShortcuts }: { onShowShortcuts: () => void }) {
 								key={link.path}
 								to={link.path}
 								onClick={() => setShowDropdown(false)}
-								className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+								className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-700"
 							>
 								{link.label}
 							</Link>
 						))}
 					</div>
-					<div className="border-t border-gray-100 py-1">
+					<div className="border-t border-gray-100 dark:border-gray-700 py-1">
 						<button
 							type="button"
 							onClick={() => {
 								setShowDropdown(false);
 								onShowShortcuts();
 							}}
-							className="w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 flex items-center justify-between"
+							className="w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-700 flex items-center justify-between"
 						>
 							<span>{t('help.keyboardShortcuts')}</span>
-							<span className="text-xs text-gray-400 font-mono">?</span>
+							<span className="text-xs text-gray-400 dark:text-gray-500 font-mono">
+								?
+							</span>
 						</button>
 						<a
 							href="/api/docs"
 							target="_blank"
 							rel="noopener noreferrer"
 							onClick={() => setShowDropdown(false)}
-							className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 flex items-center gap-2"
+							className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-700 flex items-center gap-2"
 						>
 							{t('help.swaggerDocs')}
 							<svg

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -37,7 +37,8 @@
     "previous": "Previous",
     "submit": "Submit",
     "selectOrg": "Select org",
-    "version": "v{{version}}"
+    "version": "v{{version}}",
+    "versionAvailable": "v{{version}} available"
   },
   "time": {
     "minutesAgo": "{{count}}m ago",

--- a/web/src/locales/es.json
+++ b/web/src/locales/es.json
@@ -37,7 +37,8 @@
     "previous": "Anterior",
     "submit": "Enviar",
     "selectOrg": "Seleccionar org",
-    "version": "v{{version}}"
+    "version": "v{{version}}",
+    "versionAvailable": "v{{version}} disponible"
   },
   "time": {
     "minutesAgo": "hace {{count}}m",

--- a/web/src/locales/pt.json
+++ b/web/src/locales/pt.json
@@ -37,7 +37,8 @@
     "previous": "Anterior",
     "submit": "Enviar",
     "selectOrg": "Selecionar org",
-    "version": "v{{version}}"
+    "version": "v{{version}}",
+    "versionAvailable": "v{{version}} disponível"
   },
   "time": {
     "minutesAgo": "{{count}}m atrás",


### PR DESCRIPTION
## Summary
Tightens several issues surfaced by a full-repo audit. All fixes verified across two consecutive clean passes (go build/vet/test, tsc, biome, vitest, vite build, playwright e2e).

- **`database_backup.go`** — verifier returned 200 even when the post-verify persist failed, so clients had no way to tell that the verification status wasn't recorded. Now returns 500 with `verified: true` so the actual outcome is visible.
- **`notification_rules` DELETE** — added `org_id` to the WHERE clause at the DB layer (defense-in-depth). Handler already checked org membership, but the DB query trusted the caller. Interface, implementations, and handler caller updated together.
- **`routes.go`** — removed misaligned `FeatureNotificationSlack` gate on the `/notification-rules` group. The handler already gates per-channel at create time, and the broad gate locked out Pro licenses that had Teams/PagerDuty/Discord but not Slack.
- **`Layout.tsx`** — replaced hardcoded "v{x} available" sidebar string with `t('common.versionAvailable')` and added `dark:` variants to the help dropdown that were missing (background, border, text, hover states).
- **`locales/{en,es,pt}.json`** — added the new `common.versionAvailable` key in all three languages.

## Test plan
- [x] `go build ./...` clean (x2)
- [x] `go vet ./...` clean (x2)
- [x] `go test -short ./...` zero failures (x2)
- [x] `npx tsc --noEmit` clean (x2)
- [x] `npx @biomejs/biome check .` clean (x2)
- [x] `npx vitest run` — 1635/1635 across 112 files (x2)
- [x] `npm run build` succeeds (x2)
- [x] `npx playwright test` exit 0 (x2)