### PR TITLE
More hook + component test coverage

### DIFF
--- a/web/src/components/ClassificationBadge.test.tsx
+++ b/web/src/components/ClassificationBadge.test.tsx
@@ -1,0 +1,111 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import {
+	ClassificationBadge,
+	ClassificationLevelSelect,
+	DataTypeMultiSelect,
+} from './ClassificationBadge';
+
+describe('ClassificationBadge', () => {
+	it('renders Public label by default', () => {
+		render(<ClassificationBadge />);
+		expect(screen.getByText('Public')).toBeDefined();
+	});
+
+	it('renders Internal label', () => {
+		render(<ClassificationBadge level="internal" />);
+		expect(screen.getByText('Internal')).toBeDefined();
+	});
+
+	it('renders Confidential label', () => {
+		render(<ClassificationBadge level="confidential" />);
+		expect(screen.getByText('Confidential')).toBeDefined();
+	});
+
+	it('renders Restricted label', () => {
+		render(<ClassificationBadge level="restricted" />);
+		expect(screen.getByText('Restricted')).toBeDefined();
+	});
+
+	it('falls back to public colors for unknown level', () => {
+		render(<ClassificationBadge level="bogus" />);
+		expect(screen.getByText('bogus')).toBeDefined();
+	});
+
+	it('shows data type tags when showDataTypes is true', () => {
+		render(
+			<ClassificationBadge
+				level="confidential"
+				dataTypes={['pii', 'phi']}
+				showDataTypes
+			/>,
+		);
+		expect(screen.getByText('PII')).toBeDefined();
+		expect(screen.getByText('PHI')).toBeDefined();
+	});
+
+	it('hides data type tags by default', () => {
+		render(<ClassificationBadge level="restricted" dataTypes={['pii']} />);
+		expect(screen.queryByText('PII')).toBeNull();
+	});
+});
+
+describe('ClassificationLevelSelect', () => {
+	it('renders 4 options', () => {
+		const onChange = vi.fn();
+		render(<ClassificationLevelSelect value="public" onChange={onChange} />);
+		expect(screen.getByRole('option', { name: 'Public' })).toBeDefined();
+		expect(screen.getByRole('option', { name: 'Internal' })).toBeDefined();
+		expect(screen.getByRole('option', { name: 'Confidential' })).toBeDefined();
+		expect(screen.getByRole('option', { name: 'Restricted' })).toBeDefined();
+	});
+
+	it('fires onChange when selection changes', () => {
+		const onChange = vi.fn();
+		render(<ClassificationLevelSelect value="public" onChange={onChange} />);
+		fireEvent.change(screen.getByRole('combobox'), {
+			target: { value: 'restricted' },
+		});
+		expect(onChange).toHaveBeenCalledWith('restricted');
+	});
+
+	it('renders disabled when disabled=true', () => {
+		render(
+			<ClassificationLevelSelect value="public" onChange={() => {}} disabled />,
+		);
+		expect(screen.getByRole('combobox')).toBeDisabled();
+	});
+});
+
+describe('DataTypeMultiSelect', () => {
+	it('renders all data type buttons', () => {
+		render(<DataTypeMultiSelect value={[]} onChange={() => {}} />);
+		expect(screen.getByRole('button', { name: 'PII' })).toBeDefined();
+		expect(screen.getByRole('button', { name: 'PHI' })).toBeDefined();
+		expect(screen.getByRole('button', { name: 'PCI' })).toBeDefined();
+		expect(screen.getByRole('button', { name: 'Proprietary' })).toBeDefined();
+		expect(screen.getByRole('button', { name: 'General' })).toBeDefined();
+	});
+
+	it('toggles a type on click', () => {
+		const onChange = vi.fn();
+		render(<DataTypeMultiSelect value={['general']} onChange={onChange} />);
+		screen.getByRole('button', { name: 'PII' }).click();
+		// adding pii should remove 'general' (per handleToggle logic)
+		expect(onChange).toHaveBeenCalledWith(['pii']);
+	});
+
+	it('removes a type when already selected', () => {
+		const onChange = vi.fn();
+		render(<DataTypeMultiSelect value={['pii', 'phi']} onChange={onChange} />);
+		screen.getByRole('button', { name: 'PII' }).click();
+		expect(onChange).toHaveBeenCalledWith(['phi']);
+	});
+
+	it('falls back to general when last type removed', () => {
+		const onChange = vi.fn();
+		render(<DataTypeMultiSelect value={['pii']} onChange={onChange} />);
+		screen.getByRole('button', { name: 'PII' }).click();
+		expect(onChange).toHaveBeenCalledWith(['general']);
+	});
+});

--- a/web/src/components/StorageTierBadge.test.tsx
+++ b/web/src/components/StorageTierBadge.test.tsx
@@ -1,0 +1,107 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import {
+	ColdRestoreStatusBadge,
+	StorageTierBadge,
+	StorageTierSelect,
+	TierCostIndicator,
+} from './StorageTierBadge';
+
+describe('StorageTierBadge', () => {
+	it('renders Hot label', () => {
+		render(<StorageTierBadge tier="hot" />);
+		expect(screen.getByText('Hot')).toBeDefined();
+	});
+
+	it('renders Warm label', () => {
+		render(<StorageTierBadge tier="warm" />);
+		expect(screen.getByText('Warm')).toBeDefined();
+	});
+
+	it('renders Cold label', () => {
+		render(<StorageTierBadge tier="cold" />);
+		expect(screen.getByText('Cold')).toBeDefined();
+	});
+
+	it('renders Archive label', () => {
+		render(<StorageTierBadge tier="archive" />);
+		expect(screen.getByText('Archive')).toBeDefined();
+	});
+
+	it('shows age when showAge=true', () => {
+		render(<StorageTierBadge tier="cold" ageDays={42} showAge />);
+		expect(screen.getByText('(42d)')).toBeDefined();
+	});
+
+	it('hides age by default', () => {
+		render(<StorageTierBadge tier="cold" ageDays={42} />);
+		expect(screen.queryByText('(42d)')).toBeNull();
+	});
+});
+
+describe('StorageTierSelect', () => {
+	it('renders 4 tier options by default', () => {
+		render(<StorageTierSelect value="hot" onChange={() => {}} />);
+		expect(screen.getAllByRole('option')).toHaveLength(4);
+	});
+
+	it('excludes specified tiers', () => {
+		render(
+			<StorageTierSelect
+				value="hot"
+				onChange={() => {}}
+				excludeTiers={['archive']}
+			/>,
+		);
+		expect(screen.getAllByRole('option')).toHaveLength(3);
+		expect(screen.queryByRole('option', { name: 'Archive' })).toBeNull();
+	});
+
+	it('fires onChange when selection changes', () => {
+		const onChange = vi.fn();
+		render(<StorageTierSelect value="hot" onChange={onChange} />);
+		fireEvent.change(screen.getByRole('combobox'), {
+			target: { value: 'archive' },
+		});
+		expect(onChange).toHaveBeenCalledWith('archive');
+	});
+});
+
+describe('TierCostIndicator', () => {
+	it('renders tier badge + cost', () => {
+		render(<TierCostIndicator tier="hot" monthlyCost={4.5} />);
+		expect(screen.getByText('Hot')).toBeDefined();
+		expect(screen.getByText('$4.50/mo')).toBeDefined();
+	});
+
+	it('renders <$0.01 when cost very small', () => {
+		render(<TierCostIndicator tier="archive" monthlyCost={0.001} />);
+		expect(screen.getByText('<$0.01/mo')).toBeDefined();
+	});
+});
+
+describe('ColdRestoreStatusBadge', () => {
+	it('renders Pending status', () => {
+		render(<ColdRestoreStatusBadge status="pending" />);
+		expect(screen.getByText('Pending')).toBeDefined();
+	});
+
+	it('renders Warming status with animated dot', () => {
+		const { container } = render(<ColdRestoreStatusBadge status="warming" />);
+		expect(screen.getByText('Warming')).toBeDefined();
+		expect(container.querySelector('.animate-pulse')).not.toBeNull();
+	});
+
+	it('renders ETA when warming with estimatedReadyAt', () => {
+		const future = new Date(Date.now() + 30 * 60_000).toISOString();
+		render(
+			<ColdRestoreStatusBadge status="warming" estimatedReadyAt={future} />,
+		);
+		expect(screen.getByText(/30m|29m|31m/)).toBeDefined();
+	});
+
+	it('falls back to Pending for unknown status', () => {
+		render(<ColdRestoreStatusBadge status="bogus" />);
+		expect(screen.getByText('Pending')).toBeDefined();
+	});
+});

