### PR TITLE
Cover last 17 hooks + 3 more components

### DIFF
--- a/web/src/components/features/AirGapIndicator.test.tsx
+++ b/web/src/components/features/AirGapIndicator.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../hooks/useAirGap', () => ({
+	useAirGap: vi.fn(),
+	useLicenseStatus: vi.fn(),
+}));
+
+import { useAirGap, useLicenseStatus } from '../../hooks/useAirGap';
+import {
+	AirGapIndicator,
+	AirGapStatusCard,
+	ExternalLink,
+} from './AirGapIndicator';
+
+function setAirGap(value: Record<string, unknown>) {
+	vi.mocked(useAirGap).mockReturnValue(value as never);
+}
+
+function setLicense(value: unknown, isLoading = false) {
+	vi.mocked(useLicenseStatus).mockReturnValue({
+		data: value,
+		isLoading,
+	} as never);
+}
+
+function withRouter(ui: React.ReactNode) {
+	return <MemoryRouter>{ui}</MemoryRouter>;
+}
+
+describe('AirGapIndicator', () => {
+	it('renders nothing while loading', () => {
+		setAirGap({ isAirGapMode: true, licenseValid: true, isLoading: true });
+		const { container } = render(withRouter(<AirGapIndicator />));
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders nothing when not air-gapped', () => {
+		setAirGap({ isAirGapMode: false, licenseValid: true, isLoading: false });
+		const { container } = render(withRouter(<AirGapIndicator />));
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders Air-Gapped badge when in air-gap mode', () => {
+		setAirGap({ isAirGapMode: true, licenseValid: true, isLoading: false });
+		render(withRouter(<AirGapIndicator />));
+		expect(screen.getByText('Air-Gapped')).toBeDefined();
+	});
+
+	it('shows Check License chip when invalid + showDetails', () => {
+		setAirGap({ isAirGapMode: true, licenseValid: false, isLoading: false });
+		render(withRouter(<AirGapIndicator showDetails />));
+		expect(screen.getByText('Check License')).toBeDefined();
+	});
+});
+
+describe('AirGapStatusCard', () => {
+	it('shows loading skeleton', () => {
+		setAirGap({ isAirGapMode: true, isLoading: true });
+		setLicense(undefined, true);
+		const { container } = render(withRouter(<AirGapStatusCard />));
+		expect(container.querySelector('.animate-pulse')).not.toBeNull();
+	});
+
+	it('renders Connected Mode when not air-gapped', () => {
+		setAirGap({ isAirGapMode: false, isLoading: false });
+		setLicense({}, false);
+		render(withRouter(<AirGapStatusCard />));
+		expect(screen.getByText('Connected Mode')).toBeDefined();
+	});
+
+	it('renders Air-Gapped Mode card with license valid badge', () => {
+		setAirGap({
+			isAirGapMode: true,
+			disableExternalLinks: true,
+			offlineDocsVersion: '1.0',
+			isLoading: false,
+		});
+		setLicense({ valid: true, type: 'enterprise' }, false);
+		render(withRouter(<AirGapStatusCard />));
+		expect(screen.getByText('Air-Gapped Mode')).toBeDefined();
+		expect(screen.getByText('Valid')).toBeDefined();
+		expect(screen.getByText('Blocked')).toBeDefined();
+	});
+});
+
+describe('ExternalLink', () => {
+	it('renders anchor with target=_blank when not blocked', () => {
+		setAirGap({ shouldBlockExternalLink: () => false });
+		render(<ExternalLink href="https://example.com">External</ExternalLink>);
+		const a = screen.getByText('External').closest('a');
+		expect(a?.getAttribute('target')).toBe('_blank');
+		expect(a?.getAttribute('rel')).toBe('noopener noreferrer');
+	});
+
+	it('renders inert span when blocked', () => {
+		setAirGap({ shouldBlockExternalLink: () => true });
+		render(<ExternalLink href="https://example.com">External</ExternalLink>);
+		expect(screen.getByText('External').tagName).toBe('SPAN');
+	});
+});

--- a/web/src/components/features/TrialBanner.test.tsx
+++ b/web/src/components/features/TrialBanner.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../hooks/useTrial', () => ({
+	useTrialStatus: vi.fn(),
+	useStartTrial: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+	useTranslation: () => ({
+		t: (
+			_key: string,
+			defaultValue: string,
+			vars?: Record<string, string | number>,
+		) => {
+			if (!vars) return defaultValue;
+			return defaultValue.replace(/\{\{(\w+)\}\}/g, (_m, k) =>
+				String(vars[k] ?? ''),
+			);
+		},
+	}),
+}));
+
+import { useStartTrial, useTrialStatus } from '../../hooks/useTrial';
+import { TrialBanner } from './TrialBanner';
+
+function setTrial(data: unknown, isLoading = false, isError = false) {
+	vi.mocked(useTrialStatus).mockReturnValue({
+		data,
+		isLoading,
+		isError,
+	} as never);
+	vi.mocked(useStartTrial).mockReturnValue({
+		mutate: vi.fn(),
+		isPending: false,
+		isError: false,
+	} as never);
+}
+
+describe('TrialBanner', () => {
+	it('renders nothing while loading', () => {
+		setTrial(undefined, true);
+		const { container } = render(<TrialBanner />);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders nothing on error', () => {
+		setTrial(undefined, false, true);
+		const { container } = render(<TrialBanner />);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders nothing when no trial info', () => {
+		setTrial(undefined);
+		const { container } = render(<TrialBanner />);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders nothing when already on paid plan', () => {
+		setTrial({ plan_tier: 'pro', trial_status: 'none' });
+		const { container } = render(<TrialBanner />);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders nothing when trial is converted', () => {
+		setTrial({ plan_tier: 'free', trial_status: 'converted' });
+		const { container } = render(<TrialBanner />);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders expired trial banner', () => {
+		setTrial({ plan_tier: 'free', trial_status: 'expired' });
+		render(<TrialBanner />);
+		expect(screen.getByText('Pro Trial Expired')).toBeDefined();
+	});
+
+	it('renders active trial banner with days remaining', () => {
+		setTrial({
+			plan_tier: 'free',
+			trial_status: 'active',
+			is_trial_active: true,
+			days_remaining: 21,
+		});
+		render(<TrialBanner />);
+		expect(screen.getByText('Pro trial: 21 days remaining')).toBeDefined();
+	});
+
+	it('renders start trial prompt when trial_status=none', () => {
+		setTrial({
+			plan_tier: 'free',
+			trial_status: 'none',
+			is_trial_active: false,
+		});
+		render(<TrialBanner />);
+		expect(screen.getByText('Try Pro features free for 30 days')).toBeDefined();
+	});
+});

--- a/web/src/hooks/useBackupCalendar.test.ts
+++ b/web/src/hooks/useBackupCalendar.test.ts
@@ -1,0 +1,46 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import { useBackupCalendar } from './useBackupCalendar';
+
+vi.mock('../lib/api', () => ({
+	backupsApi: {
+		getCalendar: vi.fn(),
+	},
+}));
+
+import { backupsApi } from '../lib/api';
+
+describe('useBackupCalendar', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches calendar data for given month', async () => {
+		const mockData = { days: [], month: '2025-01' };
+		vi.mocked(backupsApi.getCalendar).mockResolvedValue(mockData);
+
+		const { result } = renderHook(
+			() => useBackupCalendar({ month: '2025-01' }),
+			{ wrapper: createWrapper() },
+		);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual(mockData);
+		expect(backupsApi.getCalendar).toHaveBeenCalledWith('2025-01');
+	});
+
+	it('handles error state', async () => {
+		vi.mocked(backupsApi.getCalendar).mockRejectedValue(
+			new Error('Network error'),
+		);
+
+		const { result } = renderHook(
+			() => useBackupCalendar({ month: '2025-01' }),
+			{ wrapper: createWrapper() },
+		);
+
+		await waitFor(() => expect(result.current.isError).toBe(true));
+		expect(result.current.error).toBeDefined();
+	});
+});

