### PR TITLE
Cover 24 more components

### DIFF
--- a/web/src/components/ErrorBoundary.test.tsx
+++ b/web/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ErrorBoundary } from './ErrorBoundary';
+
+function Boom(): React.ReactElement {
+	throw new Error('boom');
+}
+
+function Ok(): React.ReactElement {
+	return <div>child-ok</div>;
+}
+
+const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+describe('ErrorBoundary', () => {
+	beforeEach(() => {
+		consoleErrorSpy.mockClear();
+	});
+
+	afterEach(() => {
+		consoleErrorSpy.mockClear();
+	});
+
+	it('renders children when no error', () => {
+		render(
+			<MemoryRouter>
+				<ErrorBoundary>
+					<Ok />
+				</ErrorBoundary>
+			</MemoryRouter>,
+		);
+		expect(screen.getByText('child-ok')).toBeDefined();
+	});
+
+	it('renders fallback when child throws', () => {
+		render(
+			<MemoryRouter>
+				<ErrorBoundary fallback={<div>custom-fallback</div>}>
+					<Boom />
+				</ErrorBoundary>
+			</MemoryRouter>,
+		);
+		expect(screen.getByText('custom-fallback')).toBeDefined();
+	});
+
+	it('renders default ServerError fallback when no fallback provided', () => {
+		const { container } = render(
+			<MemoryRouter>
+				<ErrorBoundary>
+					<Boom />
+				</ErrorBoundary>
+			</MemoryRouter>,
+		);
+		// ServerError fallback rendered (replaces Boom child entirely)
+		expect(container.textContent).not.toContain('boom-not-rendered');
+		// Fallback content rendered something (not empty)
+		expect(container.firstChild).not.toBeNull();
+	});
+});

--- a/web/src/components/PasswordExpirationBanner.test.tsx
+++ b/web/src/components/PasswordExpirationBanner.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../hooks/usePasswordPolicy', () => ({
+	usePasswordExpiration: vi.fn(),
+}));
+
+vi.mock('./ChangePasswordForm', () => ({
+	ChangePasswordForm: () => <div data-testid="change-password-form" />,
+}));
+
+import { usePasswordExpiration } from '../hooks/usePasswordPolicy';
+import { PasswordExpirationBanner } from './PasswordExpirationBanner';
+
+function setExpiration(
+	data: unknown,
+	{ isLoading = false }: { isLoading?: boolean } = {},
+) {
+	vi.mocked(usePasswordExpiration).mockReturnValue({
+		data,
+		isLoading,
+	} as never);
+}
+
+describe('PasswordExpirationBanner', () => {
+	it('renders nothing while loading', () => {
+		setExpiration(undefined, { isLoading: true });
+		const { container } = render(<PasswordExpirationBanner />);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders nothing without expiration info', () => {
+		setExpiration(undefined);
+		const { container } = render(<PasswordExpirationBanner />);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders nothing when password is fine', () => {
+		setExpiration({
+			is_expired: false,
+			must_change_now: false,
+			days_until_expiry: 365,
+			warn_days_remaining: 7,
+		});
+		const { container } = render(<PasswordExpirationBanner />);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders blocking modal when password expired', () => {
+		setExpiration({
+			is_expired: true,
+			must_change_now: false,
+			warn_days_remaining: 7,
+		});
+		render(<PasswordExpirationBanner />);
+		expect(screen.getByText('Password Expired')).toBeDefined();
+		expect(screen.getByTestId('change-password-form')).toBeDefined();
+	});
+
+	it('renders blocking modal when admin forced change', () => {
+		setExpiration({
+			is_expired: false,
+			must_change_now: true,
+			warn_days_remaining: 7,
+		});
+		render(<PasswordExpirationBanner />);
+		expect(screen.getByText('Password Change Required')).toBeDefined();
+	});
+
+	it('renders warning banner when expiring soon', () => {
+		setExpiration({
+			is_expired: false,
+			must_change_now: false,
+			days_until_expiry: 3,
+			warn_days_remaining: 7,
+		});
+		render(<PasswordExpirationBanner />);
+		expect(
+			screen.getByText(/Your password will expire in 3 days/),
+		).toBeDefined();
+		expect(screen.getByRole('button', { name: 'Change Now' })).toBeDefined();
+	});
+});