--- a/web/src/components/features/SnapshotImmutabilityBadge.test.tsx
+++ b/web/src/components/features/SnapshotImmutabilityBadge.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../hooks/useImmutability', () => ({
+	useSnapshotImmutabilityStatus: vi.fn(),
+}));
+
+import { useSnapshotImmutabilityStatus } from '../../hooks/useImmutability';
+import {
+	ImmutabilityDeleteWarning,
+	LockIcon,
+	SnapshotImmutabilityBadge,
+} from './SnapshotImmutabilityBadge';
+
+function setStatus(status: unknown, isLoading = false) {
+	vi.mocked(useSnapshotImmutabilityStatus).mockReturnValue({
+		data: status,
+		isLoading,
+	} as never);
+}
+
+describe('SnapshotImmutabilityBadge', () => {
+	it('renders nothing while loading', () => {
+		setStatus(undefined, true);
+		const { container } = render(
+			<SnapshotImmutabilityBadge snapshotId="snap" repositoryId="repo" />,
+		);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders nothing when not locked', () => {
+		setStatus({ is_locked: false });
+		const { container } = render(
+			<SnapshotImmutabilityBadge snapshotId="snap" repositoryId="repo" />,
+		);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders badge when locked', () => {
+		setStatus({
+			is_locked: true,
+			locked_until: '2026-12-31T00:00:00Z',
+			remaining_days: 45,
+		});
+		const { container } = render(
+			<SnapshotImmutabilityBadge snapshotId="snap" repositoryId="repo" />,
+		);
+		expect(container.querySelector('span.bg-amber-100')).not.toBeNull();
+	});
+
+	it('shows days when showDetails=true', () => {
+		setStatus({ is_locked: true, remaining_days: 12 });
+		render(
+			<SnapshotImmutabilityBadge
+				snapshotId="snap"
+				repositoryId="repo"
+				showDetails
+			/>,
+		);
+		expect(screen.getByText('12d')).toBeDefined();
+	});
+});
+
+describe('LockIcon', () => {
+	it('renders nothing when isLocked=false', () => {
+		const { container } = render(<LockIcon isLocked={false} />);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders SVG when locked', () => {
+		const { container } = render(<LockIcon isLocked />);
+		expect(container.querySelector('svg')).not.toBeNull();
+	});
+
+	it('applies size class', () => {
+		const { container } = render(<LockIcon isLocked size="lg" />);
+		expect(container.querySelector('.w-5')).not.toBeNull();
+	});
+});
+
+describe('ImmutabilityDeleteWarning', () => {
+	it('renders nothing when isLocked=false', () => {
+		const { container } = render(
+			<ImmutabilityDeleteWarning isLocked={false} />,
+		);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders warning copy when locked', () => {
+		render(<ImmutabilityDeleteWarning isLocked />);
+		expect(screen.getByText('Snapshot is immutable')).toBeDefined();
+	});
+
+	it('includes remaining days when provided', () => {
+		render(<ImmutabilityDeleteWarning isLocked remainingDays={7} />);
+		expect(screen.getByText(/7 days remaining/)).toBeDefined();
+	});
+});