--- a/web/src/hooks/useBackupHookTemplates.test.ts
+++ b/web/src/hooks/useBackupHookTemplates.test.ts
@@ -1,0 +1,186 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import {
+	useApplyBackupHookTemplate,
+	useBackupHookTemplate,
+	useBackupHookTemplates,
+	useBuiltInBackupHookTemplates,
+	useCreateBackupHookTemplate,
+	useDeleteBackupHookTemplate,
+	useUpdateBackupHookTemplate,
+} from './useBackupHookTemplates';
+
+vi.mock('../lib/api', () => ({
+	backupHookTemplatesApi: {
+		list: vi.fn(),
+		listBuiltIn: vi.fn(),
+		get: vi.fn(),
+		create: vi.fn(),
+		update: vi.fn(),
+		delete: vi.fn(),
+		apply: vi.fn(),
+	},
+}));
+
+import { backupHookTemplatesApi } from '../lib/api';
+
+describe('useBackupHookTemplates', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches templates list', async () => {
+		const mockTemplates = [{ id: 't-1', name: 'Postgres' }];
+		vi.mocked(backupHookTemplatesApi.list).mockResolvedValue(mockTemplates);
+
+		const { result } = renderHook(() => useBackupHookTemplates(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual(mockTemplates);
+		expect(backupHookTemplatesApi.list).toHaveBeenCalledWith(undefined);
+	});
+
+	it('passes filter params', async () => {
+		vi.mocked(backupHookTemplatesApi.list).mockResolvedValue([]);
+
+		renderHook(() => useBackupHookTemplates({ service_type: 'postgres' }), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => {
+			expect(backupHookTemplatesApi.list).toHaveBeenCalledWith({
+				service_type: 'postgres',
+			});
+		});
+	});
+});
+
+describe('useBuiltInBackupHookTemplates', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches built-in templates', async () => {
+		vi.mocked(backupHookTemplatesApi.listBuiltIn).mockResolvedValue([]);
+
+		const { result } = renderHook(() => useBuiltInBackupHookTemplates(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(backupHookTemplatesApi.listBuiltIn).toHaveBeenCalledOnce();
+	});
+});
+
+describe('useBackupHookTemplate', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches a single template', async () => {
+		vi.mocked(backupHookTemplatesApi.get).mockResolvedValue({ id: 't-1' });
+
+		const { result } = renderHook(() => useBackupHookTemplate('t-1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(backupHookTemplatesApi.get).toHaveBeenCalledWith('t-1');
+	});
+
+	it('does not fetch when id is empty', () => {
+		renderHook(() => useBackupHookTemplate(''), {
+			wrapper: createWrapper(),
+		});
+
+		expect(backupHookTemplatesApi.get).not.toHaveBeenCalled();
+	});
+});
+
+describe('useCreateBackupHookTemplate', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('creates a template', async () => {
+		vi.mocked(backupHookTemplatesApi.create).mockResolvedValue({ id: 'new' });
+
+		const { result } = renderHook(() => useCreateBackupHookTemplate(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ name: 'new' } as never);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(backupHookTemplatesApi.create).toHaveBeenCalled();
+	});
+});
+
+describe('useUpdateBackupHookTemplate', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('updates a template', async () => {
+		vi.mocked(backupHookTemplatesApi.update).mockResolvedValue({ id: 't-1' });
+
+		const { result } = renderHook(() => useUpdateBackupHookTemplate(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ id: 't-1', data: { name: 'renamed' } as never });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(backupHookTemplatesApi.update).toHaveBeenCalledWith('t-1', {
+			name: 'renamed',
+		});
+	});
+});
+
+describe('useDeleteBackupHookTemplate', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('deletes a template', async () => {
+		vi.mocked(backupHookTemplatesApi.delete).mockResolvedValue({
+			message: 'Deleted',
+		});
+
+		const { result } = renderHook(() => useDeleteBackupHookTemplate(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate('t-1');
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(backupHookTemplatesApi.delete).toHaveBeenCalledWith('t-1');
+	});
+});
+
+describe('useApplyBackupHookTemplate', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('applies a template', async () => {
+		vi.mocked(backupHookTemplatesApi.apply).mockResolvedValue({ ok: true });
+
+		const { result } = renderHook(() => useApplyBackupHookTemplate(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({
+			templateId: 't-1',
+			data: { schedule_id: 's-1' } as never,
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(backupHookTemplatesApi.apply).toHaveBeenCalledWith('t-1', {
+			schedule_id: 's-1',
+		});
+	});
+});

--- a/web/src/hooks/useBackupQueue.test.ts
+++ b/web/src/hooks/useBackupQueue.test.ts
@@ -1,0 +1,167 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import {
+	useAgentConcurrency,
+	useBackupQueue,
+	useBackupQueueSummary,
+	useCancelQueuedBackup,
+	useOrgConcurrency,
+	useUpdateAgentConcurrency,
+	useUpdateOrgConcurrency,
+} from './useBackupQueue';
+
+vi.mock('../lib/api', () => ({
+	backupQueueApi: {
+		list: vi.fn(),
+		getSummary: vi.fn(),
+		cancel: vi.fn(),
+	},
+	concurrencyApi: {
+		getOrgConcurrency: vi.fn(),
+		updateOrgConcurrency: vi.fn(),
+		getAgentConcurrency: vi.fn(),
+		updateAgentConcurrency: vi.fn(),
+	},
+}));
+
+import { backupQueueApi, concurrencyApi } from '../lib/api';
+
+describe('useBackupQueue', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches the queue', async () => {
+		vi.mocked(backupQueueApi.list).mockResolvedValue([]);
+
+		const { result } = renderHook(() => useBackupQueue(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(backupQueueApi.list).toHaveBeenCalledOnce();
+	});
+});
+
+describe('useBackupQueueSummary', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches summary', async () => {
+		vi.mocked(backupQueueApi.getSummary).mockResolvedValue({ queued: 0 });
+
+		const { result } = renderHook(() => useBackupQueueSummary(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(backupQueueApi.getSummary).toHaveBeenCalledOnce();
+	});
+});
+
+describe('useCancelQueuedBackup', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('cancels a queued backup', async () => {
+		vi.mocked(backupQueueApi.cancel).mockResolvedValue({ message: 'Canceled' });
+
+		const { result } = renderHook(() => useCancelQueuedBackup(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate('q-1');
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(backupQueueApi.cancel).toHaveBeenCalledWith('q-1');
+	});
+});
+
+describe('useOrgConcurrency', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches org concurrency', async () => {
+		vi.mocked(concurrencyApi.getOrgConcurrency).mockResolvedValue({ max: 5 });
+
+		const { result } = renderHook(() => useOrgConcurrency('org-1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(concurrencyApi.getOrgConcurrency).toHaveBeenCalledWith('org-1');
+	});
+
+	it('does not fetch when orgId is empty', () => {
+		renderHook(() => useOrgConcurrency(''), { wrapper: createWrapper() });
+		expect(concurrencyApi.getOrgConcurrency).not.toHaveBeenCalled();
+	});
+});
+
+describe('useUpdateOrgConcurrency', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('updates org concurrency', async () => {
+		vi.mocked(concurrencyApi.updateOrgConcurrency).mockResolvedValue({
+			max: 10,
+		});
+
+		const { result } = renderHook(() => useUpdateOrgConcurrency(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ orgId: 'org-1', data: { max: 10 } as never });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(concurrencyApi.updateOrgConcurrency).toHaveBeenCalledWith('org-1', {
+			max: 10,
+		});
+	});
+});
+
+describe('useAgentConcurrency', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches agent concurrency', async () => {
+		vi.mocked(concurrencyApi.getAgentConcurrency).mockResolvedValue({ max: 3 });
+
+		const { result } = renderHook(() => useAgentConcurrency('agent-1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(concurrencyApi.getAgentConcurrency).toHaveBeenCalledWith('agent-1');
+	});
+});
+
+describe('useUpdateAgentConcurrency', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('updates agent concurrency', async () => {
+		vi.mocked(concurrencyApi.updateAgentConcurrency).mockResolvedValue({
+			max: 4,
+		});
+
+		const { result } = renderHook(() => useUpdateAgentConcurrency(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ agentId: 'agent-1', data: { max: 4 } as never });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(concurrencyApi.updateAgentConcurrency).toHaveBeenCalledWith(
+			'agent-1',
+			{ max: 4 },
+		);
+	});
+});

--- a/web/src/hooks/useChangelog.test.ts
+++ b/web/src/hooks/useChangelog.test.ts
@@ -1,0 +1,119 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import {
+	useChangelog,
+	useChangelogEntry,
+	useLatestChanges,
+	useNewVersionAvailable,
+} from './useChangelog';
+
+vi.mock('../lib/api', () => ({
+	changelogApi: {
+		list: vi.fn(),
+		get: vi.fn(),
+	},
+}));
+
+import { changelogApi } from '../lib/api';
+
+const mockChangelog = {
+	current_version: '1.0.0',
+	entries: [
+		{ version: '1.1.0', is_unreleased: false, changes: ['change'] },
+		{ version: '1.0.0', is_unreleased: false, changes: ['initial'] },
+	],
+};
+
+describe('useChangelog', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches changelog', async () => {
+		vi.mocked(changelogApi.list).mockResolvedValue(mockChangelog);
+
+		const { result } = renderHook(() => useChangelog(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual(mockChangelog);
+	});
+});
+
+describe('useChangelogEntry', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches a single entry', async () => {
+		vi.mocked(changelogApi.get).mockResolvedValue({
+			version: '1.0.0',
+			changes: [],
+		});
+
+		const { result } = renderHook(() => useChangelogEntry('1.0.0'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(changelogApi.get).toHaveBeenCalledWith('1.0.0');
+	});
+
+	it('does not fetch when version is empty', () => {
+		renderHook(() => useChangelogEntry(''), { wrapper: createWrapper() });
+		expect(changelogApi.get).not.toHaveBeenCalled();
+	});
+});
+
+describe('useNewVersionAvailable', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('reports new version when latest differs from current', async () => {
+		vi.mocked(changelogApi.list).mockResolvedValue(mockChangelog);
+
+		const { result } = renderHook(() => useNewVersionAvailable(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => {
+			expect(result.current.hasNewVersion).toBe(true);
+		});
+		expect(result.current.latestVersion).toBe('1.1.0');
+	});
+
+	it('returns no new version when data is missing', () => {
+		vi.mocked(changelogApi.list).mockResolvedValue(
+			undefined as unknown as typeof mockChangelog,
+		);
+
+		const { result } = renderHook(() => useNewVersionAvailable(), {
+			wrapper: createWrapper(),
+		});
+
+		expect(result.current.hasNewVersion).toBe(false);
+		expect(result.current.latestVersion).toBeNull();
+	});
+});
+
+describe('useLatestChanges', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('returns the latest non-unreleased entry', async () => {
+		vi.mocked(changelogApi.list).mockResolvedValue(mockChangelog);
+
+		const { result } = renderHook(() => useLatestChanges(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => {
+			expect(result.current.latestEntry).toBeTruthy();
+		});
+		expect(result.current.latestEntry?.version).toBe('1.1.0');
+	});
+});