--- a/web/src/components/PasswordRequirements.test.tsx
+++ b/web/src/components/PasswordRequirements.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../hooks/usePasswordPolicy', () => ({
+	usePasswordRequirements: vi.fn(),
+	useValidatePassword: vi.fn(),
+}));
+
+import {
+	usePasswordRequirements,
+	useValidatePassword,
+} from '../hooks/usePasswordPolicy';
+import { PasswordRequirements } from './PasswordRequirements';
+
+function setRequirements(
+	data: unknown,
+	{ isLoading = false }: { isLoading?: boolean } = {},
+) {
+	vi.mocked(usePasswordRequirements).mockReturnValue({
+		data,
+		isLoading,
+	} as never);
+	vi.mocked(useValidatePassword).mockReturnValue({
+		mutate: vi.fn(),
+		isPending: false,
+	} as never);
+}
+
+describe('PasswordRequirements', () => {
+	it('renders skeleton when loading', () => {
+		setRequirements(undefined, { isLoading: true });
+		const { container } = render(<PasswordRequirements password="" />);
+		expect(container.querySelector('.animate-pulse')).not.toBeNull();
+	});
+
+	it('renders nothing when requirements undefined', () => {
+		setRequirements(undefined);
+		const { container } = render(<PasswordRequirements password="" />);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('lists active requirements', () => {
+		setRequirements({
+			min_length: 8,
+			require_uppercase: true,
+			require_lowercase: true,
+			require_number: true,
+			require_special: false,
+		});
+		render(<PasswordRequirements password="" />);
+		expect(screen.getByText('Password Requirements')).toBeDefined();
+		expect(screen.getByText('At least 8 characters')).toBeDefined();
+		expect(screen.getByText('Uppercase letter (A-Z)')).toBeDefined();
+		expect(screen.getByText('Lowercase letter (a-z)')).toBeDefined();
+		expect(screen.getByText('Number (0-9)')).toBeDefined();
+		expect(screen.queryByText('Special character (!@#$%^&*...)')).toBeNull();
+	});
+
+	it('always includes min length even if other rules disabled', () => {
+		setRequirements({
+			min_length: 12,
+			require_uppercase: false,
+			require_lowercase: false,
+			require_number: false,
+			require_special: false,
+		});
+		render(<PasswordRequirements password="abc" />);
+		expect(screen.getByText('At least 12 characters')).toBeDefined();
+	});
+});

--- a/web/src/components/features/DiffViewer.test.tsx
+++ b/web/src/components/features/DiffViewer.test.tsx
@@ -1,0 +1,92 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { FileDiffResponse } from '../../lib/types';
+import { DiffViewer } from './DiffViewer';
+
+function makeDiff(overrides: Partial<FileDiffResponse> = {}): FileDiffResponse {
+	return {
+		path: '/etc/foo.conf',
+		change_type: 'modified',
+		is_binary: false,
+		unified_diff:
+			'--- a/foo\n+++ b/foo\n@@ -1,2 +1,2 @@\n line one\n-removed\n+added\n',
+		old_size: 100,
+		new_size: 110,
+		old_hash: 'abc',
+		new_hash: 'def',
+		snapshot_id_1: 'snap-1',
+		snapshot_id_2: 'snap-2',
+		...overrides,
+	} as FileDiffResponse;
+}
+
+describe('DiffViewer', () => {
+	it('renders path and unified diff content', () => {
+		render(<DiffViewer diff={makeDiff()} />);
+		expect(screen.getByText('/etc/foo.conf')).toBeDefined();
+		expect(screen.getByText('modified')).toBeDefined();
+		expect(screen.getByText('added')).toBeDefined();
+		expect(screen.getByText('removed')).toBeDefined();
+	});
+
+	it('toggles to split view', () => {
+		render(<DiffViewer diff={makeDiff()} />);
+		fireEvent.click(screen.getByRole('button', { name: 'Split' }));
+		// Split view shows snapshot id headers
+		expect(screen.getByText('snap-1')).toBeDefined();
+		expect(screen.getByText('snap-2')).toBeDefined();
+	});
+
+	it('shows binary file notice for binary diffs', () => {
+		render(
+			<DiffViewer
+				diff={makeDiff({
+					is_binary: true,
+					unified_diff: '',
+				})}
+			/>,
+		);
+		expect(screen.getAllByText('Binary file').length).toBeGreaterThan(0);
+		expect(
+			screen.getByText('Content comparison is not available for binary files'),
+		).toBeDefined();
+	});
+
+	it('shows identical message when binary hashes match', () => {
+		render(
+			<DiffViewer
+				diff={makeDiff({
+					is_binary: true,
+					unified_diff: '',
+					old_hash: 'same',
+					new_hash: 'same',
+				})}
+			/>,
+		);
+		expect(screen.getByText('Files are identical')).toBeDefined();
+	});
+
+	it('shows "New file" message when change_type=added and empty diff', () => {
+		render(
+			<DiffViewer
+				diff={makeDiff({
+					change_type: 'added',
+					unified_diff: '',
+				})}
+			/>,
+		);
+		expect(screen.getByText('New file')).toBeDefined();
+	});
+
+	it('shows "Deleted file" message when change_type=removed and empty diff', () => {
+		render(
+			<DiffViewer
+				diff={makeDiff({
+					change_type: 'removed',
+					unified_diff: '',
+				})}
+			/>,
+		);
+		expect(screen.getByText('Deleted file')).toBeDefined();
+	});
+});

--- a/web/src/components/features/DryRunResultsModal.test.tsx
+++ b/web/src/components/features/DryRunResultsModal.test.tsx
@@ -1,0 +1,122 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { DryRunResponse } from '../../lib/types';
+import { DryRunResultsModal } from './DryRunResultsModal';
+
+function makeResults(overrides: Partial<DryRunResponse> = {}): DryRunResponse {
+	return {
+		total_files: 42,
+		total_size: 1024 * 1024,
+		new_files: 10,
+		changed_files: 5,
+		message: 'Dry run complete',
+		files_to_backup: [
+			{ path: '/a/file.txt', type: 'file', action: 'new', size: 1000 },
+			{ path: '/a/dir', type: 'dir', action: 'changed', size: 0 },
+		],
+		excluded_files: [{ path: '*.tmp', reason: 'excluded by pattern' }],
+		...overrides,
+	} as DryRunResponse;
+}
+
+describe('DryRunResultsModal', () => {
+	it('renders nothing when isOpen=false', () => {
+		const { container } = render(
+			<DryRunResultsModal
+				isOpen={false}
+				onClose={() => {}}
+				results={null}
+				isLoading={false}
+				error={null}
+			/>,
+		);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders loading state', () => {
+		render(
+			<DryRunResultsModal
+				isOpen
+				onClose={() => {}}
+				results={null}
+				isLoading
+				error={null}
+			/>,
+		);
+		expect(screen.getByText('Running dry run simulation...')).toBeDefined();
+	});
+
+	it('renders error state', () => {
+		render(
+			<DryRunResultsModal
+				isOpen
+				onClose={() => {}}
+				results={null}
+				isLoading={false}
+				error={new Error('something failed')}
+			/>,
+		);
+		expect(screen.getByText('Dry run failed')).toBeDefined();
+		expect(screen.getByText('something failed')).toBeDefined();
+	});
+
+	it('renders results with summary stats', () => {
+		render(
+			<DryRunResultsModal
+				isOpen
+				onClose={() => {}}
+				results={makeResults()}
+				isLoading={false}
+				error={null}
+			/>,
+		);
+		expect(screen.getByText('42')).toBeDefined();
+		expect(screen.getByText('Total Files')).toBeDefined();
+		expect(screen.getByText('Dry run complete')).toBeDefined();
+		expect(screen.getByText('/a/file.txt')).toBeDefined();
+	});
+
+	it('switches to excluded tab', () => {
+		render(
+			<DryRunResultsModal
+				isOpen
+				onClose={() => {}}
+				results={makeResults()}
+				isLoading={false}
+				error={null}
+			/>,
+		);
+		fireEvent.click(screen.getByRole('button', { name: /Excluded/ }));
+		expect(screen.getByText('*.tmp')).toBeDefined();
+		expect(screen.getByText('excluded by pattern')).toBeDefined();
+	});
+
+	it('fires onClose when close button clicked', () => {
+		const onClose = vi.fn();
+		render(
+			<DryRunResultsModal
+				isOpen
+				onClose={onClose}
+				results={makeResults()}
+				isLoading={false}
+				error={null}
+			/>,
+		);
+		const closeButtons = screen.getAllByRole('button', { name: 'Close' });
+		fireEvent.click(closeButtons[0]);
+		expect(onClose).toHaveBeenCalledOnce();
+	});
+
+	it('shows empty state when no files to backup', () => {
+		render(
+			<DryRunResultsModal
+				isOpen
+				onClose={() => {}}
+				results={makeResults({ files_to_backup: [] })}
+				isLoading={false}
+				error={null}
+			/>,
+		);
+		expect(screen.getByText('No files would be backed up.')).toBeDefined();
+	});
+});

--- a/web/src/components/features/FeatureGate.test.tsx
+++ b/web/src/components/features/FeatureGate.test.tsx
@@ -1,0 +1,161 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../hooks/useLicenses', () => ({
+	useCurrentLicense: vi.fn(),
+	useLicensePurchaseUrl: vi.fn(() => ({ data: undefined })),
+}));
+
+import {
+	useCurrentLicense,
+	useLicensePurchaseUrl,
+} from '../../hooks/useLicenses';
+import {
+	FeatureCheck,
+	FeatureDisabledButton,
+	FeatureGate,
+	ProBadge,
+} from './FeatureGate';
+
+function setLicense(license: unknown, isLoading = false) {
+	vi.mocked(useCurrentLicense).mockReturnValue({
+		data: license,
+		isLoading,
+	} as never);
+	vi.mocked(useLicensePurchaseUrl).mockReturnValue({
+		data: undefined,
+	} as never);
+}
+
+function withRouter(ui: React.ReactNode) {
+	return <MemoryRouter>{ui}</MemoryRouter>;
+}
+
+describe('FeatureGate', () => {
+	it('renders children while loading', () => {
+		setLicense(undefined, true);
+		render(
+			withRouter(
+				<FeatureGate feature="sso">
+					<span>gated content</span>
+				</FeatureGate>,
+			),
+		);
+		expect(screen.getByText('gated content')).toBeDefined();
+	});
+
+	it('renders children when feature is in license', () => {
+		setLicense({ features: ['oidc'], limits: {} });
+		render(
+			withRouter(
+				<FeatureGate feature="sso">
+					<span>gated content</span>
+				</FeatureGate>,
+			),
+		);
+		expect(screen.getByText('gated content')).toBeDefined();
+	});
+
+	it('renders default upgrade prompt when feature missing', () => {
+		setLicense({ features: [], limits: {} });
+		render(
+			withRouter(
+				<FeatureGate feature="sso">
+					<span>gated content</span>
+				</FeatureGate>,
+			),
+		);
+		expect(screen.getByText('Pro Feature')).toBeDefined();
+		expect(screen.getByText('Single Sign-On')).toBeDefined();
+	});
+
+	it('renders custom fallback when provided', () => {
+		setLicense({ features: [], limits: {} });
+		render(
+			withRouter(
+				<FeatureGate feature="sso" fallback={<span>custom fallback</span>}>
+					<span>gated</span>
+				</FeatureGate>,
+			),
+		);
+		expect(screen.getByText('custom fallback')).toBeDefined();
+		expect(screen.queryByText('Pro Feature')).toBeNull();
+	});
+});
+
+describe('ProBadge', () => {
+	it('renders nothing while loading', () => {
+		setLicense(undefined, true);
+		const { container } = render(<ProBadge feature="sso" />);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders nothing when feature available', () => {
+		setLicense({ features: ['oidc'], limits: {} });
+		const { container } = render(<ProBadge feature="sso" />);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders Pro badge when feature missing', () => {
+		setLicense({ features: [], limits: {} });
+		render(<ProBadge feature="sso" />);
+		expect(screen.getByText('Pro')).toBeDefined();
+	});
+
+	it('renders feature label when showLabel=true', () => {
+		setLicense({ features: [], limits: {} });
+		render(<ProBadge feature="sso" showLabel />);
+		expect(screen.getByText('Single Sign-On')).toBeDefined();
+	});
+});
+
+describe('FeatureDisabledButton', () => {
+	it('renders enabled button when feature available', () => {
+		setLicense({ features: ['oidc'], limits: {} });
+		render(
+			<FeatureDisabledButton feature="sso">Click me</FeatureDisabledButton>,
+		);
+		const btn = screen.getByRole('button', { name: /Click me/ });
+		expect(btn).not.toBeDisabled();
+	});
+
+	it('renders disabled button when feature missing', () => {
+		setLicense({ features: [], limits: {} });
+		render(
+			<FeatureDisabledButton feature="sso">Click me</FeatureDisabledButton>,
+		);
+		const btn = screen.getByRole('button', { name: /Click me/ });
+		expect(btn).toBeDisabled();
+	});
+});
+
+describe('FeatureCheck', () => {
+	it('passes hasFeature=true when feature available', () => {
+		setLicense({ features: ['oidc'], limits: {} });
+		render(
+			<FeatureCheck feature="sso">
+				{(has, label) => (
+					<span>
+						{label}: {has ? 'yes' : 'no'}
+					</span>
+				)}
+			</FeatureCheck>,
+		);
+		expect(screen.getByText('Single Sign-On: yes')).toBeDefined();
+	});
+
+	it('passes hasFeature=false when feature missing', () => {
+		setLicense({ features: [], limits: {} });
+		render(
+			<FeatureCheck feature="sso">
+				{(has, label) => (
+					<span>
+						{label}: {has ? 'yes' : 'no'}
+					</span>
+				)}
+			</FeatureCheck>,
+		);
+		expect(screen.getByText('Single Sign-On: no')).toBeDefined();
+	});
+});