--- a/web/src/hooks/useAnnouncements.test.ts
+++ b/web/src/hooks/useAnnouncements.test.ts
@@ -1,0 +1,133 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import {
+	useActiveAnnouncements,
+	useAnnouncement,
+	useAnnouncements,
+	useCreateAnnouncement,
+	useDeleteAnnouncement,
+	useDismissAnnouncement,
+	useUpdateAnnouncement,
+} from './useAnnouncements';
+
+function mockFetch(data: unknown, ok = true, status = 200) {
+	const fn = vi.fn().mockResolvedValue({
+		ok,
+		status,
+		json: () => Promise.resolve(data),
+	} as unknown as Response);
+	vi.stubGlobal('fetch', fn);
+	return fn;
+}
+
+beforeEach(() => {
+	vi.restoreAllMocks();
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe('useAnnouncements', () => {
+	it('fetches announcements list', async () => {
+		mockFetch({ announcements: [{ id: 'a1', title: 'Hello' }] });
+
+		const { result } = renderHook(() => useAnnouncements(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual([{ id: 'a1', title: 'Hello' }]);
+	});
+});
+
+describe('useAnnouncement', () => {
+	it('fetches single announcement', async () => {
+		mockFetch({ id: 'a1', title: 'Hello' });
+
+		const { result } = renderHook(() => useAnnouncement('a1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual({ id: 'a1', title: 'Hello' });
+	});
+
+	it('does not fetch when id is empty', () => {
+		const fetchFn = mockFetch({});
+
+		renderHook(() => useAnnouncement(''), { wrapper: createWrapper() });
+
+		expect(fetchFn).not.toHaveBeenCalled();
+	});
+});
+
+describe('useActiveAnnouncements', () => {
+	it('fetches active announcements', async () => {
+		mockFetch({ announcements: [] });
+
+		const { result } = renderHook(() => useActiveAnnouncements(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual([]);
+	});
+});
+
+describe('useCreateAnnouncement', () => {
+	it('creates announcement', async () => {
+		mockFetch({ id: 'a1', title: 'New' });
+
+		const { result } = renderHook(() => useCreateAnnouncement(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ title: 'New' } as never);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useUpdateAnnouncement', () => {
+	it('updates announcement', async () => {
+		mockFetch({ id: 'a1', title: 'Updated' });
+
+		const { result } = renderHook(() => useUpdateAnnouncement(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ id: 'a1', data: { title: 'Updated' } as never });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useDeleteAnnouncement', () => {
+	it('deletes announcement', async () => {
+		mockFetch({ message: 'deleted' });
+
+		const { result } = renderHook(() => useDeleteAnnouncement(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate('a1');
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useDismissAnnouncement', () => {
+	it('dismisses announcement', async () => {
+		mockFetch({ message: 'dismissed' });
+
+		const { result } = renderHook(() => useDismissAnnouncement(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate('a1');
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});

--- a/web/src/hooks/useBreadcrumbs.test.ts
+++ b/web/src/hooks/useBreadcrumbs.test.ts
@@ -1,0 +1,110 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react';
+import { type ReactNode, createElement } from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useBreadcrumbs, useBreadcrumbsWithName } from './useBreadcrumbs';
+
+function mockFetch(data: unknown, ok = true, status = 200) {
+	const fn = vi.fn().mockResolvedValue({
+		ok,
+		status,
+		json: () => Promise.resolve(data),
+	} as unknown as Response);
+	vi.stubGlobal('fetch', fn);
+	return fn;
+}
+
+function makeWrapper(initialPath: string, routePattern: string) {
+	const queryClient = new QueryClient({
+		defaultOptions: {
+			queries: { retry: false, gcTime: 0 },
+			mutations: { retry: false },
+		},
+	});
+
+	return function Wrapper({ children }: { children: ReactNode }) {
+		return createElement(
+			QueryClientProvider,
+			{ client: queryClient },
+			createElement(
+				MemoryRouter,
+				{ initialEntries: [initialPath] },
+				createElement(
+					Routes,
+					null,
+					createElement(Route, { path: routePattern, element: children }),
+				),
+			),
+		);
+	};
+}
+
+describe('useBreadcrumbs', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('returns Dashboard breadcrumb for root path', () => {
+		mockFetch({});
+		const { result } = renderHook(() => useBreadcrumbs(), {
+			wrapper: makeWrapper('/', '/'),
+		});
+
+		expect(result.current.breadcrumbs).toHaveLength(1);
+		expect(result.current.breadcrumbs[0]).toEqual({
+			label: 'Dashboard',
+			path: '/',
+			isCurrentPage: true,
+		});
+		expect(result.current.isLoading).toBe(false);
+	});
+
+	it('builds breadcrumb trail for nested static routes', () => {
+		mockFetch({});
+		const { result } = renderHook(() => useBreadcrumbs(), {
+			wrapper: makeWrapper('/agents', '/agents'),
+		});
+
+		expect(result.current.breadcrumbs).toHaveLength(2);
+		expect(result.current.breadcrumbs[0].label).toBe('Dashboard');
+		expect(result.current.breadcrumbs[1].label).toBe('Agents');
+		expect(result.current.breadcrumbs[1].isCurrentPage).toBe(true);
+	});
+});
+
+describe('useBreadcrumbsWithName', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('returns Dashboard breadcrumb for root path', () => {
+		const { result } = renderHook(() => useBreadcrumbsWithName(), {
+			wrapper: makeWrapper('/', '/'),
+		});
+
+		expect(result.current.breadcrumbs).toHaveLength(1);
+		expect(result.current.breadcrumbs[0].label).toBe('Dashboard');
+		expect(result.current.isLoading).toBe(false);
+	});
+
+	it('uses provided name when last segment is a UUID', () => {
+		const uuid = '12345678-1234-1234-1234-123456789abc';
+		const { result } = renderHook(() => useBreadcrumbsWithName('My Agent'), {
+			wrapper: makeWrapper(`/agents/${uuid}`, '/agents/:id'),
+		});
+
+		const last =
+			result.current.breadcrumbs[result.current.breadcrumbs.length - 1];
+		expect(last.label).toBe('My Agent');
+		expect(last.isCurrentPage).toBe(true);
+	});
+});

--- a/web/src/hooks/useBulkSelect.test.ts
+++ b/web/src/hooks/useBulkSelect.test.ts
@@ -1,0 +1,52 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useBulkSelect } from './useBulkSelect';
+
+describe('useBulkSelect', () => {
+	it('initialises with empty selection', () => {
+		const { result } = renderHook(() => useBulkSelect<string>(['a', 'b', 'c']));
+
+		expect(result.current.selectedCount).toBe(0);
+		expect(result.current.isAllSelected).toBe(false);
+		expect(result.current.isPartiallySelected).toBe(false);
+		expect(result.current.selectedIds.size).toBe(0);
+	});
+
+	it('toggles selection of individual ids', () => {
+		const { result } = renderHook(() => useBulkSelect<string>(['a', 'b', 'c']));
+
+		act(() => {
+			result.current.toggle('a');
+		});
+
+		expect(result.current.selectedCount).toBe(1);
+		expect(result.current.isSelected('a')).toBe(true);
+		expect(result.current.isPartiallySelected).toBe(true);
+
+		act(() => {
+			result.current.toggle('a');
+		});
+
+		expect(result.current.selectedCount).toBe(0);
+		expect(result.current.isSelected('a')).toBe(false);
+	});
+
+	it('selects and deselects all ids', () => {
+		const { result } = renderHook(() => useBulkSelect<string>(['a', 'b', 'c']));
+
+		act(() => {
+			result.current.selectAll(['a', 'b', 'c']);
+		});
+
+		expect(result.current.selectedCount).toBe(3);
+		expect(result.current.isAllSelected).toBe(true);
+		expect(result.current.isPartiallySelected).toBe(false);
+
+		act(() => {
+			result.current.deselectAll();
+		});
+
+		expect(result.current.selectedCount).toBe(0);
+		expect(result.current.isAllSelected).toBe(false);
+	});
+});

--- a/web/src/hooks/useKeyboardShortcuts.test.ts
+++ b/web/src/hooks/useKeyboardShortcuts.test.ts
@@ -1,0 +1,69 @@
+import { renderHook } from '@testing-library/react';
+import { type ReactNode, createElement } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+	formatShortcutKeys,
+	getShortcutHint,
+	useKeyboardShortcuts,
+} from './useKeyboardShortcuts';
+
+function makeWrapper(initialPath = '/') {
+	return function Wrapper({ children }: { children: ReactNode }) {
+		return createElement(
+			MemoryRouter,
+			{ initialEntries: [initialPath] },
+			children,
+		);
+	};
+}
+
+describe('useKeyboardShortcuts', () => {
+	beforeEach(() => {
+		localStorage.clear();
+	});
+
+	afterEach(() => {
+		localStorage.clear();
+	});
+
+	it('returns default shortcuts and helpers', () => {
+		const { result } = renderHook(() => useKeyboardShortcuts(), {
+			wrapper: makeWrapper(),
+		});
+
+		expect(Array.isArray(result.current.shortcuts)).toBe(true);
+		expect(result.current.shortcuts.length).toBeGreaterThan(0);
+		expect(result.current.defaultShortcuts.length).toBe(
+			result.current.shortcuts.length,
+		);
+		expect(typeof result.current.updateCustomShortcut).toBe('function');
+		expect(typeof result.current.resetShortcut).toBe('function');
+		expect(typeof result.current.resetAllShortcuts).toBe('function');
+		expect(typeof result.current.executeAction).toBe('function');
+	});
+
+	it('respects disabled option without throwing', () => {
+		expect(() =>
+			renderHook(() => useKeyboardShortcuts({ enabled: false }), {
+				wrapper: makeWrapper(),
+			}),
+		).not.toThrow();
+	});
+});
+
+describe('formatShortcutKeys', () => {
+	it('joins keys with "then" and uppercases letters', () => {
+		expect(formatShortcutKeys(['g', 'a'])).toBe('G then A');
+	});
+
+	it('formats Escape as Esc', () => {
+		expect(formatShortcutKeys(['Escape'])).toBe('Esc');
+	});
+});
+
+describe('getShortcutHint', () => {
+	it('joins keys with + and uppercases letters', () => {
+		expect(getShortcutHint(['g', 'a'])).toBe('G+A');
+	});
+});

--- a/web/src/hooks/useLegalHolds.test.ts
+++ b/web/src/hooks/useLegalHolds.test.ts
@@ -1,0 +1,139 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import {
+	useCreateLegalHold,
+	useDeleteLegalHold,
+	useLegalHold,
+	useLegalHolds,
+} from './useLegalHolds';
+
+function mockFetch(data: unknown, ok = true, status = 200) {
+	const fn = vi.fn().mockResolvedValue({
+		ok,
+		status,
+		json: () => Promise.resolve(data),
+	} as unknown as Response);
+	vi.stubGlobal('fetch', fn);
+	return fn;
+}
+
+describe('useLegalHolds', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches legal holds', async () => {
+		const fetchFn = mockFetch({
+			legal_holds: [{ id: 'h1', snapshot_id: 's1', reason: 'audit' }],
+		});
+
+		const { result } = renderHook(() => useLegalHolds(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual([
+			{ id: 'h1', snapshot_id: 's1', reason: 'audit' },
+		]);
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/legal-holds',
+			expect.objectContaining({ credentials: 'include' }),
+		);
+	});
+});
+
+describe('useLegalHold', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches a single legal hold for a snapshot', async () => {
+		const mockHold = { id: 'h1', snapshot_id: 'snap-1', reason: 'legal' };
+		const fetchFn = mockFetch(mockHold);
+
+		const { result } = renderHook(() => useLegalHold('snap-1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual(mockHold);
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/snapshots/snap-1/hold',
+			expect.objectContaining({ credentials: 'include' }),
+		);
+	});
+
+	it('does not fetch when snapshotId is empty', () => {
+		const fetchFn = mockFetch({});
+
+		renderHook(() => useLegalHold(''), {
+			wrapper: createWrapper(),
+		});
+
+		expect(fetchFn).not.toHaveBeenCalled();
+	});
+});
+
+describe('useCreateLegalHold', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('creates a legal hold', async () => {
+		const fetchFn = mockFetch({ id: 'h1', snapshot_id: 'snap-1' });
+
+		const { result } = renderHook(() => useCreateLegalHold(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({
+			snapshotId: 'snap-1',
+			data: { reason: 'investigation' },
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/snapshots/snap-1/hold',
+			expect.objectContaining({ method: 'POST' }),
+		);
+	});
+});
+
+describe('useDeleteLegalHold', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('deletes a legal hold', async () => {
+		const fetchFn = mockFetch({ message: 'deleted' });
+
+		const { result } = renderHook(() => useDeleteLegalHold(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate('snap-1');
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/snapshots/snap-1/hold',
+			expect.objectContaining({ method: 'DELETE' }),
+		);
+	});
+});

--- a/web/src/hooks/useLicenses.test.ts
+++ b/web/src/hooks/useLicenses.test.ts
@@ -1,0 +1,288 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import {
+	useActivateLicense,
+	useAdminLicense,
+	useAdminLicenses,
+	useAdminRevokeLicense,
+	useAdminUpdateLicense,
+	useCurrentLicense,
+	useLicenseHistory,
+	useLicensePurchaseUrl,
+	useLicenseWarnings,
+	useValidateLicense,
+} from './useLicenses';
+
+function mockFetch(data: unknown, ok = true, status = 200) {
+	const fn = vi.fn().mockResolvedValue({
+		ok,
+		status,
+		json: () => Promise.resolve(data),
+	} as unknown as Response);
+	vi.stubGlobal('fetch', fn);
+	return fn;
+}
+
+describe('useCurrentLicense', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches the current license info', async () => {
+		const mockInfo = { tier: 'enterprise', valid: true };
+		const fetchFn = mockFetch(mockInfo);
+
+		const { result } = renderHook(() => useCurrentLicense(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual(mockInfo);
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/license',
+			expect.objectContaining({ credentials: 'include' }),
+		);
+	});
+});
+
+describe('useLicenseWarnings', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches license warnings', async () => {
+		const mockWarnings = { warnings: { limits: [{ name: 'agents' }] } };
+		mockFetch(mockWarnings);
+
+		const { result } = renderHook(() => useLicenseWarnings(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual(mockWarnings);
+	});
+
+	it('returns default warnings shape on error', async () => {
+		mockFetch({ error: 'fail' }, false, 500);
+
+		const { result } = renderHook(() => useLicenseWarnings(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual({ warnings: { limits: [] } });
+	});
+});
+
+describe('useLicenseHistory', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches license history', async () => {
+		const fetchFn = mockFetch({ history: [] });
+
+		const { result } = renderHook(() => useLicenseHistory(25, 0), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/licenses/history?limit=25&offset=0',
+			expect.objectContaining({ credentials: 'include' }),
+		);
+	});
+});
+
+describe('useValidateLicense', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('validates a license key', async () => {
+		const fetchFn = mockFetch({ valid: true });
+
+		const { result } = renderHook(() => useValidateLicense(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate('abc-123');
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/licenses/validate',
+			expect.objectContaining({ method: 'POST' }),
+		);
+	});
+});
+
+describe('useActivateLicense', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('activates a license', async () => {
+		const fetchFn = mockFetch({ license: { id: 'lic-1' } });
+
+		const { result } = renderHook(() => useActivateLicense(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ license_key: 'abc-123' });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/licenses/activate',
+			expect.objectContaining({ method: 'POST' }),
+		);
+	});
+});
+
+describe('useLicensePurchaseUrl', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches the purchase URL', async () => {
+		mockFetch({ url: 'https://buy.example.com' });
+
+		const { result } = renderHook(() => useLicensePurchaseUrl(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual({ url: 'https://buy.example.com' });
+	});
+
+	it('returns empty url on error', async () => {
+		mockFetch({ error: 'fail' }, false, 500);
+
+		const { result } = renderHook(() => useLicensePurchaseUrl(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual({ url: '' });
+	});
+});
+
+describe('useAdminLicenses', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches admin licenses list', async () => {
+		const fetchFn = mockFetch({ licenses: [] });
+
+		const { result } = renderHook(() => useAdminLicenses(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/admin/licenses',
+			expect.objectContaining({ credentials: 'include' }),
+		);
+	});
+});
+
+describe('useAdminLicense', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('does not fetch when id is empty', () => {
+		const fetchFn = mockFetch({});
+
+		renderHook(() => useAdminLicense(''), {
+			wrapper: createWrapper(),
+		});
+
+		expect(fetchFn).not.toHaveBeenCalled();
+	});
+});
+
+describe('useAdminUpdateLicense', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('updates an admin license', async () => {
+		const fetchFn = mockFetch({ license: { id: 'lic-1' } });
+
+		const { result } = renderHook(() => useAdminUpdateLicense(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ id: 'lic-1', data: { status: 'active' } });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/admin/licenses/lic-1',
+			expect.objectContaining({ method: 'PUT' }),
+		);
+	});
+});
+
+describe('useAdminRevokeLicense', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('revokes an admin license', async () => {
+		const fetchFn = mockFetch({ message: 'revoked' });
+
+		const { result } = renderHook(() => useAdminRevokeLicense(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate('lic-1');
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/admin/licenses/lic-1',
+			expect.objectContaining({ method: 'DELETE' }),
+		);
+	});
+});

--- a/web/src/hooks/useLifecyclePolicies.test.ts
+++ b/web/src/hooks/useLifecyclePolicies.test.ts
@@ -1,0 +1,272 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import {
+	useCreateLifecyclePolicy,
+	useDeleteLifecyclePolicy,
+	useLifecycleDeletions,
+	useLifecycleDryRun,
+	useLifecyclePolicies,
+	useLifecyclePolicy,
+	useLifecyclePreview,
+	useOrgLifecycleDeletions,
+	useUpdateLifecyclePolicy,
+} from './useLifecyclePolicies';
+
+function mockFetch(data: unknown, ok = true, status = 200) {
+	const fn = vi.fn().mockResolvedValue({
+		ok,
+		status,
+		json: () => Promise.resolve(data),
+	} as unknown as Response);
+	vi.stubGlobal('fetch', fn);
+	return fn;
+}
+
+describe('useLifecyclePolicies', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches lifecycle policies', async () => {
+		const fetchFn = mockFetch({ policies: [{ id: 'lp-1', name: 'daily' }] });
+
+		const { result } = renderHook(() => useLifecyclePolicies(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual([{ id: 'lp-1', name: 'daily' }]);
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/lifecycle-policies',
+			expect.objectContaining({ credentials: 'include' }),
+		);
+	});
+});
+
+describe('useLifecyclePolicy', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches a single lifecycle policy', async () => {
+		const mockPolicy = { id: 'lp-1', name: 'monthly' };
+		mockFetch(mockPolicy);
+
+		const { result } = renderHook(() => useLifecyclePolicy('lp-1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual(mockPolicy);
+	});
+
+	it('does not fetch when id is empty', () => {
+		const fetchFn = mockFetch({});
+
+		renderHook(() => useLifecyclePolicy(''), {
+			wrapper: createWrapper(),
+		});
+
+		expect(fetchFn).not.toHaveBeenCalled();
+	});
+});
+
+describe('useCreateLifecyclePolicy', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('creates a lifecycle policy', async () => {
+		const fetchFn = mockFetch({ id: 'lp-new' });
+
+		const { result } = renderHook(() => useCreateLifecyclePolicy(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ name: 'weekly' });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/lifecycle-policies',
+			expect.objectContaining({ method: 'POST' }),
+		);
+	});
+});
+
+describe('useUpdateLifecyclePolicy', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('updates a lifecycle policy', async () => {
+		const fetchFn = mockFetch({ id: 'lp-1' });
+
+		const { result } = renderHook(() => useUpdateLifecyclePolicy(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ id: 'lp-1', data: { name: 'renamed' } });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/lifecycle-policies/lp-1',
+			expect.objectContaining({ method: 'PUT' }),
+		);
+	});
+});
+
+describe('useDeleteLifecyclePolicy', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('deletes a lifecycle policy', async () => {
+		const fetchFn = mockFetch({ message: 'deleted' });
+
+		const { result } = renderHook(() => useDeleteLifecyclePolicy(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate('lp-1');
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/lifecycle-policies/lp-1',
+			expect.objectContaining({ method: 'DELETE' }),
+		);
+	});
+});
+
+describe('useLifecycleDryRun', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('runs dry-run for a policy', async () => {
+		const fetchFn = mockFetch({ deletions: [] });
+
+		const { result } = renderHook(() => useLifecycleDryRun(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate('lp-1');
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/lifecycle-policies/lp-1/dry-run',
+			expect.objectContaining({ method: 'POST' }),
+		);
+	});
+});
+
+describe('useLifecyclePreview', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('previews a lifecycle policy', async () => {
+		const fetchFn = mockFetch({ deletions: [] });
+
+		const { result } = renderHook(() => useLifecyclePreview(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({
+			retention_days: 30,
+		} as Parameters<typeof result.current.mutate>[0]);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/lifecycle-policies/preview',
+			expect.objectContaining({ method: 'POST' }),
+		);
+	});
+});
+
+describe('useLifecycleDeletions', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches deletions for a policy', async () => {
+		const fetchFn = mockFetch({ events: [{ id: 'e1' }] });
+
+		const { result } = renderHook(() => useLifecycleDeletions('lp-1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual([{ id: 'e1' }]);
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/lifecycle-policies/lp-1/deletions',
+			expect.objectContaining({ credentials: 'include' }),
+		);
+	});
+
+	it('does not fetch when policyId is empty', () => {
+		const fetchFn = mockFetch({});
+
+		renderHook(() => useLifecycleDeletions(''), {
+			wrapper: createWrapper(),
+		});
+
+		expect(fetchFn).not.toHaveBeenCalled();
+	});
+});
+
+describe('useOrgLifecycleDeletions', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches org-wide deletions', async () => {
+		const fetchFn = mockFetch({ events: [] });
+
+		const { result } = renderHook(() => useOrgLifecycleDeletions(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/lifecycle-policies/deletions',
+			expect.objectContaining({ credentials: 'include' }),
+		);
+	});
+});