--- a/web/src/hooks/useClassifications.test.ts
+++ b/web/src/hooks/useClassifications.test.ts
@@ -1,0 +1,347 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import {
+	useAutoClassifySchedule,
+	useBackupsByClassification,
+	useClassificationDataTypes,
+	useClassificationLevels,
+	useClassificationRule,
+	useClassificationRules,
+	useClassificationSummary,
+	useComplianceReport,
+	useCreateClassificationRule,
+	useDefaultClassificationRules,
+	useDeleteClassificationRule,
+	useScheduleClassification,
+	useScheduleClassifications,
+	useSetScheduleClassification,
+	useUpdateClassificationRule,
+} from './useClassifications';
+
+vi.mock('../lib/api', () => ({
+	classificationsApi: {
+		getLevels: vi.fn(),
+		getDataTypes: vi.fn(),
+		getDefaultRules: vi.fn(),
+		listRules: vi.fn(),
+		getRule: vi.fn(),
+		createRule: vi.fn(),
+		updateRule: vi.fn(),
+		deleteRule: vi.fn(),
+		listScheduleClassifications: vi.fn(),
+		getScheduleClassification: vi.fn(),
+		setScheduleClassification: vi.fn(),
+		autoClassifySchedule: vi.fn(),
+		listBackupsByClassification: vi.fn(),
+		getSummary: vi.fn(),
+		getComplianceReport: vi.fn(),
+	},
+}));
+
+import { classificationsApi } from '../lib/api';
+
+describe('useClassificationLevels', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches levels', async () => {
+		vi.mocked(classificationsApi.getLevels).mockResolvedValue([]);
+
+		const { result } = renderHook(() => useClassificationLevels(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(classificationsApi.getLevels).toHaveBeenCalledOnce();
+	});
+});
+
+describe('useClassificationDataTypes', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches data types', async () => {
+		vi.mocked(classificationsApi.getDataTypes).mockResolvedValue([]);
+
+		const { result } = renderHook(() => useClassificationDataTypes(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(classificationsApi.getDataTypes).toHaveBeenCalledOnce();
+	});
+});
+
+describe('useDefaultClassificationRules', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches default rules', async () => {
+		vi.mocked(classificationsApi.getDefaultRules).mockResolvedValue([]);
+
+		const { result } = renderHook(() => useDefaultClassificationRules(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(classificationsApi.getDefaultRules).toHaveBeenCalledOnce();
+	});
+});
+
+describe('useClassificationRules', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches rules', async () => {
+		vi.mocked(classificationsApi.listRules).mockResolvedValue([]);
+
+		const { result } = renderHook(() => useClassificationRules(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(classificationsApi.listRules).toHaveBeenCalledOnce();
+	});
+});
+
+describe('useClassificationRule', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches a rule', async () => {
+		vi.mocked(classificationsApi.getRule).mockResolvedValue({ id: 'r-1' });
+
+		const { result } = renderHook(() => useClassificationRule('r-1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(classificationsApi.getRule).toHaveBeenCalledWith('r-1');
+	});
+
+	it('does not fetch when id is empty', () => {
+		renderHook(() => useClassificationRule(''), { wrapper: createWrapper() });
+		expect(classificationsApi.getRule).not.toHaveBeenCalled();
+	});
+});
+
+describe('useCreateClassificationRule', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('creates a rule', async () => {
+		vi.mocked(classificationsApi.createRule).mockResolvedValue({ id: 'new' });
+
+		const { result } = renderHook(() => useCreateClassificationRule(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ path: '/data' } as never);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(classificationsApi.createRule).toHaveBeenCalled();
+	});
+});
+
+describe('useUpdateClassificationRule', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('updates a rule', async () => {
+		vi.mocked(classificationsApi.updateRule).mockResolvedValue({ id: 'r-1' });
+
+		const { result } = renderHook(() => useUpdateClassificationRule(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ id: 'r-1', data: { path: '/x' } as never });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(classificationsApi.updateRule).toHaveBeenCalledWith('r-1', {
+			path: '/x',
+		});
+	});
+});
+
+describe('useDeleteClassificationRule', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('deletes a rule', async () => {
+		vi.mocked(classificationsApi.deleteRule).mockResolvedValue({
+			message: 'Deleted',
+		});
+
+		const { result } = renderHook(() => useDeleteClassificationRule(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate('r-1');
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(classificationsApi.deleteRule).toHaveBeenCalledWith('r-1');
+	});
+});
+
+describe('useScheduleClassifications', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches schedule classifications', async () => {
+		vi.mocked(classificationsApi.listScheduleClassifications).mockResolvedValue(
+			[],
+		);
+
+		const { result } = renderHook(() => useScheduleClassifications(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(classificationsApi.listScheduleClassifications).toHaveBeenCalledWith(
+			undefined,
+		);
+	});
+});
+
+describe('useScheduleClassification', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches one schedule classification', async () => {
+		vi.mocked(classificationsApi.getScheduleClassification).mockResolvedValue({
+			id: 's-1',
+		});
+
+		const { result } = renderHook(() => useScheduleClassification('s-1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(classificationsApi.getScheduleClassification).toHaveBeenCalledWith(
+			's-1',
+		);
+	});
+});
+
+describe('useSetScheduleClassification', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('sets schedule classification', async () => {
+		vi.mocked(classificationsApi.setScheduleClassification).mockResolvedValue({
+			ok: true,
+		});
+
+		const { result } = renderHook(() => useSetScheduleClassification(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({
+			scheduleId: 's-1',
+			data: { level: 'high' } as never,
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(classificationsApi.setScheduleClassification).toHaveBeenCalledWith(
+			's-1',
+			{ level: 'high' },
+		);
+	});
+});
+
+describe('useAutoClassifySchedule', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('auto-classifies a schedule', async () => {
+		vi.mocked(classificationsApi.autoClassifySchedule).mockResolvedValue({
+			ok: true,
+		});
+
+		const { result } = renderHook(() => useAutoClassifySchedule(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate('s-1');
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(classificationsApi.autoClassifySchedule).toHaveBeenCalledWith('s-1');
+	});
+});
+
+describe('useBackupsByClassification', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches backups by level', async () => {
+		vi.mocked(classificationsApi.listBackupsByClassification).mockResolvedValue(
+			[],
+		);
+
+		const { result } = renderHook(() => useBackupsByClassification('high'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(classificationsApi.listBackupsByClassification).toHaveBeenCalledWith(
+			'high',
+		);
+	});
+
+	it('does not fetch when level is empty', () => {
+		renderHook(() => useBackupsByClassification(''), {
+			wrapper: createWrapper(),
+		});
+		expect(
+			classificationsApi.listBackupsByClassification,
+		).not.toHaveBeenCalled();
+	});
+});
+
+describe('useClassificationSummary', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches summary', async () => {
+		vi.mocked(classificationsApi.getSummary).mockResolvedValue({});
+
+		const { result } = renderHook(() => useClassificationSummary(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(classificationsApi.getSummary).toHaveBeenCalledOnce();
+	});
+});
+
+describe('useComplianceReport', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches compliance report', async () => {
+		vi.mocked(classificationsApi.getComplianceReport).mockResolvedValue({});
+
+		const { result } = renderHook(() => useComplianceReport(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(classificationsApi.getComplianceReport).toHaveBeenCalledOnce();
+	});
+});

--- a/web/src/hooks/useConfigExport.test.ts
+++ b/web/src/hooks/useConfigExport.test.ts
@@ -1,0 +1,280 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import {
+	useCreateTemplate,
+	useDeleteTemplate,
+	useExportAgent,
+	useExportBundle,
+	useExportRepository,
+	useExportSchedule,
+	useImportConfig,
+	useTemplate,
+	useTemplates,
+	useUpdateTemplate,
+	useUseTemplate,
+	useValidateImport,
+} from './useConfigExport';
+
+vi.mock('../lib/api', () => ({
+	configExportApi: {
+		exportAgent: vi.fn(),
+		exportSchedule: vi.fn(),
+		exportRepository: vi.fn(),
+		exportBundle: vi.fn(),
+		importConfig: vi.fn(),
+		validateImport: vi.fn(),
+	},
+	templatesApi: {
+		list: vi.fn(),
+		get: vi.fn(),
+		create: vi.fn(),
+		update: vi.fn(),
+		delete: vi.fn(),
+		use: vi.fn(),
+	},
+}));
+
+import { configExportApi, templatesApi } from '../lib/api';
+
+describe('useExportAgent', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('exports an agent', async () => {
+		vi.mocked(configExportApi.exportAgent).mockResolvedValue('config');
+
+		const { result } = renderHook(() => useExportAgent(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ id: 'a-1', format: 'json' });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(configExportApi.exportAgent).toHaveBeenCalledWith('a-1', 'json');
+	});
+});
+
+describe('useExportSchedule', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('exports a schedule', async () => {
+		vi.mocked(configExportApi.exportSchedule).mockResolvedValue('config');
+
+		const { result } = renderHook(() => useExportSchedule(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ id: 's-1' });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(configExportApi.exportSchedule).toHaveBeenCalledWith(
+			's-1',
+			undefined,
+		);
+	});
+});
+
+describe('useExportRepository', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('exports a repository', async () => {
+		vi.mocked(configExportApi.exportRepository).mockResolvedValue('config');
+
+		const { result } = renderHook(() => useExportRepository(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ id: 'r-1' });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(configExportApi.exportRepository).toHaveBeenCalledWith(
+			'r-1',
+			undefined,
+		);
+	});
+});
+
+describe('useExportBundle', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('exports a bundle', async () => {
+		vi.mocked(configExportApi.exportBundle).mockResolvedValue('bundle');
+
+		const { result } = renderHook(() => useExportBundle(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ agent_ids: ['a-1'] } as never);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(configExportApi.exportBundle).toHaveBeenCalled();
+	});
+});
+
+describe('useImportConfig', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('imports config', async () => {
+		vi.mocked(configExportApi.importConfig).mockResolvedValue({
+			success: true,
+			imported: { agent_count: 0, schedule_count: 0, repository_count: 0 },
+		} as never);
+
+		const { result } = renderHook(() => useImportConfig(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ config: '{}' } as never);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(configExportApi.importConfig).toHaveBeenCalled();
+	});
+});
+
+describe('useValidateImport', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('validates config', async () => {
+		vi.mocked(configExportApi.validateImport).mockResolvedValue({
+			valid: true,
+		} as never);
+
+		const { result } = renderHook(() => useValidateImport(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ config: '{}' });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useTemplates', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('lists templates', async () => {
+		vi.mocked(templatesApi.list).mockResolvedValue([]);
+
+		const { result } = renderHook(() => useTemplates(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(templatesApi.list).toHaveBeenCalledOnce();
+	});
+});
+
+describe('useTemplate', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches a template', async () => {
+		vi.mocked(templatesApi.get).mockResolvedValue({ id: 't-1' });
+
+		const { result } = renderHook(() => useTemplate('t-1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(templatesApi.get).toHaveBeenCalledWith('t-1');
+	});
+
+	it('does not fetch when id is empty', () => {
+		renderHook(() => useTemplate(''), { wrapper: createWrapper() });
+		expect(templatesApi.get).not.toHaveBeenCalled();
+	});
+});
+
+describe('useCreateTemplate', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('creates a template', async () => {
+		vi.mocked(templatesApi.create).mockResolvedValue({ id: 'new' });
+
+		const { result } = renderHook(() => useCreateTemplate(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ name: 'new' } as never);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(templatesApi.create).toHaveBeenCalled();
+	});
+});
+
+describe('useUpdateTemplate', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('updates a template', async () => {
+		vi.mocked(templatesApi.update).mockResolvedValue({ id: 't-1' });
+
+		const { result } = renderHook(() => useUpdateTemplate(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ id: 't-1', data: { name: 'x' } as never });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(templatesApi.update).toHaveBeenCalledWith('t-1', { name: 'x' });
+	});
+});
+
+describe('useDeleteTemplate', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('deletes a template', async () => {
+		vi.mocked(templatesApi.delete).mockResolvedValue({ message: 'Deleted' });
+
+		const { result } = renderHook(() => useDeleteTemplate(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate('t-1');
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(templatesApi.delete).toHaveBeenCalledWith('t-1');
+	});
+});
+
+describe('useUseTemplate', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('uses a template', async () => {
+		vi.mocked(templatesApi.use).mockResolvedValue({
+			success: true,
+			imported: { agent_count: 0, schedule_count: 0, repository_count: 0 },
+		} as never);
+
+		const { result } = renderHook(() => useUseTemplate(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ id: 't-1' });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(templatesApi.use).toHaveBeenCalledWith('t-1', undefined);
+	});
+});