--- a/web/src/components/features/GeoReplicationStatusCard.test.tsx
+++ b/web/src/components/features/GeoReplicationStatusCard.test.tsx
@@ -1,0 +1,110 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { GeoReplicationConfig, Repository } from '../../lib/types';
+import { GeoReplicationStatusCard } from './GeoReplicationStatusCard';
+
+const repositories: Repository[] = [
+	{ id: 'r1', name: 'Primary Repo' } as Repository,
+	{ id: 'r2', name: 'Secondary Repo' } as Repository,
+];
+
+function makeConfig(
+	overrides: Partial<GeoReplicationConfig> = {},
+): GeoReplicationConfig {
+	return {
+		id: 'gc-1',
+		source_repository_id: 'r1',
+		target_repository_id: 'r2',
+		source_region: { display_name: 'us-east-1' },
+		target_region: { display_name: 'us-west-2' },
+		status: 'synced',
+		enabled: true,
+		max_lag_snapshots: 5,
+		max_lag_duration_hours: 24,
+		last_sync_at: new Date(Date.now() - 60_000).toISOString(),
+		...overrides,
+	} as GeoReplicationConfig;
+}
+
+describe('GeoReplicationStatusCard', () => {
+	it('renders empty state when no configs', () => {
+		render(
+			<GeoReplicationStatusCard configs={[]} repositories={repositories} />,
+		);
+		expect(screen.getByText('Geo-Replication Status')).toBeDefined();
+		expect(screen.getByText(/No geo-replication configured/)).toBeDefined();
+	});
+
+	it('renders config with source -> target names', () => {
+		render(
+			<GeoReplicationStatusCard
+				configs={[makeConfig()]}
+				repositories={repositories}
+			/>,
+		);
+		expect(screen.getByText('Primary Repo')).toBeDefined();
+		expect(screen.getByText('Secondary Repo')).toBeDefined();
+		expect(screen.getByText('Synced')).toBeDefined();
+	});
+
+	it('falls back to Unknown when repo not found', () => {
+		render(
+			<GeoReplicationStatusCard
+				configs={[makeConfig({ source_repository_id: 'missing' })]}
+				repositories={repositories}
+			/>,
+		);
+		expect(screen.getByText('Unknown')).toBeDefined();
+	});
+
+	it('fires onToggleEnabled when toggle button clicked', () => {
+		const onToggle = vi.fn();
+		render(
+			<GeoReplicationStatusCard
+				configs={[makeConfig()]}
+				repositories={repositories}
+				onToggleEnabled={onToggle}
+			/>,
+		);
+		fireEvent.click(
+			screen.getByRole('button', { name: 'Disable replication' }),
+		);
+		expect(onToggle).toHaveBeenCalledWith('gc-1', false);
+	});
+
+	it('fires onTriggerReplication when sync now clicked', () => {
+		const onTrigger = vi.fn();
+		render(
+			<GeoReplicationStatusCard
+				configs={[makeConfig()]}
+				repositories={repositories}
+				onTriggerReplication={onTrigger}
+			/>,
+		);
+		fireEvent.click(screen.getByRole('button', { name: 'Trigger sync now' }));
+		expect(onTrigger).toHaveBeenCalledWith('gc-1');
+	});
+
+	it('hides trigger button when status=syncing', () => {
+		render(
+			<GeoReplicationStatusCard
+				configs={[makeConfig({ status: 'syncing' })]}
+				repositories={repositories}
+				onTriggerReplication={vi.fn()}
+			/>,
+		);
+		expect(
+			screen.queryByRole('button', { name: 'Trigger sync now' }),
+		).toBeNull();
+	});
+
+	it('shows last_error when present', () => {
+		render(
+			<GeoReplicationStatusCard
+				configs={[makeConfig({ last_error: 'Network timeout' })]}
+				repositories={repositories}
+			/>,
+		);
+		expect(screen.getByText('Network timeout')).toBeDefined();
+	});
+});

--- a/web/src/components/features/KeyboardShortcutsSettings.test.tsx
+++ b/web/src/components/features/KeyboardShortcutsSettings.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { ShortcutDefinition } from '../../hooks/useKeyboardShortcuts';
+
+vi.mock('../../hooks/useLocale', () => ({
+	useLocale: () => ({
+		t: (key: string, ..._args: unknown[]) => key,
+	}),
+}));
+
+vi.mock('../../hooks/useKeyboardShortcuts', () => ({
+	useKeyboardShortcuts: vi.fn(),
+}));
+
+import { useKeyboardShortcuts } from '../../hooks/useKeyboardShortcuts';
+import { KeyboardShortcutsSettings } from './KeyboardShortcutsSettings';
+
+const shortcuts: ShortcutDefinition[] = [
+	{
+		keys: ['g', 'd'],
+		action: 'goToDashboard',
+		description: 'Go to Dashboard',
+		category: 'navigation',
+	},
+	{
+		keys: ['/'],
+		action: 'focusSearch',
+		description: 'Focus search',
+		category: 'actions',
+	},
+	{
+		keys: ['?'],
+		action: 'showHelp',
+		description: 'Show help',
+		category: 'general',
+	},
+];
+
+function setMocks({
+	customShortcuts = {} as Record<string, string[]>,
+}: { customShortcuts?: Record<string, string[]> } = {}) {
+	vi.mocked(useKeyboardShortcuts).mockReturnValue({
+		shortcuts,
+		customShortcuts,
+		updateCustomShortcut: vi.fn(),
+		resetShortcut: vi.fn(),
+		resetAllShortcuts: vi.fn(),
+	} as never);
+}
+
+describe('KeyboardShortcutsSettings', () => {
+	it('renders nothing when closed', () => {
+		setMocks();
+		const { container } = render(
+			<KeyboardShortcutsSettings isOpen={false} onClose={() => {}} />,
+		);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders title and section headers when open', () => {
+		setMocks();
+		render(<KeyboardShortcutsSettings isOpen={true} onClose={() => {}} />);
+		expect(screen.getByText('shortcuts.customizeTitle')).toBeDefined();
+		expect(screen.getByText('shortcuts.navigation')).toBeDefined();
+		expect(screen.getByText('shortcuts.actionsSection')).toBeDefined();
+		expect(screen.getByText('shortcuts.general')).toBeDefined();
+	});
+
+	it('shows Reset All button when custom shortcuts exist', () => {
+		setMocks({ customShortcuts: { goToDashboard: ['g', 'x'] } });
+		render(<KeyboardShortcutsSettings isOpen={true} onClose={() => {}} />);
+		expect(
+			screen.getByRole('button', { name: 'shortcuts.resetAll' }),
+		).toBeDefined();
+	});
+
+	it('hides Reset All button when no custom shortcuts', () => {
+		setMocks();
+		render(<KeyboardShortcutsSettings isOpen={true} onClose={() => {}} />);
+		expect(
+			screen.queryByRole('button', { name: 'shortcuts.resetAll' }),
+		).toBeNull();
+	});
+
+	it('fires onClose when Done clicked', () => {
+		setMocks();
+		const onClose = vi.fn();
+		render(<KeyboardShortcutsSettings isOpen={true} onClose={onClose} />);
+		screen.getByRole('button', { name: 'common.done' }).click();
+		expect(onClose).toHaveBeenCalledOnce();
+	});
+});