--- a/web/src/hooks/useMetadata.test.ts
+++ b/web/src/hooks/useMetadata.test.ts
@@ -1,0 +1,343 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import {
+	useCreateMetadataSchema,
+	useDeleteMetadataSchema,
+	useMetadataEntityTypes,
+	useMetadataFieldTypes,
+	useMetadataSchema,
+	useMetadataSchemas,
+	useMetadataSearch,
+	useUpdateAgentMetadata,
+	useUpdateMetadataSchema,
+	useUpdateRepositoryMetadata,
+	useUpdateScheduleMetadata,
+} from './useMetadata';
+
+function mockFetch(data: unknown, ok = true, status = 200) {
+	const fn = vi.fn().mockResolvedValue({
+		ok,
+		status,
+		json: () => Promise.resolve(data),
+	} as unknown as Response);
+	vi.stubGlobal('fetch', fn);
+	return fn;
+}
+
+describe('useMetadataSchemas', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches schemas for an entity type', async () => {
+		const fetchFn = mockFetch({
+			schemas: [{ id: 's1', entity_type: 'agent' }],
+		});
+
+		const { result } = renderHook(() => useMetadataSchemas('agent'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/metadata/schemas?entity_type=agent',
+			expect.objectContaining({ credentials: 'include' }),
+		);
+	});
+});
+
+describe('useMetadataSchema', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches a single schema', async () => {
+		mockFetch({ id: 's1', entity_type: 'agent' });
+
+		const { result } = renderHook(() => useMetadataSchema('s1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual({ id: 's1', entity_type: 'agent' });
+	});
+
+	it('does not fetch when id is empty', () => {
+		const fetchFn = mockFetch({});
+
+		renderHook(() => useMetadataSchema(''), { wrapper: createWrapper() });
+
+		expect(fetchFn).not.toHaveBeenCalled();
+	});
+});
+
+describe('useMetadataFieldTypes', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches field types', async () => {
+		const fetchFn = mockFetch({ field_types: [] });
+
+		const { result } = renderHook(() => useMetadataFieldTypes(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/metadata/schemas/types',
+			expect.objectContaining({ credentials: 'include' }),
+		);
+	});
+});
+
+describe('useMetadataEntityTypes', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches entity types', async () => {
+		const fetchFn = mockFetch({ entity_types: [] });
+
+		const { result } = renderHook(() => useMetadataEntityTypes(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/metadata/schemas/entities',
+			expect.objectContaining({ credentials: 'include' }),
+		);
+	});
+});
+
+describe('useCreateMetadataSchema', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('creates a schema', async () => {
+		const fetchFn = mockFetch({ id: 's2', entity_type: 'agent' });
+
+		const { result } = renderHook(() => useCreateMetadataSchema(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({
+			entity_type: 'agent',
+			name: 'new',
+		} as Parameters<typeof result.current.mutate>[0]);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/metadata/schemas',
+			expect.objectContaining({ method: 'POST' }),
+		);
+	});
+});
+
+describe('useUpdateMetadataSchema', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('updates a schema', async () => {
+		const fetchFn = mockFetch({ id: 's1', entity_type: 'agent' });
+
+		const { result } = renderHook(() => useUpdateMetadataSchema(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({
+			id: 's1',
+			data: { name: 'updated' } as Parameters<
+				typeof result.current.mutate
+			>[0]['data'],
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/metadata/schemas/s1',
+			expect.objectContaining({ method: 'PUT' }),
+		);
+	});
+});
+
+describe('useDeleteMetadataSchema', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('deletes a schema', async () => {
+		const fetchFn = mockFetch({ message: 'deleted' });
+
+		const { result } = renderHook(() => useDeleteMetadataSchema(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ id: 's1', entityType: 'agent' });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/metadata/schemas/s1',
+			expect.objectContaining({ method: 'DELETE' }),
+		);
+	});
+});
+
+describe('useUpdateAgentMetadata', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('updates agent metadata', async () => {
+		const fetchFn = mockFetch({ message: 'ok' });
+
+		const { result } = renderHook(() => useUpdateAgentMetadata(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({
+			agentId: 'a1',
+			data: { metadata: {} } as Parameters<
+				typeof result.current.mutate
+			>[0]['data'],
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/agents/a1/metadata',
+			expect.objectContaining({ method: 'PUT' }),
+		);
+	});
+});
+
+describe('useUpdateRepositoryMetadata', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('updates repository metadata', async () => {
+		const fetchFn = mockFetch({ message: 'ok' });
+
+		const { result } = renderHook(() => useUpdateRepositoryMetadata(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({
+			repositoryId: 'r1',
+			data: { metadata: {} } as Parameters<
+				typeof result.current.mutate
+			>[0]['data'],
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/repositories/r1/metadata',
+			expect.objectContaining({ method: 'PUT' }),
+		);
+	});
+});
+
+describe('useUpdateScheduleMetadata', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('updates schedule metadata', async () => {
+		const fetchFn = mockFetch({ message: 'ok' });
+
+		const { result } = renderHook(() => useUpdateScheduleMetadata(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({
+			scheduleId: 'sc1',
+			data: { metadata: {} } as Parameters<
+				typeof result.current.mutate
+			>[0]['data'],
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/schedules/sc1/metadata',
+			expect.objectContaining({ method: 'PUT' }),
+		);
+	});
+});
+
+describe('useMetadataSearch', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('searches metadata', async () => {
+		const fetchFn = mockFetch({ results: [] });
+
+		const { result } = renderHook(
+			() => useMetadataSearch('agent', 'env', 'prod'),
+			{ wrapper: createWrapper() },
+		);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/metadata/search?entity_type=agent&key=env&value=prod',
+			expect.objectContaining({ credentials: 'include' }),
+		);
+	});
+
+	it('does not fetch when disabled', () => {
+		const fetchFn = mockFetch({});
+
+		renderHook(() => useMetadataSearch('agent', '', ''), {
+			wrapper: createWrapper(),
+		});
+
+		expect(fetchFn).not.toHaveBeenCalled();
+	});
+});

--- a/web/src/hooks/useMigration.test.ts
+++ b/web/src/hooks/useMigration.test.ts
@@ -1,0 +1,162 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import {
+	downloadMigrationExport,
+	readFileAsText,
+	useGenerateExportKey,
+	useMigrationExport,
+	useMigrationImport,
+	useValidateMigrationImport,
+} from './useMigration';
+
+function mockFetch(data: unknown, ok = true, status = 200) {
+	const fn = vi.fn().mockResolvedValue({
+		ok,
+		status,
+		json: () => Promise.resolve(data),
+		blob: () => Promise.resolve(new Blob([JSON.stringify(data)])),
+	} as unknown as Response);
+	vi.stubGlobal('fetch', fn);
+	return fn;
+}
+
+describe('useGenerateExportKey', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('generates an export key', async () => {
+		const fetchFn = mockFetch({ key: 'gen-key' });
+
+		const { result } = renderHook(() => useGenerateExportKey(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate();
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/migration/export/generate-key',
+			expect.objectContaining({ method: 'POST' }),
+		);
+	});
+});
+
+describe('useMigrationExport', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('exports migration data as a blob', async () => {
+		const fetchFn = mockFetch({});
+
+		const { result } = renderHook(() => useMigrationExport(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ include_secrets: false });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/migration/export',
+			expect.objectContaining({ method: 'POST' }),
+		);
+		expect(result.current.data).toBeInstanceOf(Blob);
+	});
+});
+
+describe('useValidateMigrationImport', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('validates migration import data', async () => {
+		const fetchFn = mockFetch({ valid: true, encrypted: false });
+
+		const { result } = renderHook(() => useValidateMigrationImport(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ data: '{}' });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/migration/import/validate',
+			expect.objectContaining({ method: 'POST' }),
+		);
+	});
+});
+
+describe('useMigrationImport', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('runs migration import', async () => {
+		const fetchFn = mockFetch({
+			success: true,
+			dry_run: false,
+			imported: {},
+			skipped: {},
+		});
+
+		const { result } = renderHook(() => useMigrationImport(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ data: '{}' });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/migration/import',
+			expect.objectContaining({ method: 'POST' }),
+		);
+	});
+});
+
+describe('downloadMigrationExport', () => {
+	it('triggers a download for a blob', () => {
+		const createObjectURL = vi.fn(() => 'blob:url');
+		const revokeObjectURL = vi.fn();
+		vi.stubGlobal('URL', {
+			...URL,
+			createObjectURL,
+			revokeObjectURL,
+		});
+		const blob = new Blob(['data']);
+
+		downloadMigrationExport(blob, false);
+
+		expect(createObjectURL).toHaveBeenCalledWith(blob);
+		expect(revokeObjectURL).toHaveBeenCalledWith('blob:url');
+
+		vi.unstubAllGlobals();
+	});
+});
+
+describe('readFileAsText', () => {
+	it('reads a file as text', async () => {
+		const file = new File(['hello world'], 'test.txt', {
+			type: 'text/plain',
+		});
+		const text = await readFileAsText(file);
+		expect(text).toBe('hello world');
+	});
+});