--- a/web/src/hooks/useContainerHooks.test.ts
+++ b/web/src/hooks/useContainerHooks.test.ts
@@ -1,0 +1,174 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import {
+	useContainerHook,
+	useContainerHookExecutions,
+	useContainerHookTemplates,
+	useContainerHooks,
+	useCreateContainerHook,
+	useDeleteContainerHook,
+	useUpdateContainerHook,
+} from './useContainerHooks';
+
+vi.mock('../lib/api', () => ({
+	containerHooksApi: {
+		list: vi.fn(),
+		get: vi.fn(),
+		create: vi.fn(),
+		update: vi.fn(),
+		delete: vi.fn(),
+		listTemplates: vi.fn(),
+		listExecutions: vi.fn(),
+	},
+}));
+
+import { containerHooksApi } from '../lib/api';
+
+describe('useContainerHooks', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches container hooks for a schedule', async () => {
+		vi.mocked(containerHooksApi.list).mockResolvedValue([]);
+
+		const { result } = renderHook(() => useContainerHooks('s-1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(containerHooksApi.list).toHaveBeenCalledWith('s-1');
+	});
+
+	it('does not fetch when scheduleId is empty', () => {
+		renderHook(() => useContainerHooks(''), { wrapper: createWrapper() });
+		expect(containerHooksApi.list).not.toHaveBeenCalled();
+	});
+});
+
+describe('useContainerHook', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches a single hook', async () => {
+		vi.mocked(containerHooksApi.get).mockResolvedValue({ id: 'h-1' });
+
+		const { result } = renderHook(() => useContainerHook('s-1', 'h-1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(containerHooksApi.get).toHaveBeenCalledWith('s-1', 'h-1');
+	});
+});
+
+describe('useCreateContainerHook', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('creates a hook', async () => {
+		vi.mocked(containerHooksApi.create).mockResolvedValue({ id: 'new' });
+
+		const { result } = renderHook(() => useCreateContainerHook(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({
+			scheduleId: 's-1',
+			data: { name: 'h' } as never,
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(containerHooksApi.create).toHaveBeenCalledWith('s-1', { name: 'h' });
+	});
+});
+
+describe('useUpdateContainerHook', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('updates a hook', async () => {
+		vi.mocked(containerHooksApi.update).mockResolvedValue({ id: 'h-1' });
+
+		const { result } = renderHook(() => useUpdateContainerHook(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({
+			scheduleId: 's-1',
+			id: 'h-1',
+			data: { name: 'x' } as never,
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(containerHooksApi.update).toHaveBeenCalledWith('s-1', 'h-1', {
+			name: 'x',
+		});
+	});
+});
+
+describe('useDeleteContainerHook', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('deletes a hook', async () => {
+		vi.mocked(containerHooksApi.delete).mockResolvedValue({
+			message: 'Deleted',
+		});
+
+		const { result } = renderHook(() => useDeleteContainerHook(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ scheduleId: 's-1', id: 'h-1' });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(containerHooksApi.delete).toHaveBeenCalledWith('s-1', 'h-1');
+	});
+});
+
+describe('useContainerHookTemplates', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('lists templates', async () => {
+		vi.mocked(containerHooksApi.listTemplates).mockResolvedValue([]);
+
+		const { result } = renderHook(() => useContainerHookTemplates(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(containerHooksApi.listTemplates).toHaveBeenCalledOnce();
+	});
+});
+
+describe('useContainerHookExecutions', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('lists executions for backup', async () => {
+		vi.mocked(containerHooksApi.listExecutions).mockResolvedValue([]);
+
+		const { result } = renderHook(() => useContainerHookExecutions('b-1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(containerHooksApi.listExecutions).toHaveBeenCalledWith('b-1');
+	});
+
+	it('does not fetch when backupId is empty', () => {
+		renderHook(() => useContainerHookExecutions(''), {
+			wrapper: createWrapper(),
+		});
+		expect(containerHooksApi.listExecutions).not.toHaveBeenCalled();
+	});
+});

--- a/web/src/hooks/useDockerLogs.test.ts
+++ b/web/src/hooks/useDockerLogs.test.ts
@@ -1,0 +1,246 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import {
+	useApplyDockerLogRetention,
+	useDeleteDockerLogBackup,
+	useDockerLogBackup,
+	useDockerLogBackups,
+	useDockerLogBackupsByAgent,
+	useDockerLogBackupsByContainer,
+	useDockerLogDownload,
+	useDockerLogSettings,
+	useDockerLogStorageStats,
+	useDockerLogView,
+	useUpdateDockerLogSettings,
+} from './useDockerLogs';
+
+vi.mock('../lib/api', () => ({
+	dockerLogsApi: {
+		list: vi.fn(),
+		get: vi.fn(),
+		view: vi.fn(),
+		download: vi.fn(),
+		delete: vi.fn(),
+		getSettings: vi.fn(),
+		updateSettings: vi.fn(),
+		listByAgent: vi.fn(),
+		listByContainer: vi.fn(),
+		getStorageStats: vi.fn(),
+		applyRetention: vi.fn(),
+	},
+}));
+
+import { dockerLogsApi } from '../lib/api';
+
+describe('useDockerLogBackups', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('lists docker log backups', async () => {
+		vi.mocked(dockerLogsApi.list).mockResolvedValue([]);
+
+		const { result } = renderHook(() => useDockerLogBackups(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(dockerLogsApi.list).toHaveBeenCalledWith(undefined);
+	});
+});
+
+describe('useDockerLogBackup', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches a backup', async () => {
+		vi.mocked(dockerLogsApi.get).mockResolvedValue({ id: 'b-1' });
+
+		const { result } = renderHook(() => useDockerLogBackup('b-1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(dockerLogsApi.get).toHaveBeenCalledWith('b-1');
+	});
+
+	it('does not fetch when id is empty', () => {
+		renderHook(() => useDockerLogBackup(''), { wrapper: createWrapper() });
+		expect(dockerLogsApi.get).not.toHaveBeenCalled();
+	});
+});
+
+describe('useDockerLogView', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('views backup contents', async () => {
+		vi.mocked(dockerLogsApi.view).mockResolvedValue({ lines: [] });
+
+		const { result } = renderHook(() => useDockerLogView('b-1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(dockerLogsApi.view).toHaveBeenCalledWith('b-1', 0, 1000);
+	});
+});
+
+describe('useDockerLogDownload', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('downloads a backup', async () => {
+		const blob = new Blob(['x']);
+		vi.mocked(dockerLogsApi.download).mockResolvedValue(blob);
+		const createObjectURL = vi.fn().mockReturnValue('blob:url');
+		const revokeObjectURL = vi.fn();
+		vi.stubGlobal('URL', { createObjectURL, revokeObjectURL });
+
+		const { result } = renderHook(() => useDockerLogDownload(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ id: 'b-1', format: 'json' });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(dockerLogsApi.download).toHaveBeenCalledWith('b-1', 'json');
+
+		vi.unstubAllGlobals();
+	});
+});
+
+describe('useDeleteDockerLogBackup', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('deletes a backup', async () => {
+		vi.mocked(dockerLogsApi.delete).mockResolvedValue({ message: 'Deleted' });
+
+		const { result } = renderHook(() => useDeleteDockerLogBackup(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate('b-1');
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(dockerLogsApi.delete).toHaveBeenCalledWith('b-1');
+	});
+});
+
+describe('useDockerLogSettings', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches settings for an agent', async () => {
+		vi.mocked(dockerLogsApi.getSettings).mockResolvedValue({});
+
+		const { result } = renderHook(() => useDockerLogSettings('a-1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(dockerLogsApi.getSettings).toHaveBeenCalledWith('a-1');
+	});
+});
+
+describe('useUpdateDockerLogSettings', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('updates settings', async () => {
+		vi.mocked(dockerLogsApi.updateSettings).mockResolvedValue({});
+
+		const { result } = renderHook(() => useUpdateDockerLogSettings(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({
+			agentId: 'a-1',
+			settings: { enabled: true } as never,
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(dockerLogsApi.updateSettings).toHaveBeenCalledWith('a-1', {
+			enabled: true,
+		});
+	});
+});
+
+describe('useDockerLogBackupsByAgent', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches backups by agent', async () => {
+		vi.mocked(dockerLogsApi.listByAgent).mockResolvedValue([]);
+
+		const { result } = renderHook(() => useDockerLogBackupsByAgent('a-1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(dockerLogsApi.listByAgent).toHaveBeenCalledWith('a-1');
+	});
+});
+
+describe('useDockerLogBackupsByContainer', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches backups by container', async () => {
+		vi.mocked(dockerLogsApi.listByContainer).mockResolvedValue([]);
+
+		const { result } = renderHook(
+			() => useDockerLogBackupsByContainer('a-1', 'c-1'),
+			{ wrapper: createWrapper() },
+		);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(dockerLogsApi.listByContainer).toHaveBeenCalledWith('a-1', 'c-1');
+	});
+});
+
+describe('useDockerLogStorageStats', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches storage stats', async () => {
+		vi.mocked(dockerLogsApi.getStorageStats).mockResolvedValue({});
+
+		const { result } = renderHook(() => useDockerLogStorageStats('a-1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(dockerLogsApi.getStorageStats).toHaveBeenCalledWith('a-1');
+	});
+});
+
+describe('useApplyDockerLogRetention', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('applies retention', async () => {
+		vi.mocked(dockerLogsApi.applyRetention).mockResolvedValue({});
+
+		const { result } = renderHook(() => useApplyDockerLogRetention(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ agentId: 'a-1' });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(dockerLogsApi.applyRetention).toHaveBeenCalledWith('a-1', undefined);
+	});
+});

--- a/web/src/hooks/useDockerRegistries.test.ts
+++ b/web/src/hooks/useDockerRegistries.test.ts
@@ -1,0 +1,292 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import {
+	useCreateDockerRegistry,
+	useDeleteDockerRegistry,
+	useDockerRegistries,
+	useDockerRegistry,
+	useDockerRegistryTypes,
+	useExpiringCredentials,
+	useHealthCheckAllDockerRegistries,
+	useHealthCheckDockerRegistry,
+	useLoginAllDockerRegistries,
+	useLoginDockerRegistry,
+	useRotateDockerRegistryCredentials,
+	useSetDefaultDockerRegistry,
+	useUpdateDockerRegistry,
+} from './useDockerRegistries';
+
+vi.mock('../lib/api', () => ({
+	dockerRegistriesApi: {
+		list: vi.fn(),
+		get: vi.fn(),
+		getTypes: vi.fn(),
+		getExpiringCredentials: vi.fn(),
+		create: vi.fn(),
+		update: vi.fn(),
+		delete: vi.fn(),
+		login: vi.fn(),
+		loginAll: vi.fn(),
+		healthCheck: vi.fn(),
+		healthCheckAll: vi.fn(),
+		rotateCredentials: vi.fn(),
+		setDefault: vi.fn(),
+	},
+}));
+
+import { dockerRegistriesApi } from '../lib/api';
+
+describe('useDockerRegistries', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('lists registries', async () => {
+		vi.mocked(dockerRegistriesApi.list).mockResolvedValue([]);
+
+		const { result } = renderHook(() => useDockerRegistries(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(dockerRegistriesApi.list).toHaveBeenCalledOnce();
+	});
+});
+
+describe('useDockerRegistry', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches a registry', async () => {
+		vi.mocked(dockerRegistriesApi.get).mockResolvedValue({ id: 'r-1' });
+
+		const { result } = renderHook(() => useDockerRegistry('r-1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(dockerRegistriesApi.get).toHaveBeenCalledWith('r-1');
+	});
+
+	it('does not fetch when id is empty', () => {
+		renderHook(() => useDockerRegistry(''), { wrapper: createWrapper() });
+		expect(dockerRegistriesApi.get).not.toHaveBeenCalled();
+	});
+});
+
+describe('useDockerRegistryTypes', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches registry types', async () => {
+		vi.mocked(dockerRegistriesApi.getTypes).mockResolvedValue([]);
+
+		const { result } = renderHook(() => useDockerRegistryTypes(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(dockerRegistriesApi.getTypes).toHaveBeenCalledOnce();
+	});
+});
+
+describe('useExpiringCredentials', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches expiring credentials', async () => {
+		vi.mocked(dockerRegistriesApi.getExpiringCredentials).mockResolvedValue([]);
+
+		const { result } = renderHook(() => useExpiringCredentials(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(dockerRegistriesApi.getExpiringCredentials).toHaveBeenCalledOnce();
+	});
+});
+
+describe('useCreateDockerRegistry', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('creates a registry', async () => {
+		vi.mocked(dockerRegistriesApi.create).mockResolvedValue({ id: 'new' });
+
+		const { result } = renderHook(() => useCreateDockerRegistry(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ name: 'docker' } as never);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(dockerRegistriesApi.create).toHaveBeenCalled();
+	});
+});
+
+describe('useUpdateDockerRegistry', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('updates a registry', async () => {
+		vi.mocked(dockerRegistriesApi.update).mockResolvedValue({ id: 'r-1' });
+
+		const { result } = renderHook(() => useUpdateDockerRegistry(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ id: 'r-1', data: { name: 'x' } as never });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(dockerRegistriesApi.update).toHaveBeenCalledWith('r-1', {
+			name: 'x',
+		});
+	});
+});
+
+describe('useDeleteDockerRegistry', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('deletes a registry', async () => {
+		vi.mocked(dockerRegistriesApi.delete).mockResolvedValue({
+			message: 'Deleted',
+		});
+
+		const { result } = renderHook(() => useDeleteDockerRegistry(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate('r-1');
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(dockerRegistriesApi.delete).toHaveBeenCalledWith('r-1');
+	});
+});
+
+describe('useLoginDockerRegistry', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('logs into a registry', async () => {
+		vi.mocked(dockerRegistriesApi.login).mockResolvedValue({ ok: true });
+
+		const { result } = renderHook(() => useLoginDockerRegistry(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate('r-1');
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(dockerRegistriesApi.login).toHaveBeenCalledWith('r-1');
+	});
+});
+
+describe('useLoginAllDockerRegistries', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('logs into all registries', async () => {
+		vi.mocked(dockerRegistriesApi.loginAll).mockResolvedValue({ ok: true });
+
+		const { result } = renderHook(() => useLoginAllDockerRegistries(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate();
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(dockerRegistriesApi.loginAll).toHaveBeenCalledOnce();
+	});
+});
+
+describe('useHealthCheckDockerRegistry', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('runs health check', async () => {
+		vi.mocked(dockerRegistriesApi.healthCheck).mockResolvedValue({ ok: true });
+
+		const { result } = renderHook(() => useHealthCheckDockerRegistry(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate('r-1');
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(dockerRegistriesApi.healthCheck).toHaveBeenCalledWith('r-1');
+	});
+});
+
+describe('useHealthCheckAllDockerRegistries', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('runs health check on all', async () => {
+		vi.mocked(dockerRegistriesApi.healthCheckAll).mockResolvedValue({
+			ok: true,
+		});
+
+		const { result } = renderHook(() => useHealthCheckAllDockerRegistries(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate();
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(dockerRegistriesApi.healthCheckAll).toHaveBeenCalledOnce();
+	});
+});
+
+describe('useRotateDockerRegistryCredentials', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('rotates credentials', async () => {
+		vi.mocked(dockerRegistriesApi.rotateCredentials).mockResolvedValue({
+			ok: true,
+		});
+
+		const { result } = renderHook(() => useRotateDockerRegistryCredentials(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ id: 'r-1', data: { token: 'x' } as never });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(dockerRegistriesApi.rotateCredentials).toHaveBeenCalledWith('r-1', {
+			token: 'x',
+		});
+	});
+});
+
+describe('useSetDefaultDockerRegistry', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('sets default registry', async () => {
+		vi.mocked(dockerRegistriesApi.setDefault).mockResolvedValue({ ok: true });
+
+		const { result } = renderHook(() => useSetDefaultDockerRegistry(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate('r-1');
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(dockerRegistriesApi.setDefault).toHaveBeenCalledWith('r-1');
+	});
+});

--- a/web/src/hooks/useDockerRestore.test.ts
+++ b/web/src/hooks/useDockerRestore.test.ts
@@ -1,0 +1,186 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import {
+	useCancelDockerRestore,
+	useContainersInSnapshot,
+	useCreateDockerRestore,
+	useDockerRestore,
+	useDockerRestorePreview,
+	useDockerRestoreProgress,
+	useDockerRestores,
+	useVolumesInSnapshot,
+} from './useDockerRestore';
+
+vi.mock('../lib/api', () => ({
+	dockerRestoresApi: {
+		list: vi.fn(),
+		get: vi.fn(),
+		create: vi.fn(),
+		preview: vi.fn(),
+		getProgress: vi.fn(),
+		listContainers: vi.fn(),
+		listVolumes: vi.fn(),
+		cancel: vi.fn(),
+	},
+}));
+
+import { dockerRestoresApi } from '../lib/api';
+
+describe('useDockerRestores', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('lists docker restores', async () => {
+		vi.mocked(dockerRestoresApi.list).mockResolvedValue([]);
+
+		const { result } = renderHook(() => useDockerRestores(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(dockerRestoresApi.list).toHaveBeenCalledWith(undefined);
+	});
+});
+
+describe('useDockerRestore', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches a restore', async () => {
+		vi.mocked(dockerRestoresApi.get).mockResolvedValue({
+			id: 'r-1',
+			status: 'complete',
+		});
+
+		const { result } = renderHook(() => useDockerRestore('r-1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(dockerRestoresApi.get).toHaveBeenCalledWith('r-1');
+	});
+
+	it('does not fetch when id is empty', () => {
+		renderHook(() => useDockerRestore(''), { wrapper: createWrapper() });
+		expect(dockerRestoresApi.get).not.toHaveBeenCalled();
+	});
+});
+
+describe('useCreateDockerRestore', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('creates a restore', async () => {
+		vi.mocked(dockerRestoresApi.create).mockResolvedValue({ id: 'new' });
+
+		const { result } = renderHook(() => useCreateDockerRestore(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ snapshot_id: 's-1' } as never);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(dockerRestoresApi.create).toHaveBeenCalled();
+	});
+});
+
+describe('useDockerRestorePreview', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('previews a restore', async () => {
+		vi.mocked(dockerRestoresApi.preview).mockResolvedValue({ ok: true });
+
+		const { result } = renderHook(() => useDockerRestorePreview(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ snapshot_id: 's-1' } as never);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});
+
+describe('useDockerRestoreProgress', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches restore progress', async () => {
+		vi.mocked(dockerRestoresApi.getProgress).mockResolvedValue({ percent: 50 });
+
+		const { result } = renderHook(() => useDockerRestoreProgress('r-1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(dockerRestoresApi.getProgress).toHaveBeenCalledWith('r-1');
+	});
+
+	it('does not fetch when disabled', () => {
+		renderHook(() => useDockerRestoreProgress('r-1', false), {
+			wrapper: createWrapper(),
+		});
+		expect(dockerRestoresApi.getProgress).not.toHaveBeenCalled();
+	});
+});
+
+describe('useContainersInSnapshot', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('lists containers in snapshot', async () => {
+		vi.mocked(dockerRestoresApi.listContainers).mockResolvedValue([]);
+
+		const { result } = renderHook(() => useContainersInSnapshot('s-1', 'a-1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(dockerRestoresApi.listContainers).toHaveBeenCalledWith('s-1', 'a-1');
+	});
+});
+
+describe('useVolumesInSnapshot', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('lists volumes in snapshot', async () => {
+		vi.mocked(dockerRestoresApi.listVolumes).mockResolvedValue([]);
+
+		const { result } = renderHook(() => useVolumesInSnapshot('s-1', 'a-1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(dockerRestoresApi.listVolumes).toHaveBeenCalledWith('s-1', 'a-1');
+	});
+});
+
+describe('useCancelDockerRestore', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('cancels a restore', async () => {
+		vi.mocked(dockerRestoresApi.cancel).mockResolvedValue({
+			message: 'Canceled',
+		});
+
+		const { result } = renderHook(() => useCancelDockerRestore(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate('r-1');
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(dockerRestoresApi.cancel).toHaveBeenCalledWith('r-1');
+	});
+});

--- a/web/src/hooks/useKomodoIntegration.test.ts
+++ b/web/src/hooks/useKomodoIntegration.test.ts
@@ -1,0 +1,299 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import {
+	useCreateKomodoIntegration,
+	useDeleteKomodoIntegration,
+	useDiscoverKomodoContainers,
+	useKomodoContainer,
+	useKomodoContainers,
+	useKomodoIntegration,
+	useKomodoIntegrations,
+	useKomodoStack,
+	useKomodoStacks,
+	useKomodoWebhookEvents,
+	useSyncKomodoIntegration,
+	useTestKomodoConnection,
+	useUpdateKomodoContainer,
+	useUpdateKomodoIntegration,
+} from './useKomodoIntegration';
+
+vi.mock('../lib/api', () => ({
+	komodoApi: {
+		listIntegrations: vi.fn(),
+		getIntegration: vi.fn(),
+		createIntegration: vi.fn(),
+		updateIntegration: vi.fn(),
+		deleteIntegration: vi.fn(),
+		testConnection: vi.fn(),
+		syncIntegration: vi.fn(),
+		discoverContainers: vi.fn(),
+		listContainers: vi.fn(),
+		getContainer: vi.fn(),
+		updateContainer: vi.fn(),
+		listStacks: vi.fn(),
+		getStack: vi.fn(),
+		listWebhookEvents: vi.fn(),
+	},
+}));
+
+import { komodoApi } from '../lib/api';
+
+describe('useKomodoIntegrations', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('lists integrations', async () => {
+		vi.mocked(komodoApi.listIntegrations).mockResolvedValue([]);
+
+		const { result } = renderHook(() => useKomodoIntegrations(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(komodoApi.listIntegrations).toHaveBeenCalledOnce();
+	});
+});
+
+describe('useKomodoIntegration', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches one integration', async () => {
+		vi.mocked(komodoApi.getIntegration).mockResolvedValue({ id: 'k-1' });
+
+		const { result } = renderHook(() => useKomodoIntegration('k-1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(komodoApi.getIntegration).toHaveBeenCalledWith('k-1');
+	});
+
+	it('does not fetch when id is empty', () => {
+		renderHook(() => useKomodoIntegration(''), { wrapper: createWrapper() });
+		expect(komodoApi.getIntegration).not.toHaveBeenCalled();
+	});
+});
+
+describe('useCreateKomodoIntegration', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('creates integration', async () => {
+		vi.mocked(komodoApi.createIntegration).mockResolvedValue({ id: 'new' });
+
+		const { result } = renderHook(() => useCreateKomodoIntegration(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ name: 'k' } as never);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(komodoApi.createIntegration).toHaveBeenCalled();
+	});
+});
+
+describe('useUpdateKomodoIntegration', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('updates integration', async () => {
+		vi.mocked(komodoApi.updateIntegration).mockResolvedValue({ id: 'k-1' });
+
+		const { result } = renderHook(() => useUpdateKomodoIntegration(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ id: 'k-1', data: { name: 'x' } as never });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(komodoApi.updateIntegration).toHaveBeenCalledWith('k-1', {
+			name: 'x',
+		});
+	});
+});
+
+describe('useDeleteKomodoIntegration', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('deletes integration', async () => {
+		vi.mocked(komodoApi.deleteIntegration).mockResolvedValue({
+			message: 'Deleted',
+		});
+
+		const { result } = renderHook(() => useDeleteKomodoIntegration(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate('k-1');
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(komodoApi.deleteIntegration).toHaveBeenCalledWith('k-1');
+	});
+});
+
+describe('useTestKomodoConnection', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('tests connection', async () => {
+		vi.mocked(komodoApi.testConnection).mockResolvedValue({ ok: true });
+
+		const { result } = renderHook(() => useTestKomodoConnection(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate('k-1');
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(komodoApi.testConnection).toHaveBeenCalledWith('k-1');
+	});
+});
+
+describe('useSyncKomodoIntegration', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('syncs integration', async () => {
+		vi.mocked(komodoApi.syncIntegration).mockResolvedValue({ ok: true });
+
+		const { result } = renderHook(() => useSyncKomodoIntegration(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate('k-1');
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(komodoApi.syncIntegration).toHaveBeenCalledWith('k-1');
+	});
+});
+
+describe('useDiscoverKomodoContainers', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('returns disabled query until refetched', () => {
+		const { result } = renderHook(() => useDiscoverKomodoContainers('k-1'), {
+			wrapper: createWrapper(),
+		});
+
+		expect(result.current.isFetching).toBe(false);
+		expect(komodoApi.discoverContainers).not.toHaveBeenCalled();
+	});
+});
+
+describe('useKomodoContainers', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('lists containers', async () => {
+		vi.mocked(komodoApi.listContainers).mockResolvedValue([]);
+
+		const { result } = renderHook(() => useKomodoContainers(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(komodoApi.listContainers).toHaveBeenCalledOnce();
+	});
+});
+
+describe('useKomodoContainer', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches a container', async () => {
+		vi.mocked(komodoApi.getContainer).mockResolvedValue({ id: 'c-1' });
+
+		const { result } = renderHook(() => useKomodoContainer('c-1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(komodoApi.getContainer).toHaveBeenCalledWith('c-1');
+	});
+});
+
+describe('useUpdateKomodoContainer', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('updates a container', async () => {
+		vi.mocked(komodoApi.updateContainer).mockResolvedValue({ id: 'c-1' });
+
+		const { result } = renderHook(() => useUpdateKomodoContainer(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ id: 'c-1', data: { enabled: true } as never });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(komodoApi.updateContainer).toHaveBeenCalledWith('c-1', {
+			enabled: true,
+		});
+	});
+});
+
+describe('useKomodoStacks', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('lists stacks', async () => {
+		vi.mocked(komodoApi.listStacks).mockResolvedValue([]);
+
+		const { result } = renderHook(() => useKomodoStacks(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(komodoApi.listStacks).toHaveBeenCalledOnce();
+	});
+});
+
+describe('useKomodoStack', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches a stack', async () => {
+		vi.mocked(komodoApi.getStack).mockResolvedValue({ id: 's-1' });
+
+		const { result } = renderHook(() => useKomodoStack('s-1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(komodoApi.getStack).toHaveBeenCalledWith('s-1');
+	});
+});
+
+describe('useKomodoWebhookEvents', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('lists webhook events', async () => {
+		vi.mocked(komodoApi.listWebhookEvents).mockResolvedValue([]);
+
+		const { result } = renderHook(() => useKomodoWebhookEvents(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(komodoApi.listWebhookEvents).toHaveBeenCalledOnce();
+	});
+});

--- a/web/src/hooks/useSLA.test.ts
+++ b/web/src/hooks/useSLA.test.ts
@@ -1,0 +1,332 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import {
+	useAcknowledgeBreach,
+	useActiveSLABreaches,
+	useCreateSLA,
+	useCreateSLAAssignment,
+	useDeleteSLA,
+	useDeleteSLAAssignment,
+	useOrgSLACompliance,
+	useResolveBreach,
+	useSLA,
+	useSLAAssignments,
+	useSLABreach,
+	useSLABreaches,
+	useSLABreachesBySLA,
+	useSLACompliance,
+	useSLADashboard,
+	useSLAReport,
+	useSLAs,
+	useUpdateSLA,
+} from './useSLA';
+
+vi.mock('../lib/api', () => ({
+	slaApi: {
+		list: vi.fn(),
+		get: vi.fn(),
+		create: vi.fn(),
+		update: vi.fn(),
+		delete: vi.fn(),
+		listAssignments: vi.fn(),
+		createAssignment: vi.fn(),
+		deleteAssignment: vi.fn(),
+		getCompliance: vi.fn(),
+		listOrgCompliance: vi.fn(),
+		listBreaches: vi.fn(),
+		listActiveBreaches: vi.fn(),
+		listBreachesBySLA: vi.fn(),
+		getBreach: vi.fn(),
+		acknowledgeBreach: vi.fn(),
+		resolveBreach: vi.fn(),
+		getDashboard: vi.fn(),
+		getReport: vi.fn(),
+	},
+}));
+
+import { slaApi } from '../lib/api';
+
+describe('useSLAs', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('lists SLAs', async () => {
+		vi.mocked(slaApi.list).mockResolvedValue([]);
+		const { result } = renderHook(() => useSLAs(), {
+			wrapper: createWrapper(),
+		});
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(slaApi.list).toHaveBeenCalledOnce();
+	});
+});
+
+describe('useSLA', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches an SLA', async () => {
+		vi.mocked(slaApi.get).mockResolvedValue({ id: 's-1' });
+		const { result } = renderHook(() => useSLA('s-1'), {
+			wrapper: createWrapper(),
+		});
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(slaApi.get).toHaveBeenCalledWith('s-1');
+	});
+
+	it('does not fetch when id is empty', () => {
+		renderHook(() => useSLA(''), { wrapper: createWrapper() });
+		expect(slaApi.get).not.toHaveBeenCalled();
+	});
+});
+
+describe('useCreateSLA', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('creates an SLA', async () => {
+		vi.mocked(slaApi.create).mockResolvedValue({ id: 'new' });
+		const { result } = renderHook(() => useCreateSLA(), {
+			wrapper: createWrapper(),
+		});
+		result.current.mutate({ name: 's' } as never);
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(slaApi.create).toHaveBeenCalled();
+	});
+});
+
+describe('useUpdateSLA', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('updates an SLA', async () => {
+		vi.mocked(slaApi.update).mockResolvedValue({ id: 's-1' });
+		const { result } = renderHook(() => useUpdateSLA(), {
+			wrapper: createWrapper(),
+		});
+		result.current.mutate({ id: 's-1', data: { name: 'x' } as never });
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(slaApi.update).toHaveBeenCalledWith('s-1', { name: 'x' });
+	});
+});
+
+describe('useDeleteSLA', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('deletes an SLA', async () => {
+		vi.mocked(slaApi.delete).mockResolvedValue({ message: 'Deleted' });
+		const { result } = renderHook(() => useDeleteSLA(), {
+			wrapper: createWrapper(),
+		});
+		result.current.mutate('s-1');
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(slaApi.delete).toHaveBeenCalledWith('s-1');
+	});
+});
+
+describe('useSLAAssignments', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('lists assignments', async () => {
+		vi.mocked(slaApi.listAssignments).mockResolvedValue([]);
+		const { result } = renderHook(() => useSLAAssignments('s-1'), {
+			wrapper: createWrapper(),
+		});
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(slaApi.listAssignments).toHaveBeenCalledWith('s-1');
+	});
+});
+
+describe('useCreateSLAAssignment', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('creates an assignment', async () => {
+		vi.mocked(slaApi.createAssignment).mockResolvedValue({ id: 'a-1' });
+		const { result } = renderHook(() => useCreateSLAAssignment(), {
+			wrapper: createWrapper(),
+		});
+		result.current.mutate({ slaId: 's-1', data: { id: 'x' } as never });
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(slaApi.createAssignment).toHaveBeenCalledWith('s-1', { id: 'x' });
+	});
+});
+
+describe('useDeleteSLAAssignment', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('deletes an assignment', async () => {
+		vi.mocked(slaApi.deleteAssignment).mockResolvedValue({
+			message: 'Deleted',
+		});
+		const { result } = renderHook(() => useDeleteSLAAssignment(), {
+			wrapper: createWrapper(),
+		});
+		result.current.mutate({ slaId: 's-1', assignmentId: 'a-1' });
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(slaApi.deleteAssignment).toHaveBeenCalledWith('s-1', 'a-1');
+	});
+});
+
+describe('useSLACompliance', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches compliance', async () => {
+		vi.mocked(slaApi.getCompliance).mockResolvedValue({});
+		const { result } = renderHook(() => useSLACompliance('s-1'), {
+			wrapper: createWrapper(),
+		});
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(slaApi.getCompliance).toHaveBeenCalledWith('s-1');
+	});
+});
+
+describe('useOrgSLACompliance', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('lists org compliance', async () => {
+		vi.mocked(slaApi.listOrgCompliance).mockResolvedValue([]);
+		const { result } = renderHook(() => useOrgSLACompliance(), {
+			wrapper: createWrapper(),
+		});
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(slaApi.listOrgCompliance).toHaveBeenCalledOnce();
+	});
+});
+
+describe('useSLABreaches', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('lists breaches', async () => {
+		vi.mocked(slaApi.listBreaches).mockResolvedValue([]);
+		const { result } = renderHook(() => useSLABreaches(), {
+			wrapper: createWrapper(),
+		});
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(slaApi.listBreaches).toHaveBeenCalledOnce();
+	});
+});
+
+describe('useActiveSLABreaches', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('lists active breaches', async () => {
+		vi.mocked(slaApi.listActiveBreaches).mockResolvedValue([]);
+		const { result } = renderHook(() => useActiveSLABreaches(), {
+			wrapper: createWrapper(),
+		});
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(slaApi.listActiveBreaches).toHaveBeenCalledOnce();
+	});
+});
+
+describe('useSLABreachesBySLA', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('lists breaches by SLA', async () => {
+		vi.mocked(slaApi.listBreachesBySLA).mockResolvedValue([]);
+		const { result } = renderHook(() => useSLABreachesBySLA('s-1'), {
+			wrapper: createWrapper(),
+		});
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(slaApi.listBreachesBySLA).toHaveBeenCalledWith('s-1');
+	});
+});
+
+describe('useSLABreach', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches a breach', async () => {
+		vi.mocked(slaApi.getBreach).mockResolvedValue({ id: 'b-1' });
+		const { result } = renderHook(() => useSLABreach('b-1'), {
+			wrapper: createWrapper(),
+		});
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(slaApi.getBreach).toHaveBeenCalledWith('b-1');
+	});
+});
+
+describe('useAcknowledgeBreach', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('acknowledges a breach', async () => {
+		vi.mocked(slaApi.acknowledgeBreach).mockResolvedValue({ ok: true });
+		const { result } = renderHook(() => useAcknowledgeBreach(), {
+			wrapper: createWrapper(),
+		});
+		result.current.mutate({ id: 'b-1' });
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(slaApi.acknowledgeBreach).toHaveBeenCalledWith('b-1', undefined);
+	});
+});
+
+describe('useResolveBreach', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('resolves a breach', async () => {
+		vi.mocked(slaApi.resolveBreach).mockResolvedValue({ ok: true });
+		const { result } = renderHook(() => useResolveBreach(), {
+			wrapper: createWrapper(),
+		});
+		result.current.mutate('b-1');
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(slaApi.resolveBreach).toHaveBeenCalledWith('b-1');
+	});
+});
+
+describe('useSLADashboard', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches dashboard', async () => {
+		vi.mocked(slaApi.getDashboard).mockResolvedValue({});
+		const { result } = renderHook(() => useSLADashboard(), {
+			wrapper: createWrapper(),
+		});
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(slaApi.getDashboard).toHaveBeenCalledOnce();
+	});
+});
+
+describe('useSLAReport', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches report', async () => {
+		vi.mocked(slaApi.getReport).mockResolvedValue({});
+		const { result } = renderHook(() => useSLAReport('2025-01'), {
+			wrapper: createWrapper(),
+		});
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(slaApi.getReport).toHaveBeenCalledWith('2025-01');
+	});
+});

