### PR TITLE
Add frontend hook + component test coverage

### DIFF
--- a/web/src/components/features/AnnouncementBanner.test.tsx
+++ b/web/src/components/features/AnnouncementBanner.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { Announcement } from '../../lib/types';
+
+vi.mock('../../hooks/useAnnouncements', () => ({
+	useActiveAnnouncements: vi.fn(),
+	useDismissAnnouncement: vi.fn(),
+}));
+
+import {
+	useActiveAnnouncements,
+	useDismissAnnouncement,
+} from '../../hooks/useAnnouncements';
+import { AnnouncementBanner } from './AnnouncementBanner';
+
+function makeAnnouncement(overrides: Partial<Announcement> = {}): Announcement {
+	return {
+		id: 'a1',
+		title: 'System maintenance tonight',
+		message: 'Brief downtime expected',
+		type: 'info',
+		dismissible: true,
+		active: true,
+		starts_at: null,
+		ends_at: null,
+		created_at: '',
+		updated_at: '',
+		...overrides,
+	} as Announcement;
+}
+
+const mutate = vi.fn();
+
+function setMocks(
+	announcements: Announcement[] | undefined,
+	isPending = false,
+) {
+	vi.mocked(useActiveAnnouncements).mockReturnValue({
+		data: announcements,
+		isLoading: false,
+		isError: false,
+		error: null,
+	} as never);
+	vi.mocked(useDismissAnnouncement).mockReturnValue({
+		mutate,
+		isPending,
+	} as never);
+}
+
+describe('AnnouncementBanner', () => {
+	it('renders nothing when no announcements', () => {
+		setMocks([]);
+		const { container } = render(<AnnouncementBanner />);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders nothing when announcements undefined', () => {
+		setMocks(undefined);
+		const { container } = render(<AnnouncementBanner />);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders title for each announcement', () => {
+		setMocks([
+			makeAnnouncement({ id: '1', title: 'First' }),
+			makeAnnouncement({ id: '2', title: 'Second' }),
+		]);
+		render(<AnnouncementBanner />);
+		expect(screen.getByText('First')).toBeDefined();
+		expect(screen.getByText('Second')).toBeDefined();
+	});
+
+	it('fires mutate(id) when dismiss clicked', () => {
+		mutate.mockReset();
+		setMocks([makeAnnouncement({ id: 'abc', dismissible: true })]);
+		render(<AnnouncementBanner />);
+		screen.getByRole('button', { name: 'Dismiss announcement' }).click();
+		expect(mutate).toHaveBeenCalledWith('abc');
+	});
+
+	it('hides dismiss button when dismissible=false', () => {
+		setMocks([makeAnnouncement({ dismissible: false })]);
+		render(<AnnouncementBanner />);
+		expect(
+			screen.queryByRole('button', { name: 'Dismiss announcement' }),
+		).toBeNull();
+	});
+
+	it('disables dismiss button while pending', () => {
+		setMocks([makeAnnouncement({ dismissible: true })], true);
+		render(<AnnouncementBanner />);
+		expect(
+			screen.getByRole('button', { name: 'Dismiss announcement' }),
+		).toBeDisabled();
+	});
+});

--- a/web/src/components/features/TierBadge.test.tsx
+++ b/web/src/components/features/TierBadge.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { TierBadge } from './TierBadge';
+
+describe('TierBadge', () => {
+	it('renders Free label for free tier', () => {
+		render(<TierBadge tier="free" />);
+		expect(screen.getByText('Free')).toBeDefined();
+	});
+
+	it('renders Pro label for pro tier', () => {
+		render(<TierBadge tier="pro" />);
+		expect(screen.getByText('Pro')).toBeDefined();
+	});
+
+	it('renders Professional label for professional tier', () => {
+		render(<TierBadge tier="professional" />);
+		expect(screen.getByText('Professional')).toBeDefined();
+	});
+
+	it('renders Enterprise label for enterprise tier', () => {
+		render(<TierBadge tier="enterprise" />);
+		expect(screen.getByText('Enterprise')).toBeDefined();
+	});
+
+	it('applies enterprise tier purple style', () => {
+		const { container } = render(<TierBadge tier="enterprise" />);
+		expect((container.firstChild as HTMLElement).className).toContain(
+			'bg-purple-100',
+		);
+	});
+
+	it('appends custom className', () => {
+		const { container } = render(
+			<TierBadge tier="free" className="extra-class" />,
+		);
+		expect((container.firstChild as HTMLElement).className).toContain(
+			'extra-class',
+		);
+	});
+});

--- a/web/src/components/ui/Breadcrumbs.test.tsx
+++ b/web/src/components/ui/Breadcrumbs.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import type { BreadcrumbItem } from '../../hooks/useBreadcrumbs';
+
+vi.mock('../../hooks/useBreadcrumbs', () => ({
+	useBreadcrumbs: vi.fn(),
+}));
+
+import { useBreadcrumbs } from '../../hooks/useBreadcrumbs';
+import { Breadcrumbs, BreadcrumbsWithItems } from './Breadcrumbs';
+
+function setMock(breadcrumbs: BreadcrumbItem[], isLoading = false) {
+	vi.mocked(useBreadcrumbs).mockReturnValue({ breadcrumbs, isLoading });
+}
+
+function withRouter(ui: React.ReactNode) {
+	return <MemoryRouter>{ui}</MemoryRouter>;
+}
+
+describe('Breadcrumbs', () => {
+	it('renders nothing when only Dashboard is present', () => {
+		setMock([{ label: 'Dashboard', path: '/', isCurrentPage: true }]);
+		const { container } = render(withRouter(<Breadcrumbs />));
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders breadcrumb labels with current page marker', () => {
+		setMock([
+			{ label: 'Dashboard', path: '/', isCurrentPage: false },
+			{ label: 'Agents', path: '/agents', isCurrentPage: true },
+		]);
+		render(withRouter(<Breadcrumbs />));
+		expect(screen.getByText('Agents')).toBeDefined();
+		expect(screen.getByText('Agents').getAttribute('aria-current')).toBe(
+			'page',
+		);
+	});
+
+	it('renders explicit items prop when provided', () => {
+		setMock([{ label: 'Dashboard', path: '/', isCurrentPage: true }]);
+		render(
+			withRouter(
+				<Breadcrumbs
+					items={[
+						{ label: 'Dashboard', path: '/', isCurrentPage: false },
+						{
+							label: 'Repositories',
+							path: '/repositories',
+							isCurrentPage: true,
+						},
+					]}
+				/>,
+			),
+		);
+		expect(screen.getByText('Repositories')).toBeDefined();
+	});
+
+	it('renders loading skeleton for current page when isLoading', () => {
+		setMock(
+			[
+				{ label: 'Dashboard', path: '/', isCurrentPage: false },
+				{ label: 'loading', path: '/agents/abc', isCurrentPage: true },
+			],
+			true,
+		);
+		const { container } = render(withRouter(<Breadcrumbs />));
+		expect(container.querySelector('.animate-pulse')).not.toBeNull();
+	});
+});
+
+describe('BreadcrumbsWithItems', () => {
+	it('renders nothing for single item', () => {
+		const { container } = render(
+			withRouter(
+				<BreadcrumbsWithItems
+					items={[{ label: 'Dashboard', path: '/', isCurrentPage: true }]}
+				/>,
+			),
+		);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders items with chevron separators', () => {
+		render(
+			withRouter(
+				<BreadcrumbsWithItems
+					items={[
+						{ label: 'Dashboard', path: '/', isCurrentPage: false },
+						{ label: 'Snapshots', path: '/snapshots', isCurrentPage: false },
+						{
+							label: 'Compare',
+							path: '/snapshots/compare',
+							isCurrentPage: true,
+						},
+					]}
+				/>,
+			),
+		);
+		expect(screen.getByText('Snapshots')).toBeDefined();
+		expect(screen.getByText('Compare')).toBeDefined();
+	});
+});

--- a/web/src/components/ui/ConfirmationModal.test.tsx
+++ b/web/src/components/ui/ConfirmationModal.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ConfirmationModal } from './ConfirmationModal';
+
+const baseProps = {
+	isOpen: true,
+	onClose: vi.fn(),
+	onConfirm: vi.fn(),
+	title: 'Delete item',
+	message: 'Are you sure?',
+};
+
+describe('ConfirmationModal', () => {
+	it('renders nothing when closed', () => {
+		render(<ConfirmationModal {...baseProps} isOpen={false} />);
+		expect(screen.queryByText('Delete item')).toBeNull();
+	});
+
+	it('renders title and message when open', () => {
+		render(<ConfirmationModal {...baseProps} />);
+		expect(screen.getByText('Delete item')).toBeDefined();
+		expect(screen.getByText('Are you sure?')).toBeDefined();
+	});
+
+	it('fires onConfirm when confirm button clicked', () => {
+		const onConfirm = vi.fn();
+		render(<ConfirmationModal {...baseProps} onConfirm={onConfirm} />);
+		screen.getByRole('button', { name: 'Confirm' }).click();
+		expect(onConfirm).toHaveBeenCalledOnce();
+	});
+
+	it('fires onClose when cancel button clicked', () => {
+		const onClose = vi.fn();
+		render(<ConfirmationModal {...baseProps} onClose={onClose} />);
+		screen.getByRole('button', { name: 'Cancel' }).click();
+		expect(onClose).toHaveBeenCalledOnce();
+	});
+
+	it('uses custom labels when provided', () => {
+		render(
+			<ConfirmationModal
+				{...baseProps}
+				confirmLabel="Delete Forever"
+				cancelLabel="Keep It"
+			/>,
+		);
+		expect(
+			screen.getByRole('button', { name: 'Delete Forever' }),
+		).toBeDefined();
+		expect(screen.getByRole('button', { name: 'Keep It' })).toBeDefined();
+	});
+
+	it('shows item count when provided', () => {
+		render(<ConfirmationModal {...baseProps} itemCount={5} />);
+		expect(screen.getByText('This action will affect 5 items.')).toBeDefined();
+	});
+
+	it('uses singular form when itemCount is 1', () => {
+		render(<ConfirmationModal {...baseProps} itemCount={1} />);
+		expect(screen.getByText('This action will affect 1 item.')).toBeDefined();
+	});
+
+	it('shows Processing label when loading and disables buttons', () => {
+		render(<ConfirmationModal {...baseProps} isLoading />);
+		expect(screen.getByText('Processing...')).toBeDefined();
+		expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+	});
+});