--- a/web/src/hooks/useNotificationRules.test.ts
+++ b/web/src/hooks/useNotificationRules.test.ts
@@ -1,0 +1,246 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import {
+	useCreateNotificationRule,
+	useDeleteNotificationRule,
+	useNotificationRule,
+	useNotificationRuleEvents,
+	useNotificationRuleExecutions,
+	useNotificationRules,
+	useTestNotificationRule,
+	useUpdateNotificationRule,
+} from './useNotificationRules';
+
+function mockFetch(data: unknown, ok = true, status = 200) {
+	const fn = vi.fn().mockResolvedValue({
+		ok,
+		status,
+		json: () => Promise.resolve(data),
+	} as unknown as Response);
+	vi.stubGlobal('fetch', fn);
+	return fn;
+}
+
+describe('useNotificationRules', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches notification rules', async () => {
+		const fetchFn = mockFetch({ rules: [{ id: 'r1', name: 'rule-1' }] });
+
+		const { result } = renderHook(() => useNotificationRules(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual([{ id: 'r1', name: 'rule-1' }]);
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/notification-rules',
+			expect.objectContaining({ credentials: 'include' }),
+		);
+	});
+});
+
+describe('useNotificationRule', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches a single rule', async () => {
+		mockFetch({ id: 'r1' });
+
+		const { result } = renderHook(() => useNotificationRule('r1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual({ id: 'r1' });
+	});
+
+	it('does not fetch when id is empty', () => {
+		const fetchFn = mockFetch({});
+
+		renderHook(() => useNotificationRule(''), { wrapper: createWrapper() });
+
+		expect(fetchFn).not.toHaveBeenCalled();
+	});
+});
+
+describe('useCreateNotificationRule', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('creates a rule', async () => {
+		const fetchFn = mockFetch({ id: 'r2' });
+
+		const { result } = renderHook(() => useCreateNotificationRule(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({
+			name: 'new',
+		} as Parameters<typeof result.current.mutate>[0]);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/notification-rules',
+			expect.objectContaining({ method: 'POST' }),
+		);
+	});
+});
+
+describe('useUpdateNotificationRule', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('updates a rule', async () => {
+		const fetchFn = mockFetch({ id: 'r1' });
+
+		const { result } = renderHook(() => useUpdateNotificationRule(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({
+			id: 'r1',
+			data: { name: 'renamed' } as Parameters<
+				typeof result.current.mutate
+			>[0]['data'],
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/notification-rules/r1',
+			expect.objectContaining({ method: 'PUT' }),
+		);
+	});
+});
+
+describe('useDeleteNotificationRule', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('deletes a rule', async () => {
+		const fetchFn = mockFetch({ message: 'deleted' });
+
+		const { result } = renderHook(() => useDeleteNotificationRule(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate('r1');
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/notification-rules/r1',
+			expect.objectContaining({ method: 'DELETE' }),
+		);
+	});
+});
+
+describe('useTestNotificationRule', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('tests a rule', async () => {
+		const fetchFn = mockFetch({ success: true });
+
+		const { result } = renderHook(() => useTestNotificationRule(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ id: 'r1' });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/notification-rules/r1/test',
+			expect.objectContaining({ method: 'POST' }),
+		);
+	});
+});
+
+describe('useNotificationRuleEvents', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches events for a rule', async () => {
+		const fetchFn = mockFetch({ events: [] });
+
+		const { result } = renderHook(() => useNotificationRuleEvents('r1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/notification-rules/r1/events',
+			expect.objectContaining({ credentials: 'include' }),
+		);
+	});
+
+	it('does not fetch when ruleId is empty', () => {
+		const fetchFn = mockFetch({});
+
+		renderHook(() => useNotificationRuleEvents(''), {
+			wrapper: createWrapper(),
+		});
+
+		expect(fetchFn).not.toHaveBeenCalled();
+	});
+});
+
+describe('useNotificationRuleExecutions', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches executions for a rule', async () => {
+		const fetchFn = mockFetch({ executions: [] });
+
+		const { result } = renderHook(() => useNotificationRuleExecutions('r1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(fetchFn).toHaveBeenCalledWith(
+			'/api/v1/notification-rules/r1/executions',
+			expect.objectContaining({ credentials: 'include' }),
+		);
+	});
+});