--- a/web/src/hooks/useSavedFilters.test.ts
+++ b/web/src/hooks/useSavedFilters.test.ts
@@ -1,0 +1,135 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import {
+	useCreateSavedFilter,
+	useDeleteSavedFilter,
+	useSavedFilter,
+	useSavedFilters,
+	useUpdateSavedFilter,
+} from './useSavedFilters';
+
+vi.mock('../lib/api', () => ({
+	savedFiltersApi: {
+		list: vi.fn(),
+		get: vi.fn(),
+		create: vi.fn(),
+		update: vi.fn(),
+		delete: vi.fn(),
+	},
+}));
+
+import { savedFiltersApi } from '../lib/api';
+
+describe('useSavedFilters', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('lists saved filters', async () => {
+		vi.mocked(savedFiltersApi.list).mockResolvedValue([]);
+
+		const { result } = renderHook(() => useSavedFilters(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(savedFiltersApi.list).toHaveBeenCalledWith(undefined);
+	});
+
+	it('passes entityType', async () => {
+		vi.mocked(savedFiltersApi.list).mockResolvedValue([]);
+
+		renderHook(() => useSavedFilters('backup'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => {
+			expect(savedFiltersApi.list).toHaveBeenCalledWith('backup');
+		});
+	});
+});
+
+describe('useSavedFilter', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches a filter', async () => {
+		vi.mocked(savedFiltersApi.get).mockResolvedValue({ id: 'f-1' });
+
+		const { result } = renderHook(() => useSavedFilter('f-1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(savedFiltersApi.get).toHaveBeenCalledWith('f-1');
+	});
+
+	it('does not fetch when id is empty', () => {
+		renderHook(() => useSavedFilter(''), { wrapper: createWrapper() });
+		expect(savedFiltersApi.get).not.toHaveBeenCalled();
+	});
+});
+
+describe('useCreateSavedFilter', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('creates a filter', async () => {
+		vi.mocked(savedFiltersApi.create).mockResolvedValue({
+			id: 'new',
+			entity_type: 'backup',
+		});
+
+		const { result } = renderHook(() => useCreateSavedFilter(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ name: 'f', entity_type: 'backup' } as never);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(savedFiltersApi.create).toHaveBeenCalled();
+	});
+});
+
+describe('useUpdateSavedFilter', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('updates a filter', async () => {
+		vi.mocked(savedFiltersApi.update).mockResolvedValue({ id: 'f-1' });
+
+		const { result } = renderHook(() => useUpdateSavedFilter(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ id: 'f-1', data: { name: 'x' } as never });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(savedFiltersApi.update).toHaveBeenCalledWith('f-1', { name: 'x' });
+	});
+});
+
+describe('useDeleteSavedFilter', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('deletes a filter', async () => {
+		vi.mocked(savedFiltersApi.delete).mockResolvedValue({
+			message: 'Deleted',
+		});
+
+		const { result } = renderHook(() => useDeleteSavedFilter(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate('f-1');
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(savedFiltersApi.delete).toHaveBeenCalledWith('f-1');
+	});
+});

--- a/web/src/hooks/useSetup.test.ts
+++ b/web/src/hooks/useSetup.test.ts
@@ -1,0 +1,338 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import {
+	useActivateLicense,
+	useCompleteSetup,
+	useConfigureOIDC,
+	useConfigureSMTP,
+	useCreateFirstOrganization,
+	useCreateSuperuser,
+	useRerunConfigureOIDC,
+	useRerunConfigureSMTP,
+	useRerunStatus,
+	useRerunUpdateLicense,
+	useSetupStatus,
+	useSkipOIDC,
+	useSkipSMTP,
+	useStartTrial,
+	useTestDatabase,
+} from './useSetup';
+
+vi.mock('../lib/api', () => ({
+	setupApi: {
+		getStatus: vi.fn(),
+		testDatabase: vi.fn(),
+		createSuperuser: vi.fn(),
+		configureSMTP: vi.fn(),
+		skipSMTP: vi.fn(),
+		configureOIDC: vi.fn(),
+		skipOIDC: vi.fn(),
+		activateLicense: vi.fn(),
+		startTrial: vi.fn(),
+		createOrganization: vi.fn(),
+		completeSetup: vi.fn(),
+		getRerunStatus: vi.fn(),
+		rerunConfigureSMTP: vi.fn(),
+		rerunConfigureOIDC: vi.fn(),
+		rerunUpdateLicense: vi.fn(),
+	},
+}));
+
+import { setupApi } from '../lib/api';
+
+describe('useSetupStatus', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches setup status', async () => {
+		vi.mocked(setupApi.getStatus).mockResolvedValue({ ready: true });
+
+		const { result } = renderHook(() => useSetupStatus(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(setupApi.getStatus).toHaveBeenCalledOnce();
+	});
+});
+
+describe('useTestDatabase', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('tests database', async () => {
+		vi.mocked(setupApi.testDatabase).mockResolvedValue({ ok: true });
+
+		const { result } = renderHook(() => useTestDatabase(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate();
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(setupApi.testDatabase).toHaveBeenCalledOnce();
+	});
+});
+
+describe('useCreateSuperuser', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('creates a superuser', async () => {
+		vi.mocked(setupApi.createSuperuser).mockResolvedValue({ id: 'u-1' });
+
+		const { result } = renderHook(() => useCreateSuperuser(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ email: 'a@b.com', password: 'x' } as never);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(setupApi.createSuperuser).toHaveBeenCalled();
+	});
+});
+
+describe('useConfigureSMTP', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('configures SMTP', async () => {
+		vi.mocked(setupApi.configureSMTP).mockResolvedValue({ ok: true });
+
+		const { result } = renderHook(() => useConfigureSMTP(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ host: 'smtp.example.com' } as never);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(setupApi.configureSMTP).toHaveBeenCalled();
+	});
+});
+
+describe('useSkipSMTP', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('skips SMTP', async () => {
+		vi.mocked(setupApi.skipSMTP).mockResolvedValue({ ok: true });
+
+		const { result } = renderHook(() => useSkipSMTP(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate();
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(setupApi.skipSMTP).toHaveBeenCalledOnce();
+	});
+});
+
+describe('useConfigureOIDC', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('configures OIDC', async () => {
+		vi.mocked(setupApi.configureOIDC).mockResolvedValue({ ok: true });
+
+		const { result } = renderHook(() => useConfigureOIDC(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ issuer: 'https://x' } as never);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(setupApi.configureOIDC).toHaveBeenCalled();
+	});
+});
+
+describe('useSkipOIDC', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('skips OIDC', async () => {
+		vi.mocked(setupApi.skipOIDC).mockResolvedValue({ ok: true });
+
+		const { result } = renderHook(() => useSkipOIDC(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate();
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(setupApi.skipOIDC).toHaveBeenCalledOnce();
+	});
+});
+
+describe('useActivateLicense', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('activates a license', async () => {
+		vi.mocked(setupApi.activateLicense).mockResolvedValue({ ok: true });
+
+		const { result } = renderHook(() => useActivateLicense(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ key: 'X' } as never);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(setupApi.activateLicense).toHaveBeenCalled();
+	});
+});
+
+describe('useStartTrial', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('starts a trial', async () => {
+		vi.mocked(setupApi.startTrial).mockResolvedValue({ ok: true });
+
+		const { result } = renderHook(() => useStartTrial(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ email: 'a@b.com' } as never);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(setupApi.startTrial).toHaveBeenCalled();
+	});
+});
+
+describe('useCreateFirstOrganization', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('creates first organization', async () => {
+		vi.mocked(setupApi.createOrganization).mockResolvedValue({ id: 'o-1' });
+
+		const { result } = renderHook(() => useCreateFirstOrganization(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ name: 'org' } as never);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(setupApi.createOrganization).toHaveBeenCalled();
+	});
+});
+
+describe('useCompleteSetup', () => {
+	const originalLocation = window.location;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		// Replace window.location so the mutation's redirect doesn't navigate jsdom.
+		Object.defineProperty(window, 'location', {
+			configurable: true,
+			value: { href: '' },
+		});
+	});
+
+	afterEach(() => {
+		Object.defineProperty(window, 'location', {
+			configurable: true,
+			value: originalLocation,
+		});
+	});
+
+	it('completes setup', async () => {
+		vi.mocked(setupApi.completeSetup).mockResolvedValue({ redirect: '/done' });
+
+		const { result } = renderHook(() => useCompleteSetup(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate();
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(setupApi.completeSetup).toHaveBeenCalledOnce();
+		expect(window.location.href).toBe('/done');
+	});
+});
+
+describe('useRerunStatus', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches rerun status', async () => {
+		vi.mocked(setupApi.getRerunStatus).mockResolvedValue({ ok: true });
+
+		const { result } = renderHook(() => useRerunStatus(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(setupApi.getRerunStatus).toHaveBeenCalledOnce();
+	});
+});
+
+describe('useRerunConfigureSMTP', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('re-configures SMTP', async () => {
+		vi.mocked(setupApi.rerunConfigureSMTP).mockResolvedValue({ ok: true });
+
+		const { result } = renderHook(() => useRerunConfigureSMTP(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ host: 'x' } as never);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(setupApi.rerunConfigureSMTP).toHaveBeenCalled();
+	});
+});
+
+describe('useRerunConfigureOIDC', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('re-configures OIDC', async () => {
+		vi.mocked(setupApi.rerunConfigureOIDC).mockResolvedValue({ ok: true });
+
+		const { result } = renderHook(() => useRerunConfigureOIDC(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ issuer: 'https://x' } as never);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(setupApi.rerunConfigureOIDC).toHaveBeenCalled();
+	});
+});
+
+describe('useRerunUpdateLicense', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('re-updates license', async () => {
+		vi.mocked(setupApi.rerunUpdateLicense).mockResolvedValue({ ok: true });
+
+		const { result } = renderHook(() => useRerunUpdateLicense(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ key: 'X' } as never);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(setupApi.rerunUpdateLicense).toHaveBeenCalled();
+	});
+});