--- a/web/src/components/features/LicenseBanner.test.tsx
+++ b/web/src/components/features/LicenseBanner.test.tsx
@@ -1,0 +1,125 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../hooks/useLicenses', () => ({
+	useLicensePurchaseUrl: vi.fn(),
+	useLicenseWarnings: vi.fn(),
+}));
+
+import {
+	useLicensePurchaseUrl,
+	useLicenseWarnings,
+} from '../../hooks/useLicenses';
+import { LicenseBanner } from './LicenseBanner';
+
+function setMocks({
+	warnings,
+	purchaseUrl,
+	isLoading = false,
+}: {
+	warnings?: unknown;
+	purchaseUrl?: string;
+	isLoading?: boolean;
+}) {
+	vi.mocked(useLicenseWarnings).mockReturnValue({
+		data: warnings ? { warnings } : undefined,
+		isLoading,
+	} as never);
+	vi.mocked(useLicensePurchaseUrl).mockReturnValue({
+		data: purchaseUrl ? { url: purchaseUrl } : undefined,
+	} as never);
+}
+
+function renderInRouter(ui: React.ReactElement) {
+	return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+describe('LicenseBanner', () => {
+	it('renders nothing while loading', () => {
+		setMocks({ isLoading: true });
+		const { container } = renderInRouter(<LicenseBanner />);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders nothing when warnings undefined', () => {
+		setMocks({});
+		const { container } = renderInRouter(<LicenseBanner />);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders expired blocking modal when expired + no grace', () => {
+		setMocks({
+			warnings: {
+				expiration: { is_expired: true, is_in_grace_period: false },
+				limits: [],
+			},
+			purchaseUrl: 'https://buy.example.com',
+		});
+		renderInRouter(<LicenseBanner />);
+		expect(screen.getByText('License Expired')).toBeDefined();
+		expect(screen.getByText('Renew License')).toBeDefined();
+	});
+
+	it('renders grace period banner', () => {
+		const grace = new Date(Date.now() + 5 * 86_400_000).toISOString();
+		setMocks({
+			warnings: {
+				expiration: {
+					is_expired: true,
+					is_in_grace_period: true,
+					grace_period_ends_at: grace,
+				},
+				limits: [],
+			},
+		});
+		renderInRouter(<LicenseBanner />);
+		expect(
+			screen.getByText(/License Expired - Grace Period Active/),
+		).toBeDefined();
+	});
+
+	it('renders expiring soon banner', () => {
+		setMocks({
+			warnings: {
+				expiration: {
+					is_expired: false,
+					is_in_grace_period: false,
+					days_until_expiry: 5,
+				},
+				limits: [],
+			},
+		});
+		renderInRouter(<LicenseBanner />);
+		expect(
+			screen.getByText(/Your license will expire in 5 days/),
+		).toBeDefined();
+	});
+
+	it('renders critical limits banner', () => {
+		setMocks({
+			warnings: {
+				expiration: null,
+				limits: [{ type: 'agents', percentage: 95, current: 95, limit: 100 }],
+			},
+		});
+		renderInRouter(<LicenseBanner />);
+		expect(screen.getByText('Limit Reached!')).toBeDefined();
+		expect(screen.getByText(/95% of your agents limit/)).toBeDefined();
+	});
+
+	it('renders nothing when no actionable conditions', () => {
+		setMocks({
+			warnings: {
+				expiration: {
+					is_expired: false,
+					is_in_grace_period: false,
+					days_until_expiry: 120,
+				},
+				limits: [{ type: 'agents', percentage: 10, current: 1, limit: 10 }],
+			},
+		});
+		const { container } = renderInRouter(<LicenseBanner />);
+		expect(container.firstChild).toBeNull();
+	});
+});

--- a/web/src/components/features/MaintenanceCountdown.test.tsx
+++ b/web/src/components/features/MaintenanceCountdown.test.tsx
@@ -1,0 +1,139 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../hooks/useAuth', () => ({
+	useMe: vi.fn(),
+}));
+
+vi.mock('../../hooks/useMaintenance', () => ({
+	useActiveMaintenance: vi.fn(),
+	useEmergencyOverride: vi.fn(),
+}));
+
+import { useMe } from '../../hooks/useAuth';
+import {
+	useActiveMaintenance,
+	useEmergencyOverride,
+} from '../../hooks/useMaintenance';
+import { MaintenanceCountdown } from './MaintenanceCountdown';
+
+const overrideMutate = vi.fn();
+
+function setMocks({
+	role = 'member',
+	maintenance = null as unknown,
+	overridePending = false,
+}: {
+	role?: string;
+	maintenance?: unknown;
+	overridePending?: boolean;
+} = {}) {
+	vi.mocked(useMe).mockReturnValue({
+		data: { current_org_role: role },
+	} as never);
+	vi.mocked(useActiveMaintenance).mockReturnValue({
+		data: maintenance,
+	} as never);
+	vi.mocked(useEmergencyOverride).mockReturnValue({
+		mutate: overrideMutate,
+		isPending: overridePending,
+	} as never);
+}
+
+describe('MaintenanceCountdown', () => {
+	it('renders nothing when no maintenance', () => {
+		setMocks();
+		const { container } = render(<MaintenanceCountdown />);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders nothing when only countdown but no active/upcoming', () => {
+		setMocks({
+			maintenance: {
+				active: null,
+				upcoming: null,
+				show_countdown: true,
+				countdown_to: new Date(Date.now() + 60_000).toISOString(),
+			},
+		});
+		const { container } = render(<MaintenanceCountdown />);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders active maintenance banner', () => {
+		setMocks({
+			maintenance: {
+				active: {
+					id: 'm1',
+					title: 'DB migration',
+					message: 'Brief outage',
+					ends_at: new Date(Date.now() + 60 * 60_000).toISOString(),
+				},
+				upcoming: null,
+				read_only_mode: false,
+			},
+		});
+		render(<MaintenanceCountdown />);
+		expect(screen.getByText(/Maintenance in progress/)).toBeDefined();
+		expect(screen.getByText('DB migration')).toBeDefined();
+	});
+
+	it('renders read-only banner with override button for admin', () => {
+		setMocks({
+			role: 'admin',
+			maintenance: {
+				active: {
+					id: 'm1',
+					title: 'Locked window',
+					message: '',
+					ends_at: new Date(Date.now() + 60 * 60_000).toISOString(),
+				},
+				upcoming: null,
+				read_only_mode: true,
+			},
+		});
+		render(<MaintenanceCountdown />);
+		expect(screen.getByText(/Read-only mode active/)).toBeDefined();
+		expect(
+			screen.getByRole('button', { name: 'Emergency Override' }),
+		).toBeDefined();
+	});
+
+	it('hides override button for non-admin', () => {
+		setMocks({
+			role: 'member',
+			maintenance: {
+				active: {
+					id: 'm1',
+					title: 'Locked window',
+					message: '',
+					ends_at: new Date(Date.now() + 60 * 60_000).toISOString(),
+				},
+				upcoming: null,
+				read_only_mode: true,
+			},
+		});
+		render(<MaintenanceCountdown />);
+		expect(
+			screen.queryByRole('button', { name: 'Emergency Override' }),
+		).toBeNull();
+	});
+
+	it('renders upcoming maintenance banner', () => {
+		setMocks({
+			maintenance: {
+				active: null,
+				upcoming: {
+					id: 'm1',
+					title: 'Planned outage',
+					message: 'Coming soon',
+					starts_at: new Date(Date.now() + 60 * 60_000).toISOString(),
+				},
+				read_only_mode: false,
+			},
+		});
+		render(<MaintenanceCountdown />);
+		expect(screen.getByText(/Scheduled maintenance/)).toBeDefined();
+		expect(screen.getByText('Planned outage')).toBeDefined();
+	});
+});

--- a/web/src/components/features/RegionMapIndicator.test.tsx
+++ b/web/src/components/features/RegionMapIndicator.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type {
+	GeoRegion,
+	GeoReplicationConfig,
+	GeoReplicationStatusType,
+} from '../../lib/types';
+import { RegionMapIndicator } from './RegionMapIndicator';
+
+function region(overrides: Partial<GeoRegion> = {}): GeoRegion {
+	return {
+		code: 'us-east-1',
+		name: 'us-east-1',
+		display_name: 'US East',
+		latitude: 0,
+		longitude: 0,
+		...overrides,
+	};
+}
+
+function config(
+	overrides: Partial<GeoReplicationConfig> = {},
+): GeoReplicationConfig {
+	return {
+		id: 'c1',
+		source_repository_id: 's1',
+		target_repository_id: 't1',
+		source_region: region({ code: 'us-east-1' }),
+		target_region: region({ code: 'eu-west-1', display_name: 'EU West' }),
+		enabled: true,
+		status: 'synced' as GeoReplicationStatusType,
+		max_lag_snapshots: 0,
+		max_lag_duration_hours: 0,
+		alert_on_lag: false,
+		created_at: '',
+		updated_at: '',
+		...overrides,
+	};
+}
+
+describe('RegionMapIndicator', () => {
+	it('renders empty message when no active configs', () => {
+		render(<RegionMapIndicator configs={[]} />);
+		expect(screen.getByText('No geo-replication configured')).toBeDefined();
+	});
+
+	it('renders empty message when all configs are disabled', () => {
+		render(<RegionMapIndicator configs={[config({ enabled: false })]} />);
+		expect(screen.getByText('No geo-replication configured')).toBeDefined();
+	});
+
+	it('renders compact summary when compact=true', () => {
+		render(
+			<RegionMapIndicator
+				compact
+				configs={[
+					config({ id: 'a', status: 'synced' }),
+					config({ id: 'b', status: 'syncing' }),
+					config({ id: 'c', status: 'failed' }),
+				]}
+			/>,
+		);
+		expect(screen.getByText('1 synced')).toBeDefined();
+		expect(screen.getByText('1 syncing')).toBeDefined();
+		expect(screen.getByText('1 failed')).toBeDefined();
+	});
+
+	it('renders full map title and legend when not compact', () => {
+		render(<RegionMapIndicator configs={[config()]} />);
+		expect(screen.getByText('Geo-Replication Map')).toBeDefined();
+		expect(screen.getByText('Synced')).toBeDefined();
+		expect(screen.getByText('Pending')).toBeDefined();
+	});
+});

--- a/web/src/components/features/SaveFilterButton.test.tsx
+++ b/web/src/components/features/SaveFilterButton.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../hooks/useSavedFilters', () => ({
+	useCreateSavedFilter: vi.fn(),
+}));
+
+import { useCreateSavedFilter } from '../../hooks/useSavedFilters';
+import { SaveFilterButton } from './SaveFilterButton';
+
+const mutateAsync = vi.fn();
+
+function setMocks({ isPending = false }: { isPending?: boolean } = {}) {
+	vi.mocked(useCreateSavedFilter).mockReturnValue({
+		mutateAsync,
+		isPending,
+	} as never);
+}
+
+describe('SaveFilterButton', () => {
+	it('renders nothing when no meaningful filters set', () => {
+		setMocks();
+		const { container } = render(
+			<SaveFilterButton entityType="agents" filters={{}} />,
+		);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders nothing when all filter values are empty/default', () => {
+		setMocks();
+		const { container } = render(
+			<SaveFilterButton
+				entityType="agents"
+				filters={{ status: '', priority: 'all', region: null }}
+			/>,
+		);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders Save Filter button when filters present', () => {
+		setMocks();
+		render(
+			<SaveFilterButton entityType="agents" filters={{ status: 'active' }} />,
+		);
+		expect(screen.getByRole('button', { name: /Save Filter/ })).toBeDefined();
+	});
+
+	it('opens modal when button clicked', async () => {
+		setMocks();
+		const user = userEvent.setup();
+		render(
+			<SaveFilterButton entityType="agents" filters={{ status: 'active' }} />,
+		);
+		await user.click(screen.getByRole('button', { name: /Save Filter/ }));
+		expect(screen.getByText('Save Current Filter')).toBeDefined();
+		expect(screen.getByLabelText('Filter Name')).toBeDefined();
+	});
+
+	it('disables Save Filter trigger when disabled prop true', () => {
+		setMocks();
+		render(
+			<SaveFilterButton
+				entityType="agents"
+				filters={{ status: 'active' }}
+				disabled
+			/>,
+		);
+		expect(screen.getByRole('button', { name: /Save Filter/ })).toBeDisabled();
+	});
+});