--- a/web/src/hooks/useReadOnlyMode.test.ts
+++ b/web/src/hooks/useReadOnlyMode.test.ts
@@ -1,0 +1,47 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('./useMaintenance', () => ({
+	useActiveMaintenance: vi.fn(),
+}));
+
+import { useActiveMaintenance } from './useMaintenance';
+import { useReadOnlyMode, useReadOnlyModeValue } from './useReadOnlyMode';
+
+describe('useReadOnlyMode', () => {
+	it('returns default not-readonly when no provider', () => {
+		const { result } = renderHook(() => useReadOnlyMode());
+		expect(result.current.isReadOnly).toBe(false);
+	});
+});
+
+describe('useReadOnlyModeValue', () => {
+	it('returns isReadOnly=false when no active maintenance', () => {
+		vi.mocked(useActiveMaintenance).mockReturnValue({
+			data: undefined,
+		} as never);
+		const { result } = renderHook(() => useReadOnlyModeValue());
+		expect(result.current.isReadOnly).toBe(false);
+	});
+
+	it('reflects read_only_mode flag from active maintenance', () => {
+		vi.mocked(useActiveMaintenance).mockReturnValue({
+			data: {
+				read_only_mode: true,
+				active: { title: 'Maintenance', message: 'Coming back soon' },
+			},
+		} as never);
+		const { result } = renderHook(() => useReadOnlyModeValue());
+		expect(result.current.isReadOnly).toBe(true);
+		expect(result.current.maintenanceTitle).toBe('Maintenance');
+		expect(result.current.maintenanceMessage).toBe('Coming back soon');
+	});
+
+	it('returns undefined message when maintenance message is null', () => {
+		vi.mocked(useActiveMaintenance).mockReturnValue({
+			data: { read_only_mode: false, active: { title: 'x', message: null } },
+		} as never);
+		const { result } = renderHook(() => useReadOnlyModeValue());
+		expect(result.current.maintenanceMessage).toBeUndefined();
+	});
+});