--- a/web/src/hooks/useSnapshotMounts.test.ts
+++ b/web/src/hooks/useSnapshotMounts.test.ts
@@ -1,0 +1,114 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import {
+	useMountSnapshot,
+	useSnapshotMount,
+	useSnapshotMounts,
+	useUnmountSnapshot,
+} from './useSnapshotMounts';
+
+vi.mock('../lib/api', () => ({
+	snapshotMountsApi: {
+		list: vi.fn(),
+	},
+	snapshotsApi: {
+		getMount: vi.fn(),
+		mount: vi.fn(),
+		unmount: vi.fn(),
+	},
+}));
+
+import { snapshotMountsApi, snapshotsApi } from '../lib/api';
+
+describe('useSnapshotMounts', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('lists snapshot mounts', async () => {
+		vi.mocked(snapshotMountsApi.list).mockResolvedValue([]);
+
+		const { result } = renderHook(() => useSnapshotMounts(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(snapshotMountsApi.list).toHaveBeenCalledWith(undefined);
+	});
+
+	it('passes agentId', async () => {
+		vi.mocked(snapshotMountsApi.list).mockResolvedValue([]);
+
+		renderHook(() => useSnapshotMounts('a-1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => {
+			expect(snapshotMountsApi.list).toHaveBeenCalledWith('a-1');
+		});
+	});
+});
+
+describe('useSnapshotMount', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches a mount', async () => {
+		vi.mocked(snapshotsApi.getMount).mockResolvedValue({ id: 'm-1' });
+
+		const { result } = renderHook(() => useSnapshotMount('s-1', 'a-1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(snapshotsApi.getMount).toHaveBeenCalledWith('s-1', 'a-1');
+	});
+
+	it('does not fetch when ids are empty', () => {
+		renderHook(() => useSnapshotMount('', ''), { wrapper: createWrapper() });
+		expect(snapshotsApi.getMount).not.toHaveBeenCalled();
+	});
+});
+
+describe('useMountSnapshot', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('mounts a snapshot', async () => {
+		vi.mocked(snapshotsApi.mount).mockResolvedValue({ ok: true });
+
+		const { result } = renderHook(() => useMountSnapshot(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({
+			snapshotId: 's-1',
+			data: { agent_id: 'a-1' } as never,
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(snapshotsApi.mount).toHaveBeenCalledWith('s-1', { agent_id: 'a-1' });
+	});
+});
+
+describe('useUnmountSnapshot', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('unmounts a snapshot', async () => {
+		vi.mocked(snapshotsApi.unmount).mockResolvedValue({ ok: true });
+
+		const { result } = renderHook(() => useUnmountSnapshot(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ snapshotId: 's-1', agentId: 'a-1' });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(snapshotsApi.unmount).toHaveBeenCalledWith('s-1', 'a-1');
+	});
+});

--- a/web/src/hooks/useSystemHealth.test.ts
+++ b/web/src/hooks/useSystemHealth.test.ts
@@ -1,0 +1,61 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import { useSystemHealth, useSystemHealthHistory } from './useSystemHealth';
+
+vi.mock('../lib/api', () => ({
+	systemHealthApi: {
+		getHealth: vi.fn(),
+		getHistory: vi.fn(),
+	},
+}));
+
+import { systemHealthApi } from '../lib/api';
+
+describe('useSystemHealth', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches system health', async () => {
+		vi.mocked(systemHealthApi.getHealth).mockResolvedValue({ status: 'ok' });
+
+		const { result } = renderHook(() => useSystemHealth(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual({ status: 'ok' });
+		expect(systemHealthApi.getHealth).toHaveBeenCalledOnce();
+	});
+
+	it('handles error state', async () => {
+		vi.mocked(systemHealthApi.getHealth).mockRejectedValue(
+			new Error('Network error'),
+		);
+
+		const { result } = renderHook(() => useSystemHealth(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isError).toBe(true));
+		expect(result.current.error).toBeDefined();
+	});
+});
+
+describe('useSystemHealthHistory', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches history', async () => {
+		vi.mocked(systemHealthApi.getHistory).mockResolvedValue([]);
+
+		const { result } = renderHook(() => useSystemHealthHistory(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(systemHealthApi.getHistory).toHaveBeenCalledOnce();
+	});
+});