--- a/web/src/components/features/SavedFiltersDropdown.test.tsx
+++ b/web/src/components/features/SavedFiltersDropdown.test.tsx
@@ -1,0 +1,123 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import type { SavedFilter } from '../../lib/types';
+
+vi.mock('../../hooks/useAuth', () => ({
+	useMe: vi.fn(),
+}));
+
+vi.mock('../../hooks/useSavedFilters', () => ({
+	useSavedFilters: vi.fn(),
+	useDeleteSavedFilter: vi.fn(),
+	useUpdateSavedFilter: vi.fn(),
+}));
+
+import { useMe } from '../../hooks/useAuth';
+import {
+	useDeleteSavedFilter,
+	useSavedFilters,
+	useUpdateSavedFilter,
+} from '../../hooks/useSavedFilters';
+import { SavedFiltersDropdown } from './SavedFiltersDropdown';
+
+function makeFilter(overrides: Partial<SavedFilter> = {}): SavedFilter {
+	return {
+		id: 'f1',
+		user_id: 'u1',
+		name: 'My filter',
+		entity_type: 'agents',
+		filters: {},
+		shared: false,
+		is_default: false,
+		created_at: '',
+		updated_at: '',
+		...overrides,
+	} as SavedFilter;
+}
+
+function setMocks(filters: SavedFilter[] | undefined, userId = 'u1') {
+	vi.mocked(useMe).mockReturnValue({ data: { id: userId } } as never);
+	vi.mocked(useSavedFilters).mockReturnValue({
+		data: filters,
+		isLoading: false,
+	} as never);
+	vi.mocked(useDeleteSavedFilter).mockReturnValue({
+		mutateAsync: vi.fn(),
+	} as never);
+	vi.mocked(useUpdateSavedFilter).mockReturnValue({
+		mutateAsync: vi.fn(),
+	} as never);
+}
+
+describe('SavedFiltersDropdown', () => {
+	it('renders nothing when no filters', () => {
+		setMocks([]);
+		const { container } = render(
+			<SavedFiltersDropdown entityType="agents" onApplyFilter={() => {}} />,
+		);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders nothing when filters undefined', () => {
+		setMocks(undefined);
+		const { container } = render(
+			<SavedFiltersDropdown entityType="agents" onApplyFilter={() => {}} />,
+		);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders dropdown trigger when filters present', () => {
+		setMocks([makeFilter()]);
+		render(
+			<SavedFiltersDropdown entityType="agents" onApplyFilter={() => {}} />,
+		);
+		expect(screen.getByRole('button', { name: /Saved Filters/ })).toBeDefined();
+	});
+
+	it('opens menu and shows My Filters section', async () => {
+		setMocks([makeFilter({ name: 'Mine' })]);
+		const user = userEvent.setup();
+		render(
+			<SavedFiltersDropdown entityType="agents" onApplyFilter={() => {}} />,
+		);
+		await user.click(screen.getByRole('button', { name: /Saved Filters/ }));
+		expect(screen.getByText('My Filters')).toBeDefined();
+		expect(screen.getByText('Mine')).toBeDefined();
+	});
+
+	it('shows Shared Filters section when other-owned filters are shared', async () => {
+		setMocks([
+			makeFilter({ id: 'a', name: 'Mine' }),
+			makeFilter({
+				id: 'b',
+				user_id: 'someone-else',
+				name: 'Theirs',
+				shared: true,
+			}),
+		]);
+		const user = userEvent.setup();
+		render(
+			<SavedFiltersDropdown entityType="agents" onApplyFilter={() => {}} />,
+		);
+		await user.click(screen.getByRole('button', { name: /Saved Filters/ }));
+		expect(screen.getByText('Shared Filters')).toBeDefined();
+		expect(screen.getByText('Theirs')).toBeDefined();
+	});
+
+	it('applies a filter when clicked', async () => {
+		const onApplyFilter = vi.fn();
+		const filter = makeFilter({ filters: { status: 'active' } });
+		setMocks([filter]);
+		const user = userEvent.setup();
+		render(
+			<SavedFiltersDropdown
+				entityType="agents"
+				onApplyFilter={onApplyFilter}
+			/>,
+		);
+		await user.click(screen.getByRole('button', { name: /Saved Filters/ }));
+		await user.click(screen.getByText('My filter'));
+		expect(onApplyFilter).toHaveBeenCalledWith({ status: 'active' });
+	});
+});

--- a/web/src/components/features/ShortcutHelpModal.test.tsx
+++ b/web/src/components/features/ShortcutHelpModal.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { ShortcutDefinition } from '../../hooks/useKeyboardShortcuts';
+
+vi.mock('../../hooks/useLocale', () => ({
+	useLocale: () => ({
+		t: (key: string, ..._args: unknown[]) => key,
+	}),
+}));
+
+import { ShortcutHelpModal } from './ShortcutHelpModal';
+
+const shortcuts: ShortcutDefinition[] = [
+	{
+		keys: ['g', 'd'],
+		action: 'goToDashboard',
+		description: 'Go to Dashboard',
+		category: 'navigation',
+	},
+	{
+		keys: ['/'],
+		action: 'focusSearch',
+		description: 'Focus search',
+		category: 'actions',
+	},
+	{
+		keys: ['?'],
+		action: 'showHelp',
+		description: 'Show help',
+		category: 'general',
+	},
+];
+
+describe('ShortcutHelpModal', () => {
+	it('renders nothing when closed', () => {
+		const { container } = render(
+			<ShortcutHelpModal
+				isOpen={false}
+				onClose={() => {}}
+				shortcuts={shortcuts}
+			/>,
+		);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders modal title and sections when open', () => {
+		render(
+			<ShortcutHelpModal
+				isOpen={true}
+				onClose={() => {}}
+				shortcuts={shortcuts}
+			/>,
+		);
+		expect(screen.getByText('shortcuts.title')).toBeDefined();
+		expect(screen.getByText('shortcuts.navigation')).toBeDefined();
+		expect(screen.getByText('shortcuts.actionsSection')).toBeDefined();
+		expect(screen.getByText('shortcuts.general')).toBeDefined();
+	});
+
+	it('renders kbd elements for each shortcut key', () => {
+		const { container } = render(
+			<ShortcutHelpModal
+				isOpen={true}
+				onClose={() => {}}
+				shortcuts={shortcuts}
+			/>,
+		);
+		const kbds = container.querySelectorAll('kbd');
+		expect(kbds.length).toBeGreaterThan(0);
+	});
+
+	it('fires onClose when close button clicked', () => {
+		const onClose = vi.fn();
+		render(
+			<ShortcutHelpModal
+				isOpen={true}
+				onClose={onClose}
+				shortcuts={shortcuts}
+			/>,
+		);
+		screen.getByRole('button', { name: 'common.close' }).click();
+		expect(onClose).toHaveBeenCalledOnce();
+	});
+});