--- a/web/src/hooks/useToast.test.ts
+++ b/web/src/hooks/useToast.test.ts
@@ -1,0 +1,85 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useToastValue } from './useToast';
+
+describe('useToastValue', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('starts with empty toasts array', () => {
+		const { result } = renderHook(() => useToastValue());
+		expect(result.current.toasts).toEqual([]);
+	});
+
+	it('addToast appends a toast and returns id', () => {
+		const { result } = renderHook(() => useToastValue());
+		let id = '';
+		act(() => {
+			id = result.current.addToast('Hello', 'info', 0);
+		});
+		expect(result.current.toasts).toHaveLength(1);
+		expect(result.current.toasts[0].id).toBe(id);
+		expect(result.current.toasts[0].message).toBe('Hello');
+	});
+
+	it('removeToast removes by id', () => {
+		const { result } = renderHook(() => useToastValue());
+		let id = '';
+		act(() => {
+			id = result.current.addToast('To remove', 'info', 0);
+		});
+		act(() => {
+			result.current.removeToast(id);
+		});
+		expect(result.current.toasts).toEqual([]);
+	});
+
+	it('auto-removes after duration', () => {
+		const { result } = renderHook(() => useToastValue());
+		act(() => {
+			result.current.addToast('Bye', 'info', 1000);
+		});
+		expect(result.current.toasts).toHaveLength(1);
+		act(() => {
+			vi.advanceTimersByTime(1100);
+		});
+		expect(result.current.toasts).toEqual([]);
+	});
+
+	it('success creates info variant=success toast', () => {
+		const { result } = renderHook(() => useToastValue());
+		act(() => {
+			result.current.success('Saved!', 0);
+		});
+		expect(result.current.toasts[0].variant).toBe('success');
+	});
+
+	it('error creates variant=error toast', () => {
+		const { result } = renderHook(() => useToastValue());
+		act(() => {
+			result.current.error('Boom', 0);
+		});
+		expect(result.current.toasts[0].variant).toBe('error');
+	});
+
+	it('warning creates variant=warning toast', () => {
+		const { result } = renderHook(() => useToastValue());
+		act(() => {
+			result.current.warning('Heads up', 0);
+		});
+		expect(result.current.toasts[0].variant).toBe('warning');
+	});
+
+	it('info creates variant=info toast', () => {
+		const { result } = renderHook(() => useToastValue());
+		act(() => {
+			result.current.info('FYI', 0);
+		});
+		expect(result.current.toasts[0].variant).toBe('info');
+	});
+});