--- a/web/src/hooks/useUsers.test.ts
+++ b/web/src/hooks/useUsers.test.ts
@@ -1,0 +1,300 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWrapper } from '../test/helpers';
+import {
+	useDeleteUser,
+	useDisableUser,
+	useEnableUser,
+	useEndImpersonation,
+	useImpersonationLogs,
+	useInviteUser,
+	useOrgActivityLogs,
+	useResetUserPassword,
+	useStartImpersonation,
+	useUpdateUser,
+	useUser,
+	useUserActivity,
+	useUsers,
+} from './useUsers';
+
+vi.mock('../lib/api', () => ({
+	usersApi: {
+		list: vi.fn(),
+		get: vi.fn(),
+		invite: vi.fn(),
+		update: vi.fn(),
+		delete: vi.fn(),
+		resetPassword: vi.fn(),
+		disable: vi.fn(),
+		enable: vi.fn(),
+		getActivity: vi.fn(),
+		getOrgActivityLogs: vi.fn(),
+		startImpersonation: vi.fn(),
+		endImpersonation: vi.fn(),
+		getImpersonationLogs: vi.fn(),
+	},
+}));
+
+import { usersApi } from '../lib/api';
+
+const originalLocation = window.location;
+
+beforeEach(() => {
+	Object.defineProperty(window, 'location', {
+		configurable: true,
+		value: { reload: vi.fn() },
+	});
+});
+
+afterEach(() => {
+	Object.defineProperty(window, 'location', {
+		configurable: true,
+		value: originalLocation,
+	});
+});
+
+describe('useUsers', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('lists users', async () => {
+		vi.mocked(usersApi.list).mockResolvedValue([]);
+
+		const { result } = renderHook(() => useUsers(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(usersApi.list).toHaveBeenCalledOnce();
+	});
+});
+
+describe('useUser', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches a user', async () => {
+		vi.mocked(usersApi.get).mockResolvedValue({ id: 'u-1' });
+
+		const { result } = renderHook(() => useUser('u-1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(usersApi.get).toHaveBeenCalledWith('u-1');
+	});
+
+	it('does not fetch when id is empty', () => {
+		renderHook(() => useUser(''), { wrapper: createWrapper() });
+		expect(usersApi.get).not.toHaveBeenCalled();
+	});
+});
+
+describe('useInviteUser', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('invites a user', async () => {
+		vi.mocked(usersApi.invite).mockResolvedValue({ id: 'u-2' });
+
+		const { result } = renderHook(() => useInviteUser(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ email: 'a@b.com' } as never);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(usersApi.invite).toHaveBeenCalled();
+	});
+});
+
+describe('useUpdateUser', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('updates a user', async () => {
+		vi.mocked(usersApi.update).mockResolvedValue({ id: 'u-1' });
+
+		const { result } = renderHook(() => useUpdateUser(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ id: 'u-1', data: { name: 'x' } as never });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(usersApi.update).toHaveBeenCalledWith('u-1', { name: 'x' });
+	});
+});
+
+describe('useDeleteUser', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('deletes a user', async () => {
+		vi.mocked(usersApi.delete).mockResolvedValue({ message: 'Deleted' });
+
+		const { result } = renderHook(() => useDeleteUser(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate('u-1');
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(usersApi.delete).toHaveBeenCalledWith('u-1');
+	});
+});
+
+describe('useResetUserPassword', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('resets a password', async () => {
+		vi.mocked(usersApi.resetPassword).mockResolvedValue({ ok: true });
+
+		const { result } = renderHook(() => useResetUserPassword(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ id: 'u-1', data: { password: 'x' } as never });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(usersApi.resetPassword).toHaveBeenCalledWith('u-1', {
+			password: 'x',
+		});
+	});
+});
+
+describe('useDisableUser', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('disables a user', async () => {
+		vi.mocked(usersApi.disable).mockResolvedValue({ ok: true });
+
+		const { result } = renderHook(() => useDisableUser(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate('u-1');
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(usersApi.disable).toHaveBeenCalledWith('u-1');
+	});
+});
+
+describe('useEnableUser', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('enables a user', async () => {
+		vi.mocked(usersApi.enable).mockResolvedValue({ ok: true });
+
+		const { result } = renderHook(() => useEnableUser(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate('u-1');
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(usersApi.enable).toHaveBeenCalledWith('u-1');
+	});
+});
+
+describe('useUserActivity', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches user activity', async () => {
+		vi.mocked(usersApi.getActivity).mockResolvedValue([]);
+
+		const { result } = renderHook(() => useUserActivity('u-1'), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(usersApi.getActivity).toHaveBeenCalledWith('u-1', 50, 0);
+	});
+});
+
+describe('useOrgActivityLogs', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches org activity logs', async () => {
+		vi.mocked(usersApi.getOrgActivityLogs).mockResolvedValue([]);
+
+		const { result } = renderHook(() => useOrgActivityLogs(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(usersApi.getOrgActivityLogs).toHaveBeenCalledWith(50, 0);
+	});
+});
+
+describe('useStartImpersonation', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('starts impersonation', async () => {
+		vi.mocked(usersApi.startImpersonation).mockResolvedValue({ ok: true });
+
+		const { result } = renderHook(() => useStartImpersonation(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ id: 'u-1', data: { reason: 'test' } as never });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(usersApi.startImpersonation).toHaveBeenCalledWith('u-1', {
+			reason: 'test',
+		});
+	});
+});
+
+describe('useEndImpersonation', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('ends impersonation', async () => {
+		vi.mocked(usersApi.endImpersonation).mockResolvedValue({ ok: true });
+
+		const { result } = renderHook(() => useEndImpersonation(), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate();
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(usersApi.endImpersonation).toHaveBeenCalledOnce();
+	});
+});
+
+describe('useImpersonationLogs', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fetches impersonation logs', async () => {
+		vi.mocked(usersApi.getImpersonationLogs).mockResolvedValue([]);
+
+		const { result } = renderHook(() => useImpersonationLogs(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(usersApi.getImpersonationLogs).toHaveBeenCalledWith(50, 0);
+	});
+});


### PR DESCRIPTION
## Summary
**Every hook in src/hooks/ now has its own *_test.ts file.** Plus 3 more component tests.

17 hooks tested (agent-written): useBackupCalendar, useBackupHookTemplates, useBackupQueue, useChangelog, useClassifications, useConfigExport, useContainerHooks, useDockerLogs, useDockerRegistries, useDockerRestore, useKomodoIntegration, useSavedFilters, useSetup, useSLA, useSnapshotMounts, useSystemHealth, useUsers.

3 components tested: AirGapIndicator, TrialBanner, SnapshotImmutabilityBadge (sub-variants covered too).

## Metrics
- vitest now **199** test files passing (was 180 after PR #275)
- biome + tsc clean

## Test plan
- [x] vitest clean
- [x] biome clean (470 files)
- [x] tsc --noEmit clean