--- a/web/src/components/features/WhatsNewModal.test.tsx
+++ b/web/src/components/features/WhatsNewModal.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ChangelogEntry } from '../../lib/types';
+import { WhatsNewModal } from './WhatsNewModal';
+
+function renderInRouter(ui: React.ReactElement) {
+	return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+const sampleEntry: ChangelogEntry = {
+	version: '1.2.3',
+	date: '2026-05-26',
+	added: ['Cool feature'],
+	changed: ['Improved foo'],
+	fixed: ['Fixed bar'],
+} as ChangelogEntry;
+
+describe('WhatsNewModal', () => {
+	beforeEach(() => {
+		localStorage.clear();
+	});
+
+	it('renders nothing when entry is null', () => {
+		const { container } = renderInRouter(
+			<WhatsNewModal
+				entry={null}
+				currentVersion="1.2.3"
+				onDismiss={() => {}}
+			/>,
+		);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders nothing when currentVersion undefined', () => {
+		const { container } = renderInRouter(
+			<WhatsNewModal
+				entry={sampleEntry}
+				currentVersion={undefined}
+				onDismiss={() => {}}
+			/>,
+		);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders modal with version header when version is unseen', () => {
+		renderInRouter(
+			<WhatsNewModal
+				entry={sampleEntry}
+				currentVersion="1.2.3"
+				onDismiss={() => {}}
+			/>,
+		);
+		expect(screen.getByText('Keldris v1.2.3')).toBeDefined();
+		expect(screen.getByText('New Features')).toBeDefined();
+		expect(screen.getByText('Cool feature')).toBeDefined();
+	});
+
+	it('renders nothing when version already seen', () => {
+		localStorage.setItem('keldris_seen_version', '1.2.3');
+		const { container } = renderInRouter(
+			<WhatsNewModal
+				entry={sampleEntry}
+				currentVersion="1.2.3"
+				onDismiss={() => {}}
+			/>,
+		);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders fallback copy when no changes are listed', () => {
+		renderInRouter(
+			<WhatsNewModal
+				entry={{ version: '2.0.0', date: '' } as ChangelogEntry}
+				currentVersion="2.0.0"
+				onDismiss={() => {}}
+			/>,
+		);
+		expect(
+			screen.getByText(
+				'This release includes various improvements and bug fixes.',
+			),
+		).toBeDefined();
+	});
+
+	it('fires onDismiss when Got it clicked', () => {
+		const onDismiss = vi.fn();
+		renderInRouter(
+			<WhatsNewModal
+				entry={sampleEntry}
+				currentVersion="1.2.3"
+				onDismiss={onDismiss}
+			/>,
+		);
+		screen.getByRole('button', { name: 'Got it' }).click();
+		expect(onDismiss).toHaveBeenCalledOnce();
+		expect(localStorage.getItem('keldris_seen_version')).toBe('1.2.3');
+	});
+});

--- a/web/src/components/ui/BulkActions.test.tsx
+++ b/web/src/components/ui/BulkActions.test.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { type BulkAction, BulkActionButton, BulkActions } from './BulkActions';
+
+const actions: BulkAction[] = [
+	{ id: 'delete', label: 'Delete', variant: 'danger' },
+	{ id: 'export', label: 'Export' },
+	{ id: 'disabled-action', label: 'Disabled', disabled: true },
+];
+
+describe('BulkActions', () => {
+	it('renders label and toggles menu open', () => {
+		render(<BulkActions actions={actions} onAction={() => {}} />);
+		const trigger = screen.getByRole('button', { name: /Actions/i });
+		expect(trigger).toBeDefined();
+		fireEvent.click(trigger);
+		expect(screen.getByRole('button', { name: 'Delete' })).toBeDefined();
+		expect(screen.getByRole('button', { name: 'Export' })).toBeDefined();
+	});
+
+	it('uses custom label', () => {
+		render(
+			<BulkActions actions={actions} onAction={() => {}} label="Do Stuff" />,
+		);
+		expect(screen.getByRole('button', { name: /Do Stuff/i })).toBeDefined();
+	});
+
+	it('fires onAction with action id when clicked', () => {
+		const onAction = vi.fn();
+		render(<BulkActions actions={actions} onAction={onAction} />);
+		fireEvent.click(screen.getByRole('button', { name: /Actions/i }));
+		fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+		expect(onAction).toHaveBeenCalledWith('delete');
+	});
+
+	it('disables trigger when disabled=true', () => {
+		render(<BulkActions actions={actions} onAction={() => {}} disabled />);
+		expect(screen.getByRole('button', { name: /Actions/i })).toBeDisabled();
+	});
+
+	it('disables actions marked disabled', () => {
+		render(<BulkActions actions={actions} onAction={() => {}} />);
+		fireEvent.click(screen.getByRole('button', { name: /Actions/i }));
+		expect(screen.getByRole('button', { name: 'Disabled' })).toBeDisabled();
+	});
+});
+
+describe('BulkActionButton', () => {
+	it('renders label and fires onClick', () => {
+		const onClick = vi.fn();
+		render(<BulkActionButton label="Run" onClick={onClick} />);
+		const btn = screen.getByRole('button', { name: 'Run' });
+		btn.click();
+		expect(onClick).toHaveBeenCalledOnce();
+	});
+
+	it('renders danger variant', () => {
+		render(
+			<BulkActionButton label="Delete" onClick={() => {}} variant="danger" />,
+		);
+		const btn = screen.getByRole('button', { name: 'Delete' });
+		expect(btn.className).toContain('bg-red-600');
+	});
+
+	it('renders primary variant', () => {
+		render(
+			<BulkActionButton label="Save" onClick={() => {}} variant="primary" />,
+		);
+		const btn = screen.getByRole('button', { name: 'Save' });
+		expect(btn.className).toContain('bg-indigo-600');
+	});
+
+	it('disables button when disabled=true', () => {
+		render(<BulkActionButton label="Run" onClick={() => {}} disabled />);
+		expect(screen.getByRole('button', { name: 'Run' })).toBeDisabled();
+	});
+});

--- a/web/src/components/ui/BulkOperationProgress.test.tsx
+++ b/web/src/components/ui/BulkOperationProgress.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import {
+	BulkOperationProgress,
+	type BulkOperationResult,
+} from './BulkOperationProgress';
+
+describe('BulkOperationProgress', () => {
+	it('renders nothing when isOpen=false', () => {
+		const { container } = render(
+			<BulkOperationProgress
+				isOpen={false}
+				onClose={() => {}}
+				title="Deleting"
+				total={5}
+				completed={0}
+				results={[]}
+				isComplete={false}
+			/>,
+		);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders title and progress', () => {
+		render(
+			<BulkOperationProgress
+				isOpen
+				onClose={() => {}}
+				title="Deleting agents"
+				total={10}
+				completed={3}
+				results={[]}
+				isComplete={false}
+			/>,
+		);
+		expect(screen.getByText('Deleting agents')).toBeDefined();
+		expect(screen.getByText('3 of 10')).toBeDefined();
+		expect(
+			screen.getByText('Please wait while the operation completes...'),
+		).toBeDefined();
+	});
+
+	it('shows success/failure counts when complete', () => {
+		const results: BulkOperationResult[] = [
+			{ id: '1', success: true },
+			{ id: '2', success: true },
+			{ id: '3', success: false, error: 'Failed to delete' },
+		];
+		render(
+			<BulkOperationProgress
+				isOpen
+				onClose={() => {}}
+				title="Done"
+				total={3}
+				completed={3}
+				results={results}
+				isComplete
+			/>,
+		);
+		expect(screen.getByText('2 succeeded')).toBeDefined();
+		expect(screen.getByText('1 failed')).toBeDefined();
+		expect(screen.getByText('Failed to delete')).toBeDefined();
+	});
+
+	it('shows Done button and fires onClose', () => {
+		const onClose = vi.fn();
+		render(
+			<BulkOperationProgress
+				isOpen
+				onClose={onClose}
+				title="Done"
+				total={1}
+				completed={1}
+				results={[{ id: '1', success: true }]}
+				isComplete
+			/>,
+		);
+		screen.getByRole('button', { name: 'Done' }).click();
+		expect(onClose).toHaveBeenCalledOnce();
+	});
+
+	it('handles zero total without crashing', () => {
+		render(
+			<BulkOperationProgress
+				isOpen
+				onClose={() => {}}
+				title="Empty"
+				total={0}
+				completed={0}
+				results={[]}
+				isComplete
+			/>,
+		);
+		expect(screen.getByText('0 of 0')).toBeDefined();
+	});
+});

--- a/web/src/components/ui/BulkSelect.test.tsx
+++ b/web/src/components/ui/BulkSelect.test.tsx
@@ -1,0 +1,193 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import {
+	BulkSelectCheckbox,
+	BulkSelectHeader,
+	BulkSelectToolbar,
+	SelectionIndicator,
+} from './BulkSelect';
+
+describe('BulkSelectCheckbox', () => {
+	it('renders checked when checked=true', () => {
+		const onChange = vi.fn();
+		render(<BulkSelectCheckbox checked onChange={onChange} />);
+		const cb = screen.getByRole('checkbox') as HTMLInputElement;
+		expect(cb.checked).toBe(true);
+	});
+
+	it('fires onChange when clicked', () => {
+		const onChange = vi.fn();
+		render(<BulkSelectCheckbox checked={false} onChange={onChange} />);
+		screen.getByRole('checkbox').click();
+		expect(onChange).toHaveBeenCalledOnce();
+	});
+
+	it('disables when disabled=true', () => {
+		render(<BulkSelectCheckbox checked={false} onChange={() => {}} disabled />);
+		expect(screen.getByRole('checkbox')).toBeDisabled();
+	});
+});
+
+describe('BulkSelectHeader', () => {
+	it('renders Select all label when not all selected', () => {
+		render(
+			<BulkSelectHeader
+				isAllSelected={false}
+				isPartiallySelected={false}
+				onToggleAll={() => {}}
+				selectedCount={0}
+				totalCount={5}
+			/>,
+		);
+		expect(screen.getByRole('checkbox', { name: 'Select all' })).toBeDefined();
+	});
+
+	it('renders Deselect all label when all selected', () => {
+		render(
+			<BulkSelectHeader
+				isAllSelected
+				isPartiallySelected={false}
+				onToggleAll={() => {}}
+				selectedCount={5}
+				totalCount={5}
+			/>,
+		);
+		expect(
+			screen.getByRole('checkbox', { name: 'Deselect all' }),
+		).toBeDefined();
+	});
+
+	it('fires onToggleAll when clicked', () => {
+		const onToggle = vi.fn();
+		render(
+			<BulkSelectHeader
+				isAllSelected={false}
+				isPartiallySelected={false}
+				onToggleAll={onToggle}
+				selectedCount={0}
+				totalCount={5}
+			/>,
+		);
+		screen.getByRole('checkbox').click();
+		expect(onToggle).toHaveBeenCalledOnce();
+	});
+
+	it('disables when totalCount=0', () => {
+		render(
+			<BulkSelectHeader
+				isAllSelected={false}
+				isPartiallySelected={false}
+				onToggleAll={() => {}}
+				selectedCount={0}
+				totalCount={0}
+			/>,
+		);
+		expect(screen.getByRole('checkbox')).toBeDisabled();
+	});
+});
+
+describe('SelectionIndicator', () => {
+	it('renders nothing when selectedCount=0', () => {
+		const { container } = render(
+			<SelectionIndicator selectedCount={0} totalCount={5} />,
+		);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders count with default label', () => {
+		render(<SelectionIndicator selectedCount={3} totalCount={5} />);
+		expect(screen.getByText('3 of 5 items selected')).toBeDefined();
+	});
+
+	it('renders singular label when selectedCount=1', () => {
+		render(<SelectionIndicator selectedCount={1} totalCount={5} />);
+		expect(screen.getByText('1 of 5 item selected')).toBeDefined();
+	});
+
+	it('uses custom itemLabel', () => {
+		render(
+			<SelectionIndicator selectedCount={2} totalCount={5} itemLabel="agent" />,
+		);
+		expect(screen.getByText('2 of 5 agents selected')).toBeDefined();
+	});
+});
+
+describe('BulkSelectToolbar', () => {
+	it('renders nothing when selectedCount=0', () => {
+		const { container } = render(
+			<BulkSelectToolbar
+				selectedCount={0}
+				totalCount={5}
+				onSelectAll={() => {}}
+				onDeselectAll={() => {}}
+			/>,
+		);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders Select all link when not all selected', () => {
+		render(
+			<BulkSelectToolbar
+				selectedCount={2}
+				totalCount={5}
+				onSelectAll={() => {}}
+				onDeselectAll={() => {}}
+			/>,
+		);
+		expect(screen.getByRole('button', { name: 'Select all 5' })).toBeDefined();
+	});
+
+	it('hides Select all link when all selected', () => {
+		render(
+			<BulkSelectToolbar
+				selectedCount={5}
+				totalCount={5}
+				onSelectAll={() => {}}
+				onDeselectAll={() => {}}
+			/>,
+		);
+		expect(screen.queryByRole('button', { name: 'Select all 5' })).toBeNull();
+	});
+
+	it('fires onSelectAll when Select all clicked', () => {
+		const onSelectAll = vi.fn();
+		render(
+			<BulkSelectToolbar
+				selectedCount={2}
+				totalCount={5}
+				onSelectAll={onSelectAll}
+				onDeselectAll={() => {}}
+			/>,
+		);
+		screen.getByRole('button', { name: 'Select all 5' }).click();
+		expect(onSelectAll).toHaveBeenCalledOnce();
+	});
+
+	it('fires onDeselectAll when Clear clicked', () => {
+		const onDeselectAll = vi.fn();
+		render(
+			<BulkSelectToolbar
+				selectedCount={2}
+				totalCount={5}
+				onSelectAll={() => {}}
+				onDeselectAll={onDeselectAll}
+			/>,
+		);
+		screen.getByRole('button', { name: 'Clear selection' }).click();
+		expect(onDeselectAll).toHaveBeenCalledOnce();
+	});
+
+	it('renders children', () => {
+		render(
+			<BulkSelectToolbar
+				selectedCount={2}
+				totalCount={5}
+				onSelectAll={() => {}}
+				onDeselectAll={() => {}}
+			>
+				<span>child-action</span>
+			</BulkSelectToolbar>,
+		);
+		expect(screen.getByText('child-action')).toBeDefined();
+	});
+});

--- a/web/src/components/ui/HelpTooltip.test.tsx
+++ b/web/src/components/ui/HelpTooltip.test.tsx
@@ -1,0 +1,109 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import {
+	DashboardWidgetHelp,
+	FormLabelWithHelp,
+	HelpTooltip,
+	StatusBadgeWithHelp,
+} from './HelpTooltip';
+
+describe('HelpTooltip', () => {
+	it('renders trigger button with default aria-label', () => {
+		render(<HelpTooltip content="some help" />);
+		expect(screen.getByRole('button', { name: 'Help' })).toBeDefined();
+	});
+
+	it('uses title as aria-label when provided', () => {
+		render(<HelpTooltip content="some help" title="Backup Policy" />);
+		expect(screen.getByRole('button', { name: 'Backup Policy' })).toBeDefined();
+	});
+
+	it('shows tooltip on mouseenter and hides on mouseleave', () => {
+		render(<HelpTooltip content="hello world" title="Title" />);
+		const btn = screen.getByRole('button', { name: 'Title' });
+		fireEvent.mouseEnter(btn);
+		expect(screen.getByRole('tooltip')).toBeDefined();
+		expect(screen.getByText('hello world')).toBeDefined();
+		fireEvent.mouseLeave(btn);
+		expect(screen.queryByRole('tooltip')).toBeNull();
+	});
+
+	it('parses bold markdown', () => {
+		render(<HelpTooltip content="this is **bold** text" />);
+		fireEvent.mouseEnter(screen.getByRole('button'));
+		expect(screen.getByText('bold').tagName).toBe('STRONG');
+	});
+
+	it('parses code markdown', () => {
+		render(<HelpTooltip content="run `npm test` first" />);
+		fireEvent.mouseEnter(screen.getByRole('button'));
+		expect(screen.getByText('npm test').tagName).toBe('CODE');
+	});
+
+	it('renders docs link when docsUrl provided', () => {
+		render(
+			<HelpTooltip content="content" docsUrl="https://docs.example.com" />,
+		);
+		fireEvent.mouseEnter(screen.getByRole('button'));
+		const link = screen.getByRole('link', { name: /Learn more/ });
+		expect(link.getAttribute('href')).toBe('https://docs.example.com');
+		expect(link.getAttribute('target')).toBe('_blank');
+	});
+});
+
+describe('FormLabelWithHelp', () => {
+	it('renders label and required indicator', () => {
+		render(
+			<FormLabelWithHelp
+				htmlFor="my-field"
+				label="My Field"
+				helpContent="Help"
+				required
+			/>,
+		);
+		expect(screen.getByText('My Field')).toBeDefined();
+		expect(screen.getByText('*')).toBeDefined();
+	});
+
+	it('hides required indicator when not required', () => {
+		render(
+			<FormLabelWithHelp
+				htmlFor="my-field"
+				label="My Field"
+				helpContent="Help"
+			/>,
+		);
+		expect(screen.queryByText('*')).toBeNull();
+	});
+});
+
+describe('StatusBadgeWithHelp', () => {
+	it('renders status and tooltip trigger', () => {
+		render(
+			<StatusBadgeWithHelp
+				status="active"
+				statusColor={{
+					bg: 'bg-green-100',
+					text: 'text-green-700',
+					dot: 'bg-green-500',
+				}}
+				helpContent="Status info"
+			/>,
+		);
+		expect(screen.getByText('active')).toBeDefined();
+		expect(screen.getByRole('button', { name: 'Help' })).toBeDefined();
+	});
+});
+
+describe('DashboardWidgetHelp', () => {
+	it('renders title, help tooltip, and children', () => {
+		render(
+			<DashboardWidgetHelp title="My Widget" helpContent="info">
+				<span>extra-child</span>
+			</DashboardWidgetHelp>,
+		);
+		expect(screen.getByText('My Widget')).toBeDefined();
+		expect(screen.getByText('extra-child')).toBeDefined();
+		expect(screen.getByRole('button', { name: 'Help' })).toBeDefined();
+	});
+});

--- a/web/src/components/ui/LoadingCard.test.tsx
+++ b/web/src/components/ui/LoadingCard.test.tsx
@@ -1,0 +1,43 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { LoadingCard } from './LoadingCard';
+
+describe('LoadingCard', () => {
+	it('renders default stat variant', () => {
+		const { container } = render(<LoadingCard />);
+		expect(container.firstChild).toBeDefined();
+		expect(container.querySelector('.animate-pulse')).not.toBeNull();
+	});
+
+	it('renders each preset variant without crashing', () => {
+		const variants = [
+			'stat',
+			'stat-sm',
+			'alert',
+			'template',
+			'repo',
+			'sla',
+			'health',
+		] as const;
+		for (const variant of variants) {
+			const { container } = render(<LoadingCard variant={variant} />);
+			expect(container.firstChild).toBeDefined();
+		}
+	});
+
+	it('renders children when provided', () => {
+		const { getByText } = render(
+			<LoadingCard>
+				<span>custom skeleton</span>
+			</LoadingCard>,
+		);
+		expect(getByText('custom skeleton')).toBeDefined();
+	});
+
+	it('applies custom className', () => {
+		const { container } = render(<LoadingCard className="my-extra" />);
+		expect(
+			(container.firstChild as HTMLElement).className.includes('my-extra'),
+		).toBe(true);
+	});
+});

--- a/web/src/components/ui/LoadingRow.test.tsx
+++ b/web/src/components/ui/LoadingRow.test.tsx
@@ -1,0 +1,54 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { LoadingRow } from './LoadingRow';
+
+function renderRow(ui: React.ReactNode) {
+	return render(
+		<table>
+			<tbody>{ui}</tbody>
+		</table>,
+	);
+}
+
+describe('LoadingRow', () => {
+	it('renders one td per column', () => {
+		const { container } = renderRow(
+			<LoadingRow columns={[{ width: 'w-32' }, { width: 'w-20' }]} />,
+		);
+		expect(container.querySelectorAll('td').length).toBe(2);
+	});
+
+	it('honors pill flag with rounded-full', () => {
+		const { container } = renderRow(
+			<LoadingRow columns={[{ width: 'w-12', pill: true }]} />,
+		);
+		const bar = container.querySelector('td > div');
+		expect(bar?.className.includes('rounded-full')).toBe(true);
+		expect(bar?.className.includes('h-6')).toBe(true);
+	});
+
+	it('honors button flag with h-8 + inline-block', () => {
+		const { container } = renderRow(
+			<LoadingRow columns={[{ width: 'w-12', button: true }]} />,
+		);
+		const bar = container.querySelector('td > div');
+		expect(bar?.className.includes('h-8')).toBe(true);
+		expect(bar?.className.includes('inline-block')).toBe(true);
+	});
+
+	it('honors align=right on td', () => {
+		const { container } = renderRow(
+			<LoadingRow columns={[{ width: 'w-12', align: 'right' }]} />,
+		);
+		expect(
+			container.querySelector('td')?.className.includes('text-right'),
+		).toBe(true);
+	});
+
+	it('renders custom JSX when render is provided', () => {
+		const { getByText } = renderRow(
+			<LoadingRow columns={[{ width: 'w-12', render: <span>custom</span> }]} />,
+		);
+		expect(getByText('custom')).toBeDefined();
+	});
+});

--- a/web/src/components/ui/PageSkeletons.test.tsx
+++ b/web/src/components/ui/PageSkeletons.test.tsx
@@ -1,0 +1,97 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import {
+	AgentListSkeleton,
+	AgentRowSkeleton,
+	DashboardBackupListSkeleton,
+	DashboardFavoritesSkeleton,
+	DashboardQueueSkeleton,
+	DashboardSkeleton,
+	DashboardStatsSkeleton,
+	GenericListSkeleton,
+	ScheduleFormSkeleton,
+	ScheduleListSkeleton,
+	ScheduleRowSkeleton,
+} from './PageSkeletons';
+
+function renderRowOnly(ui: React.ReactNode) {
+	return render(
+		<table>
+			<tbody>{ui}</tbody>
+		</table>,
+	);
+}
+
+describe('PageSkeletons', () => {
+	it('renders AgentRowSkeleton', () => {
+		const { container } = renderRowOnly(<AgentRowSkeleton />);
+		expect(container.querySelector('tr')).not.toBeNull();
+	});
+
+	it('renders AgentListSkeleton with default row count', () => {
+		const { container } = render(<AgentListSkeleton />);
+		expect(container.querySelectorAll('tbody tr').length).toBe(3);
+	});
+
+	it('renders AgentListSkeleton with custom row count', () => {
+		const { container } = render(<AgentListSkeleton rows={7} />);
+		expect(container.querySelectorAll('tbody tr').length).toBe(7);
+	});
+
+	it('renders ScheduleRowSkeleton', () => {
+		const { container } = renderRowOnly(<ScheduleRowSkeleton />);
+		expect(container.querySelector('tr')).not.toBeNull();
+	});
+
+	it('renders ScheduleListSkeleton', () => {
+		const { container } = render(<ScheduleListSkeleton rows={2} />);
+		expect(container.querySelectorAll('tbody tr').length).toBe(2);
+	});
+
+	it('renders DashboardStatsSkeleton with 4 cards', () => {
+		const { container } = render(<DashboardStatsSkeleton />);
+		expect(container.firstChild).toBeDefined();
+	});
+
+	it('renders DashboardBackupListSkeleton', () => {
+		const { container } = render(<DashboardBackupListSkeleton />);
+		expect(container.firstChild).toBeDefined();
+	});
+
+	it('renders DashboardQueueSkeleton', () => {
+		const { container } = render(<DashboardQueueSkeleton />);
+		expect(container.firstChild).toBeDefined();
+	});
+
+	it('renders DashboardFavoritesSkeleton', () => {
+		const { container } = render(<DashboardFavoritesSkeleton />);
+		expect(container.firstChild).toBeDefined();
+	});
+
+	it('renders DashboardSkeleton', () => {
+		const { container } = render(<DashboardSkeleton />);
+		expect(container.firstChild).toBeDefined();
+	});
+
+	it('renders ScheduleFormSkeleton', () => {
+		const { container } = render(<ScheduleFormSkeleton />);
+		expect(container.firstChild).toBeDefined();
+	});
+
+	it('renders GenericListSkeleton with defaults', () => {
+		const { container } = render(<GenericListSkeleton />);
+		expect(container.querySelectorAll('tbody tr').length).toBe(5);
+	});
+
+	it('renders GenericListSkeleton with custom config', () => {
+		const { container } = render(
+			<GenericListSkeleton
+				rows={2}
+				columns={4}
+				showCheckbox={false}
+				showActions={false}
+			/>,
+		);
+		expect(container.querySelectorAll('tbody tr').length).toBe(2);
+	});
+});

--- a/web/src/components/ui/ReadOnlyBlocker.test.tsx
+++ b/web/src/components/ui/ReadOnlyBlocker.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../hooks/useReadOnlyMode', () => ({
+	useReadOnlyMode: vi.fn(),
+}));
+
+import { useReadOnlyMode } from '../../hooks/useReadOnlyMode';
+import { ReadOnlyBlocker, ReadOnlyDisabledButton } from './ReadOnlyBlocker';
+
+function setReadOnly(isReadOnly: boolean, maintenanceTitle?: string) {
+	vi.mocked(useReadOnlyMode).mockReturnValue({
+		isReadOnly,
+		maintenanceTitle,
+	} as never);
+}
+
+describe('ReadOnlyBlocker', () => {
+	it('renders children when not in read-only mode', () => {
+		setReadOnly(false);
+		render(
+			<ReadOnlyBlocker>
+				<span>inner</span>
+			</ReadOnlyBlocker>,
+		);
+		expect(screen.getByText('inner')).toBeDefined();
+	});
+
+	it('renders fallback when in read-only mode and fallback provided', () => {
+		setReadOnly(true);
+		render(
+			<ReadOnlyBlocker fallback={<span>fallback-node</span>}>
+				<span>inner</span>
+			</ReadOnlyBlocker>,
+		);
+		expect(screen.getByText('fallback-node')).toBeDefined();
+		expect(screen.queryByText('inner')).toBeNull();
+	});
+
+	it('renders message when in read-only mode and no fallback', () => {
+		setReadOnly(true, 'Quarterly maintenance');
+		render(
+			<ReadOnlyBlocker>
+				<span>inner</span>
+			</ReadOnlyBlocker>,
+		);
+		expect(screen.getByText(/Read-only mode/)).toBeDefined();
+		expect(screen.getByText(/Quarterly maintenance/)).toBeDefined();
+	});
+
+	it('renders nothing when in read-only mode and showMessage=false', () => {
+		setReadOnly(true);
+		const { container } = render(
+			<ReadOnlyBlocker showMessage={false}>
+				<span>inner</span>
+			</ReadOnlyBlocker>,
+		);
+		expect(container.firstChild).toBeNull();
+	});
+});
+
+describe('ReadOnlyDisabledButton', () => {
+	it('fires onClick when not read-only and not disabled', () => {
+		setReadOnly(false);
+		const onClick = vi.fn();
+		render(
+			<ReadOnlyDisabledButton onClick={onClick}>Click</ReadOnlyDisabledButton>,
+		);
+		screen.getByRole('button', { name: 'Click' }).click();
+		expect(onClick).toHaveBeenCalledOnce();
+	});
+
+	it('disables button when read-only', () => {
+		setReadOnly(true, 'Window 7');
+		render(<ReadOnlyDisabledButton>Click</ReadOnlyDisabledButton>);
+		const btn = screen.getByRole('button', { name: 'Click' });
+		expect(btn).toBeDisabled();
+		expect(btn.getAttribute('title')).toContain('Window 7');
+	});
+
+	it('respects disabled prop even when not read-only', () => {
+		setReadOnly(false);
+		render(
+			<ReadOnlyDisabledButton disabled={true}>Click</ReadOnlyDisabledButton>,
+		);
+		expect(screen.getByRole('button', { name: 'Click' })).toBeDisabled();
+	});
+});