--- a/web/src/components/ui/EmptyState.test.tsx
+++ b/web/src/components/ui/EmptyState.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import {
+	EmptyState,
+	EmptyStateNoAgents,
+	EmptyStateNoBackups,
+	EmptyStateNoGroups,
+	EmptyStateNoPolicies,
+	EmptyStateNoRepositories,
+	EmptyStateNoSchedules,
+	EmptyStateNoSearchResults,
+} from './EmptyState';
+
+const icon = <span data-testid="icon">★</span>;
+
+describe('EmptyState', () => {
+	it('renders title and description', () => {
+		render(
+			<EmptyState
+				icon={icon}
+				title="No agents"
+				description="Add one to start"
+			/>,
+		);
+		expect(screen.getByText('No agents')).toBeDefined();
+		expect(screen.getByText('Add one to start')).toBeDefined();
+		expect(screen.getByTestId('icon')).toBeDefined();
+	});
+
+	it('renders action button when provided and fires onClick', () => {
+		const onClick = vi.fn();
+		render(
+			<EmptyState
+				icon={icon}
+				title="No data"
+				description="Add some"
+				action={{ label: 'Add Item', onClick }}
+			/>,
+		);
+		const btn = screen.getByRole('button', { name: 'Add Item' });
+		btn.click();
+		expect(onClick).toHaveBeenCalledOnce();
+	});
+
+	it('respects compact variant by rendering smaller wrapper', () => {
+		const { container } = render(
+			<EmptyState
+				icon={icon}
+				title="Empty"
+				description="Nothing here"
+				variant="compact"
+			/>,
+		);
+		expect(container.firstChild).toHaveProperty('className');
+	});
+
+	it('renders help tooltip when help is provided', () => {
+		render(
+			<EmptyState
+				icon={icon}
+				title="Empty"
+				description="Nothing"
+				help={{ content: 'Help info', title: 'Help' }}
+			/>,
+		);
+		expect(screen.getByText('Empty')).toBeDefined();
+	});
+
+	it('renders children below description', () => {
+		render(
+			<EmptyState icon={icon} title="Empty" description="Nothing">
+				<span>extra child node</span>
+			</EmptyState>,
+		);
+		expect(screen.getByText('extra child node')).toBeDefined();
+	});
+});
+
+describe('EmptyState variants', () => {
+	it('EmptyStateNoAgents renders default copy + fires action', () => {
+		const onAddAgent = vi.fn();
+		render(<EmptyStateNoAgents onAddAgent={onAddAgent} />);
+		expect(screen.getByText('No agents connected')).toBeDefined();
+		screen.getByRole('button', { name: 'Add Your First Agent' }).click();
+		expect(onAddAgent).toHaveBeenCalledOnce();
+	});
+
+	it('EmptyStateNoBackups renders default copy', () => {
+		render(<EmptyStateNoBackups onCreateSchedule={() => {}} />);
+		expect(screen.getByText('No backups yet')).toBeDefined();
+	});
+
+	it('EmptyStateNoSchedules shows cron examples by default', () => {
+		render(<EmptyStateNoSchedules onCreateSchedule={() => {}} />);
+		expect(screen.getByText('Common schedules:')).toBeDefined();
+		expect(screen.getByText(/Daily at 2 AM/)).toBeDefined();
+	});
+
+	it('EmptyStateNoSchedules hides cron examples when disabled', () => {
+		render(
+			<EmptyStateNoSchedules
+				onCreateSchedule={() => {}}
+				showCronExamples={false}
+			/>,
+		);
+		expect(screen.queryByText('Common schedules:')).toBeNull();
+	});
+
+	it('EmptyStateNoSearchResults injects query into title', () => {
+		render(
+			<EmptyStateNoSearchResults query="foobar" onClearSearch={() => {}} />,
+		);
+		expect(screen.getByText('No results for "foobar"')).toBeDefined();
+	});
+
+	it('EmptyStateNoGroups renders default copy', () => {
+		render(<EmptyStateNoGroups onCreateGroup={() => {}} />);
+		expect(screen.getByText('No agent groups')).toBeDefined();
+	});
+
+	it('EmptyStateNoRepositories renders default copy', () => {
+		render(<EmptyStateNoRepositories onCreateRepository={() => {}} />);
+		expect(screen.getByText('No repositories')).toBeDefined();
+	});
+
+	it('EmptyStateNoPolicies renders default copy', () => {
+		render(<EmptyStateNoPolicies onCreatePolicy={() => {}} />);
+		expect(screen.getByText('No policies defined')).toBeDefined();
+	});
+});

--- a/web/src/components/ui/Skeleton.test.tsx
+++ b/web/src/components/ui/Skeleton.test.tsx
@@ -1,0 +1,160 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import {
+	AvatarSkeleton,
+	BadgeSkeleton,
+	ButtonSkeleton,
+	CardSkeleton,
+	FormSectionSkeleton,
+	InputSkeleton,
+	Skeleton,
+	StatCardSkeleton,
+	TableRowSkeleton,
+	TextSkeleton,
+	skeletonKeys,
+} from './Skeleton';
+
+describe('Skeleton', () => {
+	it('renders with animate-pulse class', () => {
+		const { container } = render(<Skeleton />);
+		expect(container.querySelector('.animate-pulse')).not.toBeNull();
+	});
+
+	it('appends custom className', () => {
+		const { container } = render(<Skeleton className="h-10 w-20" />);
+		const el = container.firstChild as HTMLElement;
+		expect(el.className).toContain('h-10');
+		expect(el.className).toContain('w-20');
+	});
+});
+
+describe('skeletonKeys', () => {
+	it('returns stable keys with default prefix', () => {
+		expect(skeletonKeys(3)).toEqual(['sk-0', 'sk-1', 'sk-2']);
+	});
+
+	it('respects custom prefix', () => {
+		expect(skeletonKeys(2, 'row')).toEqual(['row-0', 'row-1']);
+	});
+
+	it('returns empty array for 0', () => {
+		expect(skeletonKeys(0)).toEqual([]);
+	});
+});
+
+describe('TextSkeleton', () => {
+	it('renders with default width/size classes', () => {
+		const { container } = render(<TextSkeleton />);
+		const el = container.firstChild as HTMLElement;
+		expect(el.className).toContain('w-32');
+		expect(el.className).toContain('h-4');
+	});
+
+	it('applies width prop', () => {
+		const { container } = render(<TextSkeleton width="full" />);
+		expect((container.firstChild as HTMLElement).className).toContain('w-full');
+	});
+});
+
+describe('AvatarSkeleton', () => {
+	it('renders rounded-full circle', () => {
+		const { container } = render(<AvatarSkeleton />);
+		expect((container.firstChild as HTMLElement).className).toContain(
+			'rounded-full',
+		);
+	});
+});
+
+describe('BadgeSkeleton', () => {
+	it('renders pill shape', () => {
+		const { container } = render(<BadgeSkeleton />);
+		expect((container.firstChild as HTMLElement).className).toContain(
+			'rounded-full',
+		);
+	});
+});
+
+describe('ButtonSkeleton', () => {
+	it('renders with size classes', () => {
+		const { container } = render(<ButtonSkeleton size="lg" />);
+		expect((container.firstChild as HTMLElement).className).toContain('h-12');
+	});
+});
+
+describe('CardSkeleton', () => {
+	it('renders header by default', () => {
+		const { container } = render(<CardSkeleton />);
+		expect(container.querySelectorAll('.animate-pulse').length).toBeGreaterThan(
+			1,
+		);
+	});
+
+	it('hides header when showHeader=false', () => {
+		const { container } = render(<CardSkeleton showHeader={false} />);
+		expect(container.firstChild).not.toBeNull();
+	});
+
+	it('renders requested number of lines', () => {
+		const { container } = render(<CardSkeleton lines={5} />);
+		expect(
+			container.querySelectorAll('.animate-pulse').length,
+		).toBeGreaterThanOrEqual(5);
+	});
+});
+
+describe('TableRowSkeleton', () => {
+	it('renders requested column count', () => {
+		const { container } = render(
+			<table>
+				<tbody>
+					<TableRowSkeleton columns={4} />
+				</tbody>
+			</table>,
+		);
+		expect(container.querySelectorAll('td').length).toBe(4);
+	});
+
+	it('adds checkbox column when showCheckbox=true', () => {
+		const { container } = render(
+			<table>
+				<tbody>
+					<TableRowSkeleton columns={4} showCheckbox />
+				</tbody>
+			</table>,
+		);
+		expect(container.querySelectorAll('td').length).toBe(4);
+	});
+});
+
+describe('StatCardSkeleton', () => {
+	it('renders', () => {
+		const { container } = render(<StatCardSkeleton />);
+		expect(container.firstChild).not.toBeNull();
+	});
+});
+
+describe('InputSkeleton', () => {
+	it('shows label by default', () => {
+		const { container } = render(<InputSkeleton />);
+		// Two skeleton divs: label + input
+		expect(container.querySelectorAll('.animate-pulse').length).toBe(2);
+	});
+
+	it('hides label when showLabel=false', () => {
+		const { container } = render(<InputSkeleton showLabel={false} />);
+		expect(container.querySelectorAll('.animate-pulse').length).toBe(1);
+	});
+});
+
+describe('FormSectionSkeleton', () => {
+	it('renders default 4 fields', () => {
+		const { container } = render(<FormSectionSkeleton />);
+		// 4 fields × 2 skeletons each (label+input) = 8
+		expect(container.querySelectorAll('.animate-pulse').length).toBe(8);
+	});
+
+	it('renders custom field count', () => {
+		const { container } = render(<FormSectionSkeleton fields={2} />);
+		expect(container.querySelectorAll('.animate-pulse').length).toBe(4);
+	});
+});