--- a/web/src/hooks/useVersion.test.ts
+++ b/web/src/hooks/useVersion.test.ts
@@ -1,0 +1,40 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import { useVersion } from './useVersion';
+
+function mockFetch(data: unknown, ok = true, status = 200) {
+	const fn = vi.fn().mockResolvedValue({
+		ok,
+		status,
+		json: () => Promise.resolve(data),
+	} as unknown as Response);
+	vi.stubGlobal('fetch', fn);
+	return fn;
+}
+
+describe('useVersion', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fetches server version', async () => {
+		mockFetch({
+			version: '1.2.3',
+			commit: 'abc123',
+			build_date: '2026-05-26T00:00:00Z',
+		});
+
+		const { result } = renderHook(() => useVersion(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data?.version).toBe('1.2.3');
+		expect(result.current.data?.commit).toBe('abc123');
+	});
+});


### PR DESCRIPTION
## Summary
Continues the test-coverage push. Adds 16 new test files:

- **13 hook tests**: useAnnouncements, useBreadcrumbs, useBulkSelect, useKeyboardShortcuts, useLegalHolds, useLicenses, useLifecyclePolicies, useMetadata, useMigration, useNotificationRules, useToast, useReadOnlyMode, useVersion.
- **3 component tests**: ClassificationBadge, StorageTierBadge, SnapshotImmutabilityBadge (all cover their sub-variants too).

## Metrics
- vitest now **180** files passing (was 164 after PR #274)
- biome + tsc clean

## Test plan
- [x] `npx vitest run` clean
- [x] `npx @biomejs/biome check .` clean
- [x] `npx tsc --noEmit` clean