--- a/web/src/components/ui/StarButton.test.tsx
+++ b/web/src/components/ui/StarButton.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../hooks/useFavorites', () => ({
+	useAddFavorite: vi.fn(),
+	useRemoveFavorite: vi.fn(),
+}));
+
+import { useAddFavorite, useRemoveFavorite } from '../../hooks/useFavorites';
+import { StarButton } from './StarButton';
+
+const addMutate = vi.fn();
+const removeMutate = vi.fn();
+
+function setMocks({
+	addPending = false,
+	removePending = false,
+}: { addPending?: boolean; removePending?: boolean } = {}) {
+	vi.mocked(useAddFavorite).mockReturnValue({
+		mutate: addMutate,
+		isPending: addPending,
+	} as never);
+	vi.mocked(useRemoveFavorite).mockReturnValue({
+		mutate: removeMutate,
+		isPending: removePending,
+	} as never);
+}
+
+describe('StarButton', () => {
+	it('renders Add label when not favorite', () => {
+		setMocks();
+		render(<StarButton entityType="agent" entityId="1" isFavorite={false} />);
+		expect(
+			screen.getByRole('button', { name: 'Add to favorites' }),
+		).toBeDefined();
+	});
+
+	it('renders Remove label when favorite', () => {
+		setMocks();
+		render(<StarButton entityType="agent" entityId="1" isFavorite={true} />);
+		expect(
+			screen.getByRole('button', { name: 'Remove from favorites' }),
+		).toBeDefined();
+	});
+
+	it('fires addFavorite mutate when star clicked and not favorite', () => {
+		setMocks();
+		addMutate.mockReset();
+		render(<StarButton entityType="agent" entityId="abc" isFavorite={false} />);
+		screen.getByRole('button', { name: 'Add to favorites' }).click();
+		expect(addMutate).toHaveBeenCalledWith({
+			entity_type: 'agent',
+			entity_id: 'abc',
+		});
+	});
+
+	it('fires removeFavorite mutate when star clicked and is favorite', () => {
+		setMocks();
+		removeMutate.mockReset();
+		render(<StarButton entityType="agent" entityId="xyz" isFavorite={true} />);
+		screen.getByRole('button', { name: 'Remove from favorites' }).click();
+		expect(removeMutate).toHaveBeenCalledWith({
+			entityType: 'agent',
+			entityId: 'xyz',
+		});
+	});
+
+	it('disables button while pending', () => {
+		setMocks({ addPending: true });
+		render(<StarButton entityType="agent" entityId="abc" isFavorite={false} />);
+		expect(
+			screen.getByRole('button', { name: 'Add to favorites' }),
+		).toBeDisabled();
+	});
+});


### PR DESCRIPTION
## Summary
Adds 24 component test files. Only 15 wizards/heavy editors remain untested after this PR.

Tested: LoadingCard, LoadingRow, ReadOnlyBlocker, StarButton, BulkSelect, BulkActions, BulkOperationProgress, HelpTooltip, PageSkeletons, DryRunResultsModal, WhatsNewModal, LicenseBanner, MaintenanceCountdown, PasswordExpirationBanner, FeatureGate (+ ProBadge, FeatureDisabledButton, FeatureCheck), DiffViewer, GeoReplicationStatusCard, RegionMapIndicator, SaveFilterButton, SavedFiltersDropdown, ErrorBoundary, PasswordRequirements.

## Metrics
- vitest now **223** test files passing (was 199)
- biome clean (494 files)
- tsc --noEmit clean

## Test plan
- [x] vitest clean
- [x] biome clean
- [x] tsc --noEmit clean