--- a/web/src/hooks/useActivity.test.ts
+++ b/web/src/hooks/useActivity.test.ts
@@ -1,0 +1,132 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import {
+	useActivity,
+	useActivityCategories,
+	useActivityCount,
+	useActivitySearch,
+	useRecentActivity,
+} from './useActivity';
+
+function mockFetch(data: unknown, ok = true, status = 200) {
+	const fn = vi.fn().mockResolvedValue({
+		ok,
+		status,
+		json: () => Promise.resolve(data),
+	} as unknown as Response);
+	vi.stubGlobal('fetch', fn);
+	return fn;
+}
+
+describe('useActivity', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches activity events', async () => {
+		mockFetch({ events: [], total: 0 });
+
+		const { result } = renderHook(() => useActivity(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual([]);
+	});
+});
+
+describe('useRecentActivity', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches recent activity', async () => {
+		mockFetch({ events: [] });
+
+		const { result } = renderHook(() => useRecentActivity(10), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useActivityCount', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches activity count', async () => {
+		mockFetch({ count: 42 });
+
+		const { result } = renderHook(() => useActivityCount(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual(42);
+	});
+});
+
+describe('useActivityCategories', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches categories', async () => {
+		mockFetch({ categories: [] });
+
+		const { result } = renderHook(() => useActivityCategories(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useActivitySearch', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('searches activity when query is non-empty', async () => {
+		mockFetch({ events: [] });
+
+		const { result } = renderHook(() => useActivitySearch('test'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+
+	it('does not fetch when query is empty', () => {
+		const fetchFn = mockFetch({ events: [] });
+
+		renderHook(() => useActivitySearch(''), {
+			wrapper: createWrapper(),
+		});
+
+		expect(fetchFn).not.toHaveBeenCalled();
+	});
+});

--- a/web/src/hooks/useAdminOrganizations.test.ts
+++ b/web/src/hooks/useAdminOrganizations.test.ts
@@ -1,0 +1,189 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import {
+	useAdminCreateOrganization,
+	useAdminDeleteOrganization,
+	useAdminOrgUsageStats,
+	useAdminOrganization,
+	useAdminOrganizations,
+	useAdminTransferOwnership,
+	useAdminUpdateOrganization,
+} from './useAdminOrganizations';
+
+function mockFetch(data: unknown, ok = true, status = 200) {
+	const fn = vi.fn().mockResolvedValue({
+		ok,
+		status,
+		json: () => Promise.resolve(data),
+	} as unknown as Response);
+	vi.stubGlobal('fetch', fn);
+	return fn;
+}
+
+describe('useAdminOrganizations', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches admin organizations', async () => {
+		mockFetch({ organizations: [], total: 0 });
+
+		const { result } = renderHook(() => useAdminOrganizations(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual({ organizations: [], total: 0 });
+	});
+});
+
+describe('useAdminOrganization', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches a single organization', async () => {
+		mockFetch({ id: 'org1', name: 'Test' });
+
+		const { result } = renderHook(() => useAdminOrganization('org1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+
+	it('does not fetch when id is empty', () => {
+		const fetchFn = mockFetch({});
+
+		renderHook(() => useAdminOrganization(''), {
+			wrapper: createWrapper(),
+		});
+
+		expect(fetchFn).not.toHaveBeenCalled();
+	});
+});
+
+describe('useAdminOrgUsageStats', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches usage stats', async () => {
+		mockFetch({ agent_count: 5 });
+
+		const { result } = renderHook(() => useAdminOrgUsageStats('org1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useAdminCreateOrganization', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('creates an organization', async () => {
+		mockFetch({ id: 'org1', name: 'New' });
+
+		const { result } = renderHook(() => useAdminCreateOrganization(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ name: 'New' } as Parameters<
+			typeof result.current.mutate
+		>[0]);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useAdminUpdateOrganization', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('updates an organization', async () => {
+		mockFetch({ id: 'org1', name: 'Updated' });
+
+		const { result } = renderHook(() => useAdminUpdateOrganization(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({
+			id: 'org1',
+			data: {} as Parameters<typeof result.current.mutate>[0]['data'],
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useAdminDeleteOrganization', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('deletes an organization', async () => {
+		mockFetch({ message: 'Deleted' });
+
+		const { result } = renderHook(() => useAdminDeleteOrganization(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate('org1');
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useAdminTransferOwnership', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('transfers ownership', async () => {
+		mockFetch({ message: 'Transferred' });
+
+		const { result } = renderHook(() => useAdminTransferOwnership(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({
+			orgId: 'org1',
+			data: { new_owner_id: 'user1' },
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});

--- a/web/src/hooks/useAgentImport.test.ts
+++ b/web/src/hooks/useAgentImport.test.ts
@@ -1,0 +1,158 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import {
+	useAgentImport,
+	useAgentImportPreview,
+	useAgentImportTemplate,
+	useAgentImportTemplateDownload,
+	useAgentImportTokensExport,
+	useAgentRegistrationScript,
+} from './useAgentImport';
+
+function mockFetch(data: unknown, ok = true, status = 200) {
+	const fn = vi.fn().mockResolvedValue({
+		ok,
+		status,
+		json: () => Promise.resolve(data),
+		blob: () => Promise.resolve(new Blob([JSON.stringify(data)])),
+	} as unknown as Response);
+	vi.stubGlobal('fetch', fn);
+	return fn;
+}
+
+describe('useAgentImportPreview', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('previews import', async () => {
+		mockFetch({ rows: [], errors: [] });
+
+		const { result } = renderHook(() => useAgentImportPreview(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ file: new File(['x'], 'test.csv') });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useAgentImport', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('imports agents', async () => {
+		mockFetch({ imported: 5, results: [] });
+
+		const { result } = renderHook(() => useAgentImport(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ file: new File(['x'], 'test.csv') });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useAgentImportTemplate', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches template', async () => {
+		mockFetch({ template: 'hostname,group' });
+
+		const { result } = renderHook(() => useAgentImportTemplate(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate(undefined);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useAgentImportTemplateDownload', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+		vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:url');
+		vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('downloads template blob', async () => {
+		mockFetch({ ok: true });
+
+		const { result } = renderHook(() => useAgentImportTemplateDownload(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate();
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useAgentRegistrationScript', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('generates script', async () => {
+		mockFetch({ script: 'curl ...' });
+
+		const { result } = renderHook(() => useAgentRegistrationScript(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ hostname: 'h1', registrationCode: 'code' });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useAgentImportTokensExport', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+		vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:url');
+		vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('exports tokens', async () => {
+		mockFetch({ ok: true });
+
+		const { result } = renderHook(() => useAgentImportTokensExport(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate([]);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});

--- a/web/src/hooks/useAgentRegistration.test.ts
+++ b/web/src/hooks/useAgentRegistration.test.ts
@@ -1,0 +1,85 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import {
+	useCreateRegistrationCode,
+	useDeleteRegistrationCode,
+	usePendingRegistrations,
+} from './useAgentRegistration';
+
+function mockFetch(data: unknown, ok = true, status = 200) {
+	const fn = vi.fn().mockResolvedValue({
+		ok,
+		status,
+		json: () => Promise.resolve(data),
+	} as unknown as Response);
+	vi.stubGlobal('fetch', fn);
+	return fn;
+}
+
+describe('usePendingRegistrations', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches pending registrations', async () => {
+		mockFetch({ registrations: [] });
+
+		const { result } = renderHook(() => usePendingRegistrations(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual([]);
+	});
+});
+
+describe('useCreateRegistrationCode', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('creates a registration code', async () => {
+		mockFetch({ code: 'abc123' });
+
+		const { result } = renderHook(() => useCreateRegistrationCode(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ expires_in_hours: 24 } as Parameters<
+			typeof result.current.mutate
+		>[0]);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useDeleteRegistrationCode', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('deletes a registration code', async () => {
+		mockFetch({ message: 'Deleted' });
+
+		const { result } = renderHook(() => useDeleteRegistrationCode(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate('code-id');
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});

--- a/web/src/hooks/useDockerStacks.test.ts
+++ b/web/src/hooks/useDockerStacks.test.ts
@@ -1,0 +1,173 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import {
+	useCreateDockerStack,
+	useDeleteDockerStack,
+	useDeleteDockerStackBackup,
+	useDiscoverDockerStacks,
+	useDockerStack,
+	useDockerStackBackup,
+	useDockerStackBackups,
+	useDockerStackRestore,
+	useDockerStacks,
+	useRestoreDockerStack,
+	useTriggerDockerStackBackup,
+	useUpdateDockerStack,
+} from './useDockerStacks';
+
+function mockFetch(data: unknown, ok = true, status = 200) {
+	const fn = vi.fn().mockResolvedValue({
+		ok,
+		status,
+		json: () => Promise.resolve(data),
+	} as unknown as Response);
+	vi.stubGlobal('fetch', fn);
+	return fn;
+}
+
+beforeEach(() => {
+	vi.restoreAllMocks();
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe('useDockerStacks', () => {
+	it('fetches docker stacks', async () => {
+		mockFetch({ stacks: [{ id: 's1', name: 'web' }] });
+		const { result } = renderHook(() => useDockerStacks(), {
+			wrapper: createWrapper(),
+		});
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual([{ id: 's1', name: 'web' }]);
+	});
+});
+
+describe('useDockerStack', () => {
+	it('fetches a single docker stack', async () => {
+		mockFetch({ id: 's1', name: 'web' });
+		const { result } = renderHook(() => useDockerStack('s1'), {
+			wrapper: createWrapper(),
+		});
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual({ id: 's1', name: 'web' });
+	});
+
+	it('does not fetch when id is empty', () => {
+		const fetchFn = mockFetch({});
+		renderHook(() => useDockerStack(''), { wrapper: createWrapper() });
+		expect(fetchFn).not.toHaveBeenCalled();
+	});
+});
+
+describe('useCreateDockerStack', () => {
+	it('creates a docker stack', async () => {
+		mockFetch({ id: 's1', name: 'web' });
+		const { result } = renderHook(() => useCreateDockerStack(), {
+			wrapper: createWrapper(),
+		});
+		result.current.mutate({ name: 'web', agent_id: 'a1' } as never);
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useUpdateDockerStack', () => {
+	it('updates a docker stack', async () => {
+		mockFetch({ id: 's1', name: 'web' });
+		const { result } = renderHook(() => useUpdateDockerStack(), {
+			wrapper: createWrapper(),
+		});
+		result.current.mutate({ id: 's1', data: { name: 'web2' } as never });
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useDeleteDockerStack', () => {
+	it('deletes a docker stack', async () => {
+		mockFetch({ message: 'Deleted' });
+		const { result } = renderHook(() => useDeleteDockerStack(), {
+			wrapper: createWrapper(),
+		});
+		result.current.mutate('s1');
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useTriggerDockerStackBackup', () => {
+	it('triggers a backup', async () => {
+		mockFetch({ backup_id: 'b1' });
+		const { result } = renderHook(() => useTriggerDockerStackBackup(), {
+			wrapper: createWrapper(),
+		});
+		result.current.mutate({ id: 's1' });
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useDockerStackBackups', () => {
+	it('fetches backups for a stack', async () => {
+		mockFetch({ backups: [] });
+		const { result } = renderHook(() => useDockerStackBackups('s1'), {
+			wrapper: createWrapper(),
+		});
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useDockerStackBackup', () => {
+	it('fetches a single backup', async () => {
+		mockFetch({ id: 'b1' });
+		const { result } = renderHook(() => useDockerStackBackup('b1'), {
+			wrapper: createWrapper(),
+		});
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useDeleteDockerStackBackup', () => {
+	it('deletes a backup', async () => {
+		mockFetch({ message: 'Deleted' });
+		const { result } = renderHook(() => useDeleteDockerStackBackup(), {
+			wrapper: createWrapper(),
+		});
+		result.current.mutate('b1');
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useRestoreDockerStack', () => {
+	it('restores a backup', async () => {
+		mockFetch({ id: 'r1' });
+		const { result } = renderHook(() => useRestoreDockerStack(), {
+			wrapper: createWrapper(),
+		});
+		result.current.mutate({
+			backupId: 'b1',
+			data: { agent_id: 'a1' } as never,
+		});
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useDockerStackRestore', () => {
+	it('fetches a restore', async () => {
+		mockFetch({ id: 'r1', status: 'completed' });
+		const { result } = renderHook(() => useDockerStackRestore('r1'), {
+			wrapper: createWrapper(),
+		});
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useDiscoverDockerStacks', () => {
+	it('discovers stacks', async () => {
+		mockFetch({ stacks: [] });
+		const { result } = renderHook(() => useDiscoverDockerStacks(), {
+			wrapper: createWrapper(),
+		});
+		result.current.mutate({ agent_id: 'a1' } as never);
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});

--- a/web/src/hooks/useDowntime.test.ts
+++ b/web/src/hooks/useDowntime.test.ts
@@ -1,0 +1,221 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import {
+	useActiveDowntime,
+	useCreateDowntimeAlert,
+	useCreateDowntimeEvent,
+	useDeleteDowntimeAlert,
+	useDeleteDowntimeEvent,
+	useDowntimeAlert,
+	useDowntimeAlerts,
+	useDowntimeEvent,
+	useDowntimeEvents,
+	useMonthlyUptimeReport,
+	useRefreshUptimeBadges,
+	useResolveDowntimeEvent,
+	useUpdateDowntimeAlert,
+	useUpdateDowntimeEvent,
+	useUptimeBadges,
+	useUptimeSummary,
+} from './useDowntime';
+
+function mockFetch(data: unknown, ok = true, status = 200) {
+	const fn = vi.fn().mockResolvedValue({
+		ok,
+		status,
+		json: () => Promise.resolve(data),
+	} as unknown as Response);
+	vi.stubGlobal('fetch', fn);
+	return fn;
+}
+
+beforeEach(() => {
+	vi.restoreAllMocks();
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe('useDowntimeEvents', () => {
+	it('fetches downtime events', async () => {
+		mockFetch({ events: [] });
+		const { result } = renderHook(() => useDowntimeEvents(), {
+			wrapper: createWrapper(),
+		});
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useActiveDowntime', () => {
+	it('fetches active downtime', async () => {
+		mockFetch({ events: [] });
+		const { result } = renderHook(() => useActiveDowntime(), {
+			wrapper: createWrapper(),
+		});
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useUptimeSummary', () => {
+	it('fetches uptime summary', async () => {
+		mockFetch({ uptime_percentage: 99.9 });
+		const { result } = renderHook(() => useUptimeSummary(), {
+			wrapper: createWrapper(),
+		});
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useDowntimeEvent', () => {
+	it('fetches a single event', async () => {
+		mockFetch({ id: 'e1' });
+		const { result } = renderHook(() => useDowntimeEvent('e1'), {
+			wrapper: createWrapper(),
+		});
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+
+	it('does not fetch when id is empty', () => {
+		const fetchFn = mockFetch({});
+		renderHook(() => useDowntimeEvent(''), { wrapper: createWrapper() });
+		expect(fetchFn).not.toHaveBeenCalled();
+	});
+});
+
+describe('useCreateDowntimeEvent', () => {
+	it('creates a downtime event', async () => {
+		mockFetch({ id: 'e1' });
+		const { result } = renderHook(() => useCreateDowntimeEvent(), {
+			wrapper: createWrapper(),
+		});
+		result.current.mutate({ agent_id: 'a1' } as never);
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useUpdateDowntimeEvent', () => {
+	it('updates an event', async () => {
+		mockFetch({ id: 'e1' });
+		const { result } = renderHook(() => useUpdateDowntimeEvent(), {
+			wrapper: createWrapper(),
+		});
+		result.current.mutate({ id: 'e1', data: {} as never });
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useResolveDowntimeEvent', () => {
+	it('resolves an event', async () => {
+		mockFetch({ id: 'e1' });
+		const { result } = renderHook(() => useResolveDowntimeEvent(), {
+			wrapper: createWrapper(),
+		});
+		result.current.mutate({ id: 'e1' });
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useDeleteDowntimeEvent', () => {
+	it('deletes an event', async () => {
+		mockFetch({ message: 'Deleted' });
+		const { result } = renderHook(() => useDeleteDowntimeEvent(), {
+			wrapper: createWrapper(),
+		});
+		result.current.mutate('e1');
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useUptimeBadges', () => {
+	it('fetches uptime badges', async () => {
+		mockFetch({ badges: [] });
+		const { result } = renderHook(() => useUptimeBadges(), {
+			wrapper: createWrapper(),
+		});
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useRefreshUptimeBadges', () => {
+	it('refreshes uptime badges', async () => {
+		mockFetch({ message: 'ok' });
+		const { result } = renderHook(() => useRefreshUptimeBadges(), {
+			wrapper: createWrapper(),
+		});
+		result.current.mutate();
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useMonthlyUptimeReport', () => {
+	it('fetches a monthly report', async () => {
+		mockFetch({ year: 2025, month: 1 });
+		const { result } = renderHook(() => useMonthlyUptimeReport(2025, 1), {
+			wrapper: createWrapper(),
+		});
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+
+	it('does not fetch with invalid month', () => {
+		const fetchFn = mockFetch({});
+		renderHook(() => useMonthlyUptimeReport(2025, 13), {
+			wrapper: createWrapper(),
+		});
+		expect(fetchFn).not.toHaveBeenCalled();
+	});
+});
+
+describe('useDowntimeAlerts', () => {
+	it('fetches alerts', async () => {
+		mockFetch({ alerts: [] });
+		const { result } = renderHook(() => useDowntimeAlerts(), {
+			wrapper: createWrapper(),
+		});
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useDowntimeAlert', () => {
+	it('fetches a single alert', async () => {
+		mockFetch({ id: 'al1' });
+		const { result } = renderHook(() => useDowntimeAlert('al1'), {
+			wrapper: createWrapper(),
+		});
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useCreateDowntimeAlert', () => {
+	it('creates an alert', async () => {
+		mockFetch({ id: 'al1' });
+		const { result } = renderHook(() => useCreateDowntimeAlert(), {
+			wrapper: createWrapper(),
+		});
+		result.current.mutate({ name: 'test' } as never);
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useUpdateDowntimeAlert', () => {
+	it('updates an alert', async () => {
+		mockFetch({ id: 'al1' });
+		const { result } = renderHook(() => useUpdateDowntimeAlert(), {
+			wrapper: createWrapper(),
+		});
+		result.current.mutate({ id: 'al1', data: {} as never });
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useDeleteDowntimeAlert', () => {
+	it('deletes an alert', async () => {
+		mockFetch({ message: 'Deleted' });
+		const { result } = renderHook(() => useDeleteDowntimeAlert(), {
+			wrapper: createWrapper(),
+		});
+		result.current.mutate('al1');
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});

--- a/web/src/hooks/useFavorites.test.ts
+++ b/web/src/hooks/useFavorites.test.ts
@@ -1,0 +1,84 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import {
+	useAddFavorite,
+	useFavoriteIds,
+	useFavorites,
+	useIsFavorite,
+	useRemoveFavorite,
+} from './useFavorites';
+
+function mockFetch(data: unknown, ok = true, status = 200) {
+	const fn = vi.fn().mockResolvedValue({
+		ok,
+		status,
+		json: () => Promise.resolve(data),
+	} as unknown as Response);
+	vi.stubGlobal('fetch', fn);
+	return fn;
+}
+
+beforeEach(() => {
+	vi.restoreAllMocks();
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe('useFavorites', () => {
+	it('fetches favorites', async () => {
+		mockFetch({
+			favorites: [{ id: 'f1', entity_type: 'agent', entity_id: 'a1' }],
+		});
+		const { result } = renderHook(() => useFavorites(), {
+			wrapper: createWrapper(),
+		});
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useAddFavorite', () => {
+	it('adds a favorite', async () => {
+		mockFetch({ id: 'f1', entity_type: 'agent', entity_id: 'a1' });
+		const { result } = renderHook(() => useAddFavorite(), {
+			wrapper: createWrapper(),
+		});
+		result.current.mutate({ entity_type: 'agent', entity_id: 'a1' } as never);
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useRemoveFavorite', () => {
+	it('removes a favorite', async () => {
+		mockFetch({ message: 'Deleted' });
+		const { result } = renderHook(() => useRemoveFavorite(), {
+			wrapper: createWrapper(),
+		});
+		result.current.mutate({ entityType: 'agent' as never, entityId: 'a1' });
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useIsFavorite', () => {
+	it('returns false when entity is not favorited', async () => {
+		mockFetch({ favorites: [] });
+		const { result } = renderHook(() => useIsFavorite('agent' as never, 'a1'), {
+			wrapper: createWrapper(),
+		});
+		await waitFor(() => expect(result.current).toBe(false));
+	});
+});
+
+describe('useFavoriteIds', () => {
+	it('returns a Set of favorite ids', async () => {
+		mockFetch({
+			favorites: [{ id: 'f1', entity_type: 'agent', entity_id: 'a1' }],
+		});
+		const { result } = renderHook(() => useFavoriteIds('agent' as never), {
+			wrapper: createWrapper(),
+		});
+		await waitFor(() => expect(result.current.has('a1')).toBe(true));
+	});
+});

--- a/web/src/hooks/useFileSearch.test.ts
+++ b/web/src/hooks/useFileSearch.test.ts
@@ -1,0 +1,51 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import { useFileSearch } from './useFileSearch';
+
+function mockFetch(data: unknown, ok = true, status = 200) {
+	const fn = vi.fn().mockResolvedValue({
+		ok,
+		status,
+		json: () => Promise.resolve(data),
+	} as unknown as Response);
+	vi.stubGlobal('fetch', fn);
+	return fn;
+}
+
+beforeEach(() => {
+	vi.restoreAllMocks();
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe('useFileSearch', () => {
+	it('fetches file search results', async () => {
+		mockFetch({
+			query: 'foo',
+			agent_id: 'a1',
+			repository_id: 'r1',
+			total_count: 0,
+			snapshot_count: 0,
+			snapshots: [],
+		});
+		const { result } = renderHook(
+			() =>
+				useFileSearch({
+					q: 'foo',
+					agent_id: 'a1',
+					repository_id: 'r1',
+				}),
+			{ wrapper: createWrapper() },
+		);
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+
+	it('does not fetch when params are null', () => {
+		const fetchFn = mockFetch({});
+		renderHook(() => useFileSearch(null), { wrapper: createWrapper() });
+		expect(fetchFn).not.toHaveBeenCalled();
+	});
+});

--- a/web/src/hooks/useGeoReplication.test.ts
+++ b/web/src/hooks/useGeoReplication.test.ts
@@ -1,0 +1,157 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import {
+	useCreateGeoReplicationConfig,
+	useDeleteGeoReplicationConfig,
+	useGeoReplicationConfig,
+	useGeoReplicationConfigs,
+	useGeoReplicationEvents,
+	useGeoReplicationRegions,
+	useGeoReplicationSummary,
+	useRepositoryReplicationStatus,
+	useSetRepositoryRegion,
+	useTriggerReplication,
+	useUpdateGeoReplicationConfig,
+} from './useGeoReplication';
+
+function mockFetch(data: unknown, ok = true, status = 200) {
+	const fn = vi.fn().mockResolvedValue({
+		ok,
+		status,
+		json: () => Promise.resolve(data),
+	} as unknown as Response);
+	vi.stubGlobal('fetch', fn);
+	return fn;
+}
+
+beforeEach(() => {
+	vi.restoreAllMocks();
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe('useGeoReplicationRegions', () => {
+	it('fetches regions', async () => {
+		mockFetch({ regions: [], pairs: [] });
+		const { result } = renderHook(() => useGeoReplicationRegions(), {
+			wrapper: createWrapper(),
+		});
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useGeoReplicationConfigs', () => {
+	it('fetches configs', async () => {
+		mockFetch({ configs: [] });
+		const { result } = renderHook(() => useGeoReplicationConfigs(), {
+			wrapper: createWrapper(),
+		});
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useGeoReplicationConfig', () => {
+	it('fetches a single config', async () => {
+		mockFetch({ id: 'c1' });
+		const { result } = renderHook(() => useGeoReplicationConfig('c1'), {
+			wrapper: createWrapper(),
+		});
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+
+	it('does not fetch when id is empty', () => {
+		const fetchFn = mockFetch({});
+		renderHook(() => useGeoReplicationConfig(''), {
+			wrapper: createWrapper(),
+		});
+		expect(fetchFn).not.toHaveBeenCalled();
+	});
+});
+
+describe('useGeoReplicationSummary', () => {
+	it('fetches summary', async () => {
+		mockFetch({ total: 0 });
+		const { result } = renderHook(() => useGeoReplicationSummary(), {
+			wrapper: createWrapper(),
+		});
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useGeoReplicationEvents', () => {
+	it('fetches events', async () => {
+		mockFetch({ events: [] });
+		const { result } = renderHook(() => useGeoReplicationEvents('c1'), {
+			wrapper: createWrapper(),
+		});
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useRepositoryReplicationStatus', () => {
+	it('fetches repository status', async () => {
+		mockFetch({ repository_id: 'r1' });
+		const { result } = renderHook(() => useRepositoryReplicationStatus('r1'), {
+			wrapper: createWrapper(),
+		});
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useCreateGeoReplicationConfig', () => {
+	it('creates a config', async () => {
+		mockFetch({ id: 'c1' });
+		const { result } = renderHook(() => useCreateGeoReplicationConfig(), {
+			wrapper: createWrapper(),
+		});
+		result.current.mutate({ name: 'test' } as never);
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useUpdateGeoReplicationConfig', () => {
+	it('updates a config', async () => {
+		mockFetch({ id: 'c1' });
+		const { result } = renderHook(() => useUpdateGeoReplicationConfig(), {
+			wrapper: createWrapper(),
+		});
+		result.current.mutate({ id: 'c1', data: {} as never });
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useDeleteGeoReplicationConfig', () => {
+	it('deletes a config', async () => {
+		mockFetch({ message: 'Deleted' });
+		const { result } = renderHook(() => useDeleteGeoReplicationConfig(), {
+			wrapper: createWrapper(),
+		});
+		result.current.mutate('c1');
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useTriggerReplication', () => {
+	it('triggers replication', async () => {
+		mockFetch({ message: 'ok' });
+		const { result } = renderHook(() => useTriggerReplication(), {
+			wrapper: createWrapper(),
+		});
+		result.current.mutate('c1');
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useSetRepositoryRegion', () => {
+	it('sets a repository region', async () => {
+		mockFetch({ message: 'ok' });
+		const { result } = renderHook(() => useSetRepositoryRegion(), {
+			wrapper: createWrapper(),
+		});
+		result.current.mutate({ repoId: 'r1', region: 'us-east-1' });
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});

--- a/web/src/hooks/useIPAllowlists.test.ts
+++ b/web/src/hooks/useIPAllowlists.test.ts
@@ -1,0 +1,121 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import {
+	useCreateIPAllowlist,
+	useDeleteIPAllowlist,
+	useIPAllowlist,
+	useIPAllowlistSettings,
+	useIPAllowlists,
+	useIPBlockedAttempts,
+	useUpdateIPAllowlist,
+	useUpdateIPAllowlistSettings,
+} from './useIPAllowlists';
+
+function mockFetch(data: unknown, ok = true, status = 200) {
+	const fn = vi.fn().mockResolvedValue({
+		ok,
+		status,
+		json: () => Promise.resolve(data),
+	} as unknown as Response);
+	vi.stubGlobal('fetch', fn);
+	return fn;
+}
+
+beforeEach(() => {
+	vi.restoreAllMocks();
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe('useIPAllowlists', () => {
+	it('fetches allowlists', async () => {
+		mockFetch({ allowlists: [] });
+		const { result } = renderHook(() => useIPAllowlists(), {
+			wrapper: createWrapper(),
+		});
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useIPAllowlist', () => {
+	it('fetches a single allowlist', async () => {
+		mockFetch({ id: 'a1' });
+		const { result } = renderHook(() => useIPAllowlist('a1'), {
+			wrapper: createWrapper(),
+		});
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+
+	it('does not fetch when id is empty', () => {
+		const fetchFn = mockFetch({});
+		renderHook(() => useIPAllowlist(''), { wrapper: createWrapper() });
+		expect(fetchFn).not.toHaveBeenCalled();
+	});
+});
+
+describe('useCreateIPAllowlist', () => {
+	it('creates an allowlist', async () => {
+		mockFetch({ id: 'a1' });
+		const { result } = renderHook(() => useCreateIPAllowlist(), {
+			wrapper: createWrapper(),
+		});
+		result.current.mutate({ cidr: '10.0.0.0/8' } as never);
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useUpdateIPAllowlist', () => {
+	it('updates an allowlist', async () => {
+		mockFetch({ id: 'a1' });
+		const { result } = renderHook(() => useUpdateIPAllowlist(), {
+			wrapper: createWrapper(),
+		});
+		result.current.mutate({ id: 'a1', data: {} as never });
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useDeleteIPAllowlist', () => {
+	it('deletes an allowlist', async () => {
+		mockFetch({ message: 'Deleted' });
+		const { result } = renderHook(() => useDeleteIPAllowlist(), {
+			wrapper: createWrapper(),
+		});
+		result.current.mutate('a1');
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useIPAllowlistSettings', () => {
+	it('fetches settings', async () => {
+		mockFetch({ enabled: true });
+		const { result } = renderHook(() => useIPAllowlistSettings(), {
+			wrapper: createWrapper(),
+		});
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useUpdateIPAllowlistSettings', () => {
+	it('updates settings', async () => {
+		mockFetch({ enabled: true });
+		const { result } = renderHook(() => useUpdateIPAllowlistSettings(), {
+			wrapper: createWrapper(),
+		});
+		result.current.mutate({ enabled: true } as never);
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useIPBlockedAttempts', () => {
+	it('fetches blocked attempts', async () => {
+		mockFetch({ attempts: [] });
+		const { result } = renderHook(() => useIPBlockedAttempts(), {
+			wrapper: createWrapper(),
+		});
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});

--- a/web/src/hooks/useImmutability.test.ts
+++ b/web/src/hooks/useImmutability.test.ts
@@ -1,0 +1,134 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import {
+	useCreateImmutabilityLock,
+	useExtendImmutabilityLock,
+	useImmutabilityLock,
+	useImmutabilityLocks,
+	useRepositoryImmutabilityLocks,
+	useRepositoryImmutabilitySettings,
+	useSnapshotImmutabilityStatus,
+	useUpdateRepositoryImmutabilitySettings,
+} from './useImmutability';
+
+function mockFetch(data: unknown, ok = true, status = 200) {
+	const fn = vi.fn().mockResolvedValue({
+		ok,
+		status,
+		json: () => Promise.resolve(data),
+	} as unknown as Response);
+	vi.stubGlobal('fetch', fn);
+	return fn;
+}
+
+beforeEach(() => {
+	vi.restoreAllMocks();
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe('useImmutabilityLocks', () => {
+	it('fetches locks', async () => {
+		mockFetch({ locks: [] });
+		const { result } = renderHook(() => useImmutabilityLocks(), {
+			wrapper: createWrapper(),
+		});
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useImmutabilityLock', () => {
+	it('fetches a single lock', async () => {
+		mockFetch({ id: 'l1' });
+		const { result } = renderHook(() => useImmutabilityLock('l1'), {
+			wrapper: createWrapper(),
+		});
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+
+	it('does not fetch when id is empty', () => {
+		const fetchFn = mockFetch({});
+		renderHook(() => useImmutabilityLock(''), { wrapper: createWrapper() });
+		expect(fetchFn).not.toHaveBeenCalled();
+	});
+});
+
+describe('useRepositoryImmutabilityLocks', () => {
+	it('fetches repository locks', async () => {
+		mockFetch({ locks: [] });
+		const { result } = renderHook(() => useRepositoryImmutabilityLocks('r1'), {
+			wrapper: createWrapper(),
+		});
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useSnapshotImmutabilityStatus', () => {
+	it('fetches snapshot status', async () => {
+		mockFetch({ snapshot_id: 's1', locked: false });
+		const { result } = renderHook(
+			() => useSnapshotImmutabilityStatus('s1', 'r1'),
+			{ wrapper: createWrapper() },
+		);
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+
+	it('does not fetch when ids are empty', () => {
+		const fetchFn = mockFetch({});
+		renderHook(() => useSnapshotImmutabilityStatus('', ''), {
+			wrapper: createWrapper(),
+		});
+		expect(fetchFn).not.toHaveBeenCalled();
+	});
+});
+
+describe('useRepositoryImmutabilitySettings', () => {
+	it('fetches settings', async () => {
+		mockFetch({ repository_id: 'r1' });
+		const { result } = renderHook(
+			() => useRepositoryImmutabilitySettings('r1'),
+			{ wrapper: createWrapper() },
+		);
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useCreateImmutabilityLock', () => {
+	it('creates a lock', async () => {
+		mockFetch({ id: 'l1' });
+		const { result } = renderHook(() => useCreateImmutabilityLock(), {
+			wrapper: createWrapper(),
+		});
+		result.current.mutate({
+			snapshot_id: 's1',
+			repository_id: 'r1',
+		} as never);
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useExtendImmutabilityLock', () => {
+	it('extends a lock', async () => {
+		mockFetch({ id: 'l1' });
+		const { result } = renderHook(() => useExtendImmutabilityLock(), {
+			wrapper: createWrapper(),
+		});
+		result.current.mutate({ id: 'l1', data: {} as never });
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useUpdateRepositoryImmutabilitySettings', () => {
+	it('updates settings', async () => {
+		mockFetch({ repository_id: 'r1' });
+		const { result } = renderHook(
+			() => useUpdateRepositoryImmutabilitySettings(),
+			{ wrapper: createWrapper() },
+		);
+		result.current.mutate({ repositoryId: 'r1', data: {} as never });
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});

--- a/web/src/hooks/useRateLimits.test.ts
+++ b/web/src/hooks/useRateLimits.test.ts
@@ -1,0 +1,305 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import {
+	useBlockedRequests,
+	useCreateIPBan,
+	useCreateRateLimitConfig,
+	useDeleteIPBan,
+	useDeleteRateLimitConfig,
+	useIPBans,
+	useRateLimitConfig,
+	useRateLimitConfigs,
+	useRateLimitDashboard,
+	useRateLimitStats,
+	useUpdateRateLimitConfig,
+} from './useRateLimits';
+
+function mockFetch(data: unknown, ok = true, status = 200) {
+	const fn = vi.fn().mockResolvedValue({
+		ok,
+		status,
+		json: () => Promise.resolve(data),
+	} as unknown as Response);
+	vi.stubGlobal('fetch', fn);
+	return fn;
+}
+
+describe('useRateLimitDashboard', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches dashboard stats', async () => {
+		const stats = { total: 5 };
+		const fetchFn = mockFetch(stats);
+
+		const { result } = renderHook(() => useRateLimitDashboard(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.stats).toEqual(stats));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/admin/rate-limits',
+			expect.any(Object),
+		);
+	});
+});
+
+describe('useRateLimitConfigs', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches rate limit configs', async () => {
+		const fetchFn = mockFetch({ configs: [{ id: 'rl-1' }] });
+
+		const { result } = renderHook(() => useRateLimitConfigs(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual([{ id: 'rl-1' }]);
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/rate-limit-configs',
+			expect.any(Object),
+		);
+	});
+});
+
+describe('useRateLimitConfig', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches a single rate limit config', async () => {
+		mockFetch({ id: 'rl-1' });
+
+		const { result } = renderHook(() => useRateLimitConfig('rl-1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual({ id: 'rl-1' });
+	});
+
+	it('does not fetch when id is empty', () => {
+		const fetchFn = mockFetch({});
+
+		renderHook(() => useRateLimitConfig(''), { wrapper: createWrapper() });
+
+		expect(fetchFn).not.toHaveBeenCalled();
+	});
+});
+
+describe('useRateLimitStats', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches rate limit stats', async () => {
+		mockFetch({ total: 3 });
+
+		const { result } = renderHook(() => useRateLimitStats(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual({ total: 3 });
+	});
+});
+
+describe('useBlockedRequests', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches blocked requests', async () => {
+		mockFetch({ blocked: [] });
+
+		const { result } = renderHook(() => useBlockedRequests(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual({ blocked: [] });
+	});
+});
+
+describe('useCreateRateLimitConfig', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('creates a rate limit config', async () => {
+		const fetchFn = mockFetch({ id: 'new-rl' });
+
+		const { result } = renderHook(() => useCreateRateLimitConfig(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({
+			name: 'test',
+			endpoint_pattern: '/api/x',
+			method: 'GET',
+			max_requests: 10,
+			window_seconds: 60,
+			enabled: true,
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/rate-limit-configs',
+			expect.objectContaining({ method: 'POST' }),
+		);
+	});
+});
+
+describe('useUpdateRateLimitConfig', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('updates a rate limit config', async () => {
+		const fetchFn = mockFetch({ id: 'rl-1' });
+
+		const { result } = renderHook(() => useUpdateRateLimitConfig(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ id: 'rl-1', data: { enabled: false } });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/rate-limit-configs/rl-1',
+			expect.objectContaining({ method: 'PUT' }),
+		);
+	});
+});
+
+describe('useDeleteRateLimitConfig', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('deletes a rate limit config', async () => {
+		const fetchFn = mockFetch({ message: 'ok' });
+
+		const { result } = renderHook(() => useDeleteRateLimitConfig(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate('rl-1');
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/rate-limit-configs/rl-1',
+			expect.objectContaining({ method: 'DELETE' }),
+		);
+	});
+});
+
+describe('useIPBans', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches IP bans', async () => {
+		mockFetch({ bans: [{ id: 'ban-1' }] });
+
+		const { result } = renderHook(() => useIPBans(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual([{ id: 'ban-1' }]);
+	});
+});
+
+describe('useCreateIPBan', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('creates an IP ban', async () => {
+		const fetchFn = mockFetch({ id: 'ban-1' });
+
+		const { result } = renderHook(() => useCreateIPBan(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ ip_address: '1.2.3.4', reason: 'spam' });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/ip-bans',
+			expect.objectContaining({ method: 'POST' }),
+		);
+	});
+});
+
+describe('useDeleteIPBan', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('deletes an IP ban', async () => {
+		const fetchFn = mockFetch({ message: 'ok' });
+
+		const { result } = renderHook(() => useDeleteIPBan(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate('ban-1');
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/ip-bans/ban-1',
+			expect.objectContaining({ method: 'DELETE' }),
+		);
+	});
+});

--- a/web/src/hooks/useRecentItems.test.ts
+++ b/web/src/hooks/useRecentItems.test.ts
@@ -1,0 +1,140 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import {
+	useClearRecentItems,
+	useDeleteRecentItem,
+	useRecentItems,
+	useTrackRecentItem,
+} from './useRecentItems';
+
+function mockFetch(data: unknown, ok = true, status = 200) {
+	const fn = vi.fn().mockResolvedValue({
+		ok,
+		status,
+		json: () => Promise.resolve(data),
+	} as unknown as Response);
+	vi.stubGlobal('fetch', fn);
+	return fn;
+}
+
+describe('useRecentItems', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches recent items without filter', async () => {
+		const fetchFn = mockFetch({ items: [{ id: 'item-1' }] });
+
+		const { result } = renderHook(() => useRecentItems(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual([{ id: 'item-1' }]);
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/recent-items',
+			expect.any(Object),
+		);
+	});
+
+	it('fetches recent items filtered by type', async () => {
+		const fetchFn = mockFetch({ items: [] });
+
+		const { result } = renderHook(() => useRecentItems('agent'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/recent-items?type=agent',
+			expect.any(Object),
+		);
+	});
+});
+
+describe('useTrackRecentItem', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('tracks a recent item', async () => {
+		const fetchFn = mockFetch({ id: 'item-1' });
+
+		const { result } = renderHook(() => useTrackRecentItem(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({
+			item_type: 'agent',
+			item_id: 'agent-1',
+			item_name: 'host',
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/recent-items',
+			expect.objectContaining({ method: 'POST' }),
+		);
+	});
+});
+
+describe('useDeleteRecentItem', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('deletes a recent item', async () => {
+		const fetchFn = mockFetch({ message: 'ok' });
+
+		const { result } = renderHook(() => useDeleteRecentItem(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate('item-1');
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/recent-items/item-1',
+			expect.objectContaining({ method: 'DELETE' }),
+		);
+	});
+});
+
+describe('useClearRecentItems', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('clears all recent items', async () => {
+		const fetchFn = mockFetch({ message: 'ok' });
+
+		const { result } = renderHook(() => useClearRecentItems(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate();
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/recent-items',
+			expect.objectContaining({ method: 'DELETE' }),
+		);
+	});
+});

--- a/web/src/hooks/useRepositoryImport.test.ts
+++ b/web/src/hooks/useRepositoryImport.test.ts
@@ -1,0 +1,109 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import {
+	useImportPreview,
+	useImportRepository,
+	useVerifyImportAccess,
+} from './useRepositoryImport';
+
+function mockFetch(data: unknown, ok = true, status = 200) {
+	const fn = vi.fn().mockResolvedValue({
+		ok,
+		status,
+		json: () => Promise.resolve(data),
+	} as unknown as Response);
+	vi.stubGlobal('fetch', fn);
+	return fn;
+}
+
+describe('useVerifyImportAccess', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('verifies repository import access', async () => {
+		const fetchFn = mockFetch({ accessible: true });
+
+		const { result } = renderHook(() => useVerifyImportAccess(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({
+			backend: 's3',
+			config: { bucket: 'b' },
+			password: 'pw',
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/repositories/import/verify',
+			expect.objectContaining({ method: 'POST' }),
+		);
+	});
+});
+
+describe('useImportPreview', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('previews a repository import', async () => {
+		const fetchFn = mockFetch({ snapshots: [] });
+
+		const { result } = renderHook(() => useImportPreview(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({
+			backend: 's3',
+			config: { bucket: 'b' },
+			password: 'pw',
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/repositories/import/preview',
+			expect.objectContaining({ method: 'POST' }),
+		);
+	});
+});
+
+describe('useImportRepository', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('imports a repository', async () => {
+		const fetchFn = mockFetch({ id: 'repo-1' });
+
+		const { result } = renderHook(() => useImportRepository(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({
+			name: 'imported',
+			backend: 's3',
+			config: { bucket: 'b' },
+			password: 'pw',
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/repositories/import',
+			expect.objectContaining({ method: 'POST' }),
+		);
+	});
+});

--- a/web/src/hooks/useServerLogs.test.ts
+++ b/web/src/hooks/useServerLogs.test.ts
@@ -1,0 +1,171 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import {
+	useClearServerLogs,
+	useExportServerLogsCsv,
+	useExportServerLogsJson,
+	useServerLogComponents,
+	useServerLogs,
+} from './useServerLogs';
+
+function mockFetch(data: unknown, ok = true, status = 200) {
+	const fn = vi.fn().mockResolvedValue({
+		ok,
+		status,
+		json: () => Promise.resolve(data),
+	} as unknown as Response);
+	vi.stubGlobal('fetch', fn);
+	return fn;
+}
+
+function mockFetchBlob(blob: Blob, ok = true, status = 200) {
+	const fn = vi.fn().mockResolvedValue({
+		ok,
+		status,
+		blob: () => Promise.resolve(blob),
+	} as unknown as Response);
+	vi.stubGlobal('fetch', fn);
+	return fn;
+}
+
+describe('useServerLogs', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches server logs without filter', async () => {
+		const fetchFn = mockFetch({ logs: [] });
+
+		const { result } = renderHook(() => useServerLogs(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/admin/logs',
+			expect.any(Object),
+		);
+	});
+
+	it('fetches server logs with filter', async () => {
+		const fetchFn = mockFetch({ logs: [] });
+
+		const { result } = renderHook(
+			() => useServerLogs({ level: 'error', limit: 10 }),
+			{ wrapper: createWrapper() },
+		);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/admin/logs?level=error&limit=10',
+			expect.any(Object),
+		);
+	});
+});
+
+describe('useServerLogComponents', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches server log components', async () => {
+		mockFetch({ components: ['api', 'auth'] });
+
+		const { result } = renderHook(() => useServerLogComponents(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual(['api', 'auth']);
+	});
+});
+
+describe('useExportServerLogsCsv', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+		vi.spyOn(window.URL, 'createObjectURL').mockReturnValue('blob:mock');
+		vi.spyOn(window.URL, 'revokeObjectURL').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('exports server logs as CSV', async () => {
+		const blob = new Blob(['csv-data']);
+		const fetchFn = mockFetchBlob(blob);
+
+		const { result } = renderHook(() => useExportServerLogsCsv(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate(undefined);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/admin/logs/export/csv',
+			expect.any(Object),
+		);
+	});
+});
+
+describe('useExportServerLogsJson', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+		vi.spyOn(window.URL, 'createObjectURL').mockReturnValue('blob:mock');
+		vi.spyOn(window.URL, 'revokeObjectURL').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('exports server logs as JSON', async () => {
+		const blob = new Blob(['json-data']);
+		const fetchFn = mockFetchBlob(blob);
+
+		const { result } = renderHook(() => useExportServerLogsJson(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate(undefined);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/admin/logs/export/json',
+			expect.any(Object),
+		);
+	});
+});
+
+describe('useClearServerLogs', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('clears server logs', async () => {
+		const fetchFn = mockFetch({ message: 'ok' });
+
+		const { result } = renderHook(() => useClearServerLogs(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate();
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalled();
+	});
+});

--- a/web/src/hooks/useSupport.test.ts
+++ b/web/src/hooks/useSupport.test.ts
@@ -1,0 +1,62 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import { useGenerateSupportBundle } from './useSupport';
+
+function mockFetchBlob(blob: Blob, ok = true, status = 200) {
+	const fn = vi.fn().mockResolvedValue({
+		ok,
+		status,
+		blob: () => Promise.resolve(blob),
+	} as unknown as Response);
+	vi.stubGlobal('fetch', fn);
+	return fn;
+}
+
+describe('useGenerateSupportBundle', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+		vi.spyOn(window.URL, 'createObjectURL').mockReturnValue('blob:mock');
+		vi.spyOn(window.URL, 'revokeObjectURL').mockImplementation(() => {});
+		vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('generates a support bundle', async () => {
+		const blob = new Blob(['zip-bytes']);
+		const fetchFn = mockFetchBlob(blob);
+
+		const { result } = renderHook(() => useGenerateSupportBundle(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate();
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/support/bundle',
+			expect.objectContaining({ method: 'POST' }),
+		);
+		expect(result.current.data?.filename).toMatch(/keldris-support-bundle-/);
+	});
+
+	it('handles error', async () => {
+		const fn = vi.fn().mockResolvedValue({
+			ok: false,
+			status: 500,
+			blob: () => Promise.resolve(new Blob()),
+		} as unknown as Response);
+		vi.stubGlobal('fetch', fn);
+
+		const { result } = renderHook(() => useGenerateSupportBundle(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate();
+
+		await waitFor(() => expect(result.current.isError).toBe(true));
+	});
+});

--- a/web/src/hooks/useSystemSettings.test.ts
+++ b/web/src/hooks/useSystemSettings.test.ts
@@ -1,0 +1,327 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import {
+	useOIDCSettings,
+	useSMTPSettings,
+	useSecuritySettings,
+	useSettingsAuditLog,
+	useStorageDefaultSettings,
+	useSystemSettings,
+	useTestOIDC,
+	useTestSMTP,
+	useUpdateOIDCSettings,
+	useUpdateSMTPSettings,
+	useUpdateSecuritySettings,
+	useUpdateStorageDefaultSettings,
+} from './useSystemSettings';
+
+function mockFetch(data: unknown, ok = true, status = 200) {
+	const fn = vi.fn().mockResolvedValue({
+		ok,
+		status,
+		json: () => Promise.resolve(data),
+	} as unknown as Response);
+	vi.stubGlobal('fetch', fn);
+	return fn;
+}
+
+describe('useSystemSettings', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches all system settings', async () => {
+		const fetchFn = mockFetch({ smtp: null });
+
+		const { result } = renderHook(() => useSystemSettings(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/system-settings',
+			expect.any(Object),
+		);
+	});
+});
+
+describe('useSMTPSettings', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches SMTP settings', async () => {
+		const fetchFn = mockFetch({ host: 'smtp.test' });
+
+		const { result } = renderHook(() => useSMTPSettings(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/system-settings/smtp',
+			expect.any(Object),
+		);
+	});
+});
+
+describe('useUpdateSMTPSettings', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('updates SMTP settings', async () => {
+		const fetchFn = mockFetch({ host: 'smtp.test' });
+
+		const { result } = renderHook(() => useUpdateSMTPSettings(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ host: 'smtp.test', port: 587 });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/system-settings/smtp',
+			expect.objectContaining({ method: 'PUT' }),
+		);
+	});
+});
+
+describe('useTestSMTP', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('tests SMTP settings', async () => {
+		const fetchFn = mockFetch({ success: true });
+
+		const { result } = renderHook(() => useTestSMTP(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ recipient: 'a@b.com' });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/system-settings/smtp/test',
+			expect.objectContaining({ method: 'POST' }),
+		);
+	});
+});
+
+describe('useOIDCSettings', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches OIDC settings', async () => {
+		const fetchFn = mockFetch({ enabled: false });
+
+		const { result } = renderHook(() => useOIDCSettings(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/system-settings/oidc',
+			expect.any(Object),
+		);
+	});
+});
+
+describe('useUpdateOIDCSettings', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('updates OIDC settings', async () => {
+		const fetchFn = mockFetch({ enabled: true });
+
+		const { result } = renderHook(() => useUpdateOIDCSettings(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ enabled: true });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/system-settings/oidc',
+			expect.objectContaining({ method: 'PUT' }),
+		);
+	});
+});
+
+describe('useTestOIDC', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('tests OIDC settings', async () => {
+		const fetchFn = mockFetch({ success: true });
+
+		const { result } = renderHook(() => useTestOIDC(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate();
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/system-settings/oidc/test',
+			expect.objectContaining({ method: 'POST' }),
+		);
+	});
+});
+
+describe('useStorageDefaultSettings', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches storage defaults', async () => {
+		const fetchFn = mockFetch({ default_backend: 'local' });
+
+		const { result } = renderHook(() => useStorageDefaultSettings(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/system-settings/storage',
+			expect.any(Object),
+		);
+	});
+});
+
+describe('useUpdateStorageDefaultSettings', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('updates storage defaults', async () => {
+		const fetchFn = mockFetch({ default_backend: 's3' });
+
+		const { result } = renderHook(() => useUpdateStorageDefaultSettings(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ default_backend: 's3' });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/system-settings/storage',
+			expect.objectContaining({ method: 'PUT' }),
+		);
+	});
+});
+
+describe('useSecuritySettings', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches security settings', async () => {
+		const fetchFn = mockFetch({ mfa_required: false });
+
+		const { result } = renderHook(() => useSecuritySettings(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/system-settings/security',
+			expect.any(Object),
+		);
+	});
+});
+
+describe('useUpdateSecuritySettings', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('updates security settings', async () => {
+		const fetchFn = mockFetch({ mfa_required: true });
+
+		const { result } = renderHook(() => useUpdateSecuritySettings(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ mfa_required: true });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/system-settings/security',
+			expect.objectContaining({ method: 'PUT' }),
+		);
+	});
+});
+
+describe('useSettingsAuditLog', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches settings audit log with defaults', async () => {
+		const fetchFn = mockFetch({ logs: [] });
+
+		const { result } = renderHook(() => useSettingsAuditLog(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/system-settings/audit-log?limit=50&offset=0',
+			expect.any(Object),
+		);
+	});
+});

--- a/web/src/hooks/useTrial.test.ts
+++ b/web/src/hooks/useTrial.test.ts
@@ -1,0 +1,198 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import {
+	useConvertTrial,
+	useExtendTrial,
+	useProFeatures,
+	useStartTrial,
+	useTrialActivity,
+	useTrialExtensions,
+	useTrialStatus,
+} from './useTrial';
+
+function mockFetch(data: unknown, ok = true, status = 200) {
+	const fn = vi.fn().mockResolvedValue({
+		ok,
+		status,
+		json: () => Promise.resolve(data),
+	} as unknown as Response);
+	vi.stubGlobal('fetch', fn);
+	return fn;
+}
+
+describe('useTrialStatus', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches trial status', async () => {
+		const fetchFn = mockFetch({ active: true });
+
+		const { result } = renderHook(() => useTrialStatus(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true), {
+			timeout: 5000,
+		});
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/trial/status',
+			expect.any(Object),
+		);
+	});
+});
+
+describe('useStartTrial', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('starts a trial', async () => {
+		const fetchFn = mockFetch({ active: true });
+
+		const { result } = renderHook(() => useStartTrial(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ tier: 'pro' });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/trial/start',
+			expect.objectContaining({ method: 'POST' }),
+		);
+	});
+});
+
+describe('useProFeatures', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches pro features', async () => {
+		const fetchFn = mockFetch({ features: [] });
+
+		const { result } = renderHook(() => useProFeatures(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/trial/features',
+			expect.any(Object),
+		);
+	});
+});
+
+describe('useTrialActivity', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches trial activity with defaults', async () => {
+		const fetchFn = mockFetch({ activities: [] });
+
+		const { result } = renderHook(() => useTrialActivity(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/trial/activity?limit=50&offset=0',
+			expect.any(Object),
+		);
+	});
+});
+
+describe('useExtendTrial', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('extends a trial', async () => {
+		const fetchFn = mockFetch({ id: 'ext-1' });
+
+		const { result } = renderHook(() => useExtendTrial(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ days: 7, reason: 'request' });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/trial/extend',
+			expect.objectContaining({ method: 'POST' }),
+		);
+	});
+});
+
+describe('useConvertTrial', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('converts a trial', async () => {
+		const fetchFn = mockFetch({ active: false });
+
+		const { result } = renderHook(() => useConvertTrial(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ license_key: 'KEY-XYZ' });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/trial/convert',
+			expect.objectContaining({ method: 'POST' }),
+		);
+	});
+});
+
+describe('useTrialExtensions', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches trial extensions', async () => {
+		const fetchFn = mockFetch({ extensions: [] });
+
+		const { result } = renderHook(() => useTrialExtensions(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/trial/extensions',
+			expect.any(Object),
+		);
+	});
+});

--- a/web/src/hooks/useUserSessions.test.ts
+++ b/web/src/hooks/useUserSessions.test.ts
@@ -1,0 +1,95 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import {
+	useRevokeAllSessions,
+	useRevokeSession,
+	useUserSessions,
+} from './useUserSessions';
+
+function mockFetch(data: unknown, ok = true, status = 200) {
+	const fn = vi.fn().mockResolvedValue({
+		ok,
+		status,
+		json: () => Promise.resolve(data),
+	} as unknown as Response);
+	vi.stubGlobal('fetch', fn);
+	return fn;
+}
+
+describe('useUserSessions', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches user sessions', async () => {
+		const fetchFn = mockFetch({ sessions: [{ id: 's-1' }] });
+
+		const { result } = renderHook(() => useUserSessions(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual([{ id: 's-1' }]);
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/user-sessions',
+			expect.any(Object),
+		);
+	});
+});
+
+describe('useRevokeSession', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('revokes a session', async () => {
+		const fetchFn = mockFetch({ message: 'ok' });
+
+		const { result } = renderHook(() => useRevokeSession(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate('s-1');
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/user-sessions/s-1',
+			expect.objectContaining({ method: 'DELETE' }),
+		);
+	});
+});
+
+describe('useRevokeAllSessions', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('revokes all sessions', async () => {
+		const fetchFn = mockFetch({ message: 'ok' });
+
+		const { result } = renderHook(() => useRevokeAllSessions(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate();
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/user-sessions',
+			expect.objectContaining({ method: 'DELETE' }),
+		);
+	});
+});

--- a/web/src/hooks/useWebhooks.test.ts
+++ b/web/src/hooks/useWebhooks.test.ts
@@ -1,0 +1,318 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import {
+	useCreateWebhookEndpoint,
+	useDeleteWebhookEndpoint,
+	useRetryWebhookDelivery,
+	useTestWebhookEndpoint,
+	useUpdateWebhookEndpoint,
+	useWebhookDeliveries,
+	useWebhookDelivery,
+	useWebhookEndpoint,
+	useWebhookEndpointDeliveries,
+	useWebhookEndpoints,
+	useWebhookEventTypes,
+} from './useWebhooks';
+
+function mockFetch(data: unknown, ok = true, status = 200) {
+	const fn = vi.fn().mockResolvedValue({
+		ok,
+		status,
+		json: () => Promise.resolve(data),
+	} as unknown as Response);
+	vi.stubGlobal('fetch', fn);
+	return fn;
+}
+
+describe('useWebhookEventTypes', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches webhook event types', async () => {
+		const fetchFn = mockFetch({ event_types: [] });
+
+		const { result } = renderHook(() => useWebhookEventTypes(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/webhooks/event-types',
+			expect.any(Object),
+		);
+	});
+});
+
+describe('useWebhookEndpoints', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches webhook endpoints', async () => {
+		const fetchFn = mockFetch({ endpoints: [{ id: 'wh-1' }] });
+
+		const { result } = renderHook(() => useWebhookEndpoints(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual([{ id: 'wh-1' }]);
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/webhooks/endpoints',
+			expect.any(Object),
+		);
+	});
+});
+
+describe('useWebhookEndpoint', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches a single webhook endpoint', async () => {
+		mockFetch({ id: 'wh-1' });
+
+		const { result } = renderHook(() => useWebhookEndpoint('wh-1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual({ id: 'wh-1' });
+	});
+
+	it('does not fetch when id is empty', () => {
+		const fetchFn = mockFetch({});
+
+		renderHook(() => useWebhookEndpoint(''), { wrapper: createWrapper() });
+
+		expect(fetchFn).not.toHaveBeenCalled();
+	});
+});
+
+describe('useCreateWebhookEndpoint', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('creates a webhook endpoint', async () => {
+		const fetchFn = mockFetch({ id: 'wh-1' });
+
+		const { result } = renderHook(() => useCreateWebhookEndpoint(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({
+			name: 'wh',
+			url: 'https://x.example',
+			event_types: ['backup.completed'],
+			enabled: true,
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/webhooks/endpoints',
+			expect.objectContaining({ method: 'POST' }),
+		);
+	});
+});
+
+describe('useUpdateWebhookEndpoint', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('updates a webhook endpoint', async () => {
+		const fetchFn = mockFetch({ id: 'wh-1' });
+
+		const { result } = renderHook(() => useUpdateWebhookEndpoint(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ id: 'wh-1', data: { enabled: false } });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/webhooks/endpoints/wh-1',
+			expect.objectContaining({ method: 'PUT' }),
+		);
+	});
+});
+
+describe('useDeleteWebhookEndpoint', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('deletes a webhook endpoint', async () => {
+		const fetchFn = mockFetch({ message: 'ok' });
+
+		const { result } = renderHook(() => useDeleteWebhookEndpoint(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate('wh-1');
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/webhooks/endpoints/wh-1',
+			expect.objectContaining({ method: 'DELETE' }),
+		);
+	});
+});
+
+describe('useTestWebhookEndpoint', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('tests a webhook endpoint', async () => {
+		const fetchFn = mockFetch({ success: true });
+
+		const { result } = renderHook(() => useTestWebhookEndpoint(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ id: 'wh-1' });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/webhooks/endpoints/wh-1/test',
+			expect.objectContaining({ method: 'POST' }),
+		);
+	});
+});
+
+describe('useWebhookDeliveries', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches webhook deliveries with defaults', async () => {
+		const fetchFn = mockFetch({ deliveries: [] });
+
+		const { result } = renderHook(() => useWebhookDeliveries(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/webhooks/deliveries?limit=50&offset=0',
+			expect.any(Object),
+		);
+	});
+});
+
+describe('useWebhookEndpointDeliveries', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches deliveries for an endpoint', async () => {
+		const fetchFn = mockFetch({ deliveries: [] });
+
+		const { result } = renderHook(() => useWebhookEndpointDeliveries('wh-1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/webhooks/endpoints/wh-1/deliveries?limit=50&offset=0',
+			expect.any(Object),
+		);
+	});
+
+	it('does not fetch when endpointId is empty', () => {
+		const fetchFn = mockFetch({});
+
+		renderHook(() => useWebhookEndpointDeliveries(''), {
+			wrapper: createWrapper(),
+		});
+
+		expect(fetchFn).not.toHaveBeenCalled();
+	});
+});
+
+describe('useWebhookDelivery', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches a single delivery', async () => {
+		mockFetch({ id: 'd-1' });
+
+		const { result } = renderHook(() => useWebhookDelivery('d-1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual({ id: 'd-1' });
+	});
+});
+
+describe('useRetryWebhookDelivery', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('retries a delivery', async () => {
+		const fetchFn = mockFetch({ message: 'ok' });
+
+		const { result } = renderHook(() => useRetryWebhookDelivery(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate('d-1');
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/webhooks/deliveries/d-1/retry',
+			expect.objectContaining({ method: 'POST' }),
+		);
+	});
+});


### PR DESCRIPTION
## Summary
Continues the test-coverage push from PR #272/#273. Adds 26 new test files:

- **20 React Query hook tests** following the existing `useAirGap.test.ts` pattern (`renderHook` + `createWrapper` + `vi.stubGlobal('fetch', ...)`).
- **6 component tests** for UI primitives (`Skeleton`/sub-variants, `EmptyState`, `ConfirmationModal`, `Breadcrumbs`) and one feature component (`AnnouncementBanner`, `TierBadge`).

## Metrics
- vitest now **1934/1934** across **164** files (was 1720/138 after PR #272)
- biome clean (435 files)
- tsc --noEmit clean

## Test plan
- [x] `npx vitest run` clean
- [x] `npx @biomejs/biome check .` clean
- [x] `npx tsc --noEmit` clean