### PR TITLE
Test final 15 components — 100% component coverage

### DIFF
--- a/web/src/components/features/ActivityFeed.test.tsx
+++ b/web/src/components/features/ActivityFeed.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../hooks/useActivity', () => ({
+	useRecentActivity: vi.fn(),
+	useActivityFeed: vi.fn(() => ({ events: [], isConnected: false })),
+}));
+
+vi.mock('../../hooks/useLocale', () => ({
+	useLocale: () => ({
+		t: (_key: string, defaultValue: string) => defaultValue,
+		locale: 'en',
+		formatRelativeTime: (_d: unknown) => 'just now',
+		formatDate: (_d: unknown) => 'date',
+		formatTime: (_d: unknown) => 'time',
+		formatDateTime: (_d: unknown) => 'datetime',
+	}),
+}));
+
+import { useRecentActivity } from '../../hooks/useActivity';
+import { ActivityFeedFull, ActivityFeedWidget } from './ActivityFeed';
+
+function setEvents(events: unknown[], isLoading = false) {
+	vi.mocked(useRecentActivity).mockReturnValue({
+		data: events,
+		isLoading,
+	} as never);
+}
+
+function withRouter(ui: React.ReactNode) {
+	return <MemoryRouter>{ui}</MemoryRouter>;
+}
+
+describe('ActivityFeedWidget', () => {
+	it('renders header', () => {
+		setEvents([]);
+		render(withRouter(<ActivityFeedWidget enableRealtime={false} />));
+		expect(screen.getByText('Activity Feed')).toBeDefined();
+	});
+
+	it('renders events', () => {
+		setEvents([
+			{
+				id: '1',
+				event_type: 'backup.completed',
+				category: 'backup',
+				description: 'Backup of /var/www completed',
+				timestamp: new Date().toISOString(),
+			},
+		]);
+		render(withRouter(<ActivityFeedWidget enableRealtime={false} />));
+		expect(screen.getByText('Backup of /var/www completed')).toBeDefined();
+	});
+});
+
+describe('ActivityFeedFull', () => {
+	it('renders', () => {
+		setEvents([]);
+		const { container } = render(withRouter(<ActivityFeedFull />));
+		expect(container.firstChild).not.toBeNull();
+	});
+});

--- a/web/src/components/features/AgentLogViewer.test.tsx
+++ b/web/src/components/features/AgentLogViewer.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../hooks/useAgents', () => ({
+	useAgentLogs: vi.fn(),
+}));
+
+import { useAgentLogs } from '../../hooks/useAgents';
+import { AgentLogViewer } from './AgentLogViewer';
+
+function setLogs(logs: unknown[], isLoading = false) {
+	vi.mocked(useAgentLogs).mockReturnValue({
+		data: { logs, total: logs.length },
+		isLoading,
+		refetch: vi.fn(),
+	} as never);
+}
+
+describe('AgentLogViewer', () => {
+	it('renders loading state', () => {
+		setLogs([], true);
+		const { container } = render(<AgentLogViewer agentId="abc" />);
+		expect(container.firstChild).not.toBeNull();
+	});
+
+	it('renders log entries', () => {
+		setLogs([
+			{
+				id: '1',
+				agent_id: 'abc',
+				timestamp: new Date().toISOString(),
+				level: 'info',
+				message: 'Agent connected',
+				component: 'main',
+			},
+		]);
+		render(<AgentLogViewer agentId="abc" />);
+		expect(screen.getByText('Agent connected')).toBeDefined();
+	});
+
+	it('renders empty state when no logs', () => {
+		setLogs([]);
+		const { container } = render(<AgentLogViewer agentId="abc" />);
+		expect(container.firstChild).not.toBeNull();
+	});
+});

--- a/web/src/components/features/BackupCalendar.test.tsx
+++ b/web/src/components/features/BackupCalendar.test.tsx
@@ -1,0 +1,26 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../hooks/useAgents', () => ({
+	useAgents: vi.fn(() => ({ data: [] })),
+}));
+
+vi.mock('../../hooks/useBackupCalendar', () => ({
+	useBackupCalendar: vi.fn(() => ({ data: undefined, isLoading: false })),
+}));
+
+import { BackupCalendar, MiniBackupCalendar } from './BackupCalendar';
+
+describe('BackupCalendar', () => {
+	it('renders calendar without crashing', () => {
+		const { container } = render(<BackupCalendar />);
+		expect(container.firstChild).not.toBeNull();
+	});
+});
+
+describe('MiniBackupCalendar', () => {
+	it('renders mini calendar without crashing', () => {
+		const { container } = render(<MiniBackupCalendar />);
+		expect(container.firstChild).not.toBeNull();
+	});
+});

--- a/web/src/components/features/BackupQueuePanel.test.tsx
+++ b/web/src/components/features/BackupQueuePanel.test.tsx
@@ -1,0 +1,21 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../hooks/useBackupQueue', () => ({
+	useBackupQueue: vi.fn(() => ({ data: undefined, isLoading: false })),
+	useBackupQueueSummary: vi.fn(() => ({ data: undefined })),
+	useCancelQueuedBackup: vi.fn(() => ({ mutate: vi.fn() })),
+	useOrgConcurrency: vi.fn(() => ({ data: undefined })),
+	useUpdateOrgConcurrency: vi.fn(() => ({ mutate: vi.fn() })),
+	useAgentConcurrency: vi.fn(() => ({ data: undefined })),
+	useUpdateAgentConcurrency: vi.fn(() => ({ mutate: vi.fn() })),
+}));
+
+import { BackupQueuePanel } from './BackupQueuePanel';
+
+describe('BackupQueuePanel', () => {
+	it('renders without crashing', () => {
+		const { container } = render(<BackupQueuePanel />);
+		expect(container.firstChild).not.toBeNull();
+	});
+});

--- a/web/src/components/features/ContainerHooksEditor.test.tsx
+++ b/web/src/components/features/ContainerHooksEditor.test.tsx
@@ -1,0 +1,21 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../hooks/useContainerHooks', () => ({
+	useContainerHooks: vi.fn(() => ({ data: [], isLoading: false })),
+	useContainerHook: vi.fn(() => ({ data: undefined })),
+	useCreateContainerHook: vi.fn(() => ({ mutateAsync: vi.fn() })),
+	useUpdateContainerHook: vi.fn(() => ({ mutateAsync: vi.fn() })),
+	useDeleteContainerHook: vi.fn(() => ({ mutateAsync: vi.fn() })),
+	useContainerHookTemplates: vi.fn(() => ({ data: [] })),
+	useContainerHookExecutions: vi.fn(() => ({ data: [] })),
+}));
+
+import { ContainerHooksEditor } from './ContainerHooksEditor';
+
+describe('ContainerHooksEditor', () => {
+	it('renders without crashing', () => {
+		const { container } = render(<ContainerHooksEditor scheduleId="sched-1" />);
+		expect(container.firstChild).not.toBeNull();
+	});
+});

--- a/web/src/components/features/DockerRestoreWizard.test.tsx
+++ b/web/src/components/features/DockerRestoreWizard.test.tsx
@@ -1,0 +1,46 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../hooks/useAgents', () => ({
+	useAgents: vi.fn(() => ({ data: [] })),
+}));
+
+vi.mock('../../hooks/useDockerRestore', () => ({
+	useDockerRestores: vi.fn(() => ({ data: [] })),
+	useDockerRestore: vi.fn(() => ({ data: undefined })),
+	useCreateDockerRestore: vi.fn(() => ({
+		mutateAsync: vi.fn(),
+		isPending: false,
+	})),
+	useDockerRestorePreview: vi.fn(() => ({ mutateAsync: vi.fn() })),
+	useDockerRestoreProgress: vi.fn(() => ({ data: undefined })),
+	useContainersInSnapshot: vi.fn(() => ({ data: [] })),
+	useVolumesInSnapshot: vi.fn(() => ({ data: [] })),
+	useCancelDockerRestore: vi.fn(() => ({ mutateAsync: vi.fn() })),
+}));
+
+vi.mock('../../hooks/useSnapshots', () => ({
+	useSnapshots: vi.fn(() => ({ data: [], isLoading: false })),
+	useSnapshot: vi.fn(() => ({ data: undefined })),
+	useSnapshotFiles: vi.fn(() => ({ data: [] })),
+	useSnapshotCompare: vi.fn(() => ({ data: undefined })),
+	useFileDiff: vi.fn(() => ({ data: undefined })),
+}));
+
+import { DockerRestoreWizard } from './DockerRestoreWizard';
+
+describe('DockerRestoreWizard', () => {
+	it('renders nothing when closed', () => {
+		const { container } = render(
+			<DockerRestoreWizard isOpen={false} onClose={vi.fn()} />,
+		);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders wizard when open', () => {
+		const { container } = render(
+			<DockerRestoreWizard isOpen onClose={vi.fn()} />,
+		);
+		expect(container.firstChild).not.toBeNull();
+	});
+});

--- a/web/src/components/features/DockerStackSelector.test.tsx
+++ b/web/src/components/features/DockerStackSelector.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { DockerStack } from '../../lib/types';
+import { DockerStackSelector } from './DockerStackSelector';
+
+const stacks = [
+	{
+		id: 'stack-1',
+		agent_id: 'agent-1',
+		name: 'web',
+		compose_path: '/srv/web/docker-compose.yml',
+		is_running: true,
+	} as unknown as DockerStack,
+];
+
+describe('DockerStackSelector', () => {
+	it('renders stack in select for matching agent', () => {
+		render(
+			<DockerStackSelector
+				stacks={stacks}
+				selectedStackId={null}
+				onChange={vi.fn()}
+				agentId="agent-1"
+			/>,
+		);
+		expect(screen.getByRole('option', { name: /web/ })).toBeDefined();
+	});
+
+	it('renders loading state', () => {
+		const { container } = render(
+			<DockerStackSelector
+				stacks={[]}
+				selectedStackId={null}
+				onChange={vi.fn()}
+				agentId="agent-1"
+				isLoading
+			/>,
+		);
+		expect(container.firstChild).not.toBeNull();
+	});
+
+	it('renders empty state when no stacks for agent', () => {
+		const { container } = render(
+			<DockerStackSelector
+				stacks={[]}
+				selectedStackId={null}
+				onChange={vi.fn()}
+				agentId="agent-1"
+			/>,
+		);
+		expect(container.firstChild).not.toBeNull();
+	});
+
+	it('renders agent-first message when agentId empty', () => {
+		render(
+			<DockerStackSelector
+				stacks={[]}
+				selectedStackId={null}
+				onChange={vi.fn()}
+				agentId=""
+			/>,
+		);
+		expect(screen.getByText(/Select an agent first/)).toBeDefined();
+	});
+});

--- a/web/src/components/features/ExportImportModal.test.tsx
+++ b/web/src/components/features/ExportImportModal.test.tsx
@@ -1,0 +1,50 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../hooks/useConfigExport', () => ({
+	useExportAgent: vi.fn(() => ({ mutateAsync: vi.fn() })),
+	useExportSchedule: vi.fn(() => ({ mutateAsync: vi.fn() })),
+	useExportRepository: vi.fn(() => ({ mutateAsync: vi.fn() })),
+	useExportBundle: vi.fn(() => ({ mutateAsync: vi.fn() })),
+	useImportConfig: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+	useValidateImport: vi.fn(() => ({ mutateAsync: vi.fn() })),
+	downloadExport: vi.fn(),
+}));
+
+vi.mock('../../hooks/useLocale', () => ({
+	useLocale: () => ({
+		t: (_key: string, defaultValue: string) => defaultValue,
+		locale: 'en',
+	}),
+}));
+
+import { ExportImportModal } from './ExportImportModal';
+
+describe('ExportImportModal', () => {
+	it('renders nothing when closed', () => {
+		const { container } = render(
+			<ExportImportModal isOpen={false} onClose={vi.fn()} mode="export" />,
+		);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders modal when open in export mode', () => {
+		const { container } = render(
+			<ExportImportModal
+				isOpen
+				onClose={vi.fn()}
+				mode="export"
+				resourceType="agent"
+				resourceId="abc"
+			/>,
+		);
+		expect(container.firstChild).not.toBeNull();
+	});
+
+	it('renders import mode', () => {
+		const { container } = render(
+			<ExportImportModal isOpen onClose={vi.fn()} mode="import" />,
+		);
+		expect(container.firstChild).not.toBeNull();
+	});
+});

--- a/web/src/components/features/GlobalSearchBar.test.tsx
+++ b/web/src/components/features/GlobalSearchBar.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../hooks/useSearch', () => ({
+	useGroupedSearch: vi.fn(() => ({ data: undefined, isLoading: false })),
+	useRecentSearches: vi.fn(() => ({ data: [] })),
+	useSearchSuggestions: vi.fn(() => ({ data: [] })),
+	useSaveRecentSearch: vi.fn(() => ({ mutateAsync: vi.fn() })),
+	useDeleteRecentSearch: vi.fn(() => ({ mutateAsync: vi.fn() })),
+	useClearRecentSearches: vi.fn(() => ({ mutateAsync: vi.fn() })),
+}));
+
+import { GlobalSearchBar } from './GlobalSearchBar';
+
+function withRouter(ui: React.ReactNode) {
+	return <MemoryRouter>{ui}</MemoryRouter>;
+}
+
+describe('GlobalSearchBar', () => {
+	it('renders search input', () => {
+		render(withRouter(<GlobalSearchBar />));
+		expect(screen.getByRole('combobox')).toBeDefined();
+	});
+
+	it('uses custom placeholder', () => {
+		render(withRouter(<GlobalSearchBar placeholder="Find anything" />));
+		expect(screen.getByPlaceholderText('Find anything')).toBeDefined();
+	});
+});

--- a/web/src/components/features/ImportAgentsWizard.test.tsx
+++ b/web/src/components/features/ImportAgentsWizard.test.tsx
@@ -1,0 +1,33 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../hooks/useAgentGroups', () => ({
+	useAgentGroups: vi.fn(() => ({ data: [] })),
+}));
+
+vi.mock('../../hooks/useAgentImport', () => ({
+	useAgentImportPreview: vi.fn(() => ({ mutateAsync: vi.fn() })),
+	useAgentImport: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+	useAgentImportTemplate: vi.fn(() => ({ data: undefined })),
+	useAgentImportTemplateDownload: vi.fn(() => ({ refetch: vi.fn() })),
+	useAgentRegistrationScript: vi.fn(() => ({ refetch: vi.fn() })),
+	useAgentImportTokensExport: vi.fn(() => ({ refetch: vi.fn() })),
+}));
+
+import { ImportAgentsWizard } from './ImportAgentsWizard';
+
+describe('ImportAgentsWizard', () => {
+	it('renders nothing when closed', () => {
+		const { container } = render(
+			<ImportAgentsWizard isOpen={false} onClose={vi.fn()} />,
+		);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders wizard when open', () => {
+		const { container } = render(
+			<ImportAgentsWizard isOpen onClose={vi.fn()} />,
+		);
+		expect(container.firstChild).not.toBeNull();
+	});
+});

--- a/web/src/components/features/ImportRepositoryWizard.test.tsx
+++ b/web/src/components/features/ImportRepositoryWizard.test.tsx
@@ -1,0 +1,33 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../hooks/useAgents', () => ({
+	useAgents: vi.fn(() => ({ data: [] })),
+}));
+
+vi.mock('../../hooks/useRepositoryImport', () => ({
+	useVerifyImportAccess: vi.fn(() => ({ mutateAsync: vi.fn() })),
+	useImportPreview: vi.fn(() => ({ mutateAsync: vi.fn() })),
+	useImportRepository: vi.fn(() => ({
+		mutateAsync: vi.fn(),
+		isPending: false,
+	})),
+}));
+
+import { ImportRepositoryWizard } from './ImportRepositoryWizard';
+
+describe('ImportRepositoryWizard', () => {
+	it('renders nothing when closed', () => {
+		const { container } = render(
+			<ImportRepositoryWizard isOpen={false} onClose={vi.fn()} />,
+		);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders wizard when open', () => {
+		const { container } = render(
+			<ImportRepositoryWizard isOpen onClose={vi.fn()} />,
+		);
+		expect(container.firstChild).not.toBeNull();
+	});
+});

--- a/web/src/components/features/MetadataEditor.test.tsx
+++ b/web/src/components/features/MetadataEditor.test.tsx
@@ -1,0 +1,28 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../hooks/useMetadata', () => ({
+	useMetadataSchemas: vi.fn(() => ({ data: [] })),
+}));
+
+import { MetadataEditor } from './MetadataEditor';
+
+describe('MetadataEditor', () => {
+	it('renders without crashing', () => {
+		const { container } = render(
+			<MetadataEditor entityType="agent" value={{}} onChange={vi.fn()} />,
+		);
+		expect(container.firstChild).not.toBeNull();
+	});
+
+	it('handles pre-populated values', () => {
+		const { container } = render(
+			<MetadataEditor
+				entityType="repository"
+				value={{ team: 'platform' }}
+				onChange={vi.fn()}
+			/>,
+		);
+		expect(container.firstChild).not.toBeNull();
+	});
+});

--- a/web/src/components/features/MetadataSchemaManager.test.tsx
+++ b/web/src/components/features/MetadataSchemaManager.test.tsx
@@ -1,0 +1,20 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../hooks/useMetadata', () => ({
+	useMetadataSchemas: vi.fn(() => ({ data: [], isLoading: false })),
+	useMetadataFieldTypes: vi.fn(() => ({ data: [] })),
+	useMetadataEntityTypes: vi.fn(() => ({ data: [] })),
+	useCreateMetadataSchema: vi.fn(() => ({ mutateAsync: vi.fn() })),
+	useUpdateMetadataSchema: vi.fn(() => ({ mutateAsync: vi.fn() })),
+	useDeleteMetadataSchema: vi.fn(() => ({ mutateAsync: vi.fn() })),
+}));
+
+import { MetadataSchemaManager } from './MetadataSchemaManager';
+
+describe('MetadataSchemaManager', () => {
+	it('renders without crashing', () => {
+		const { container } = render(<MetadataSchemaManager entityType="agent" />);
+		expect(container.firstChild).not.toBeNull();
+	});
+});

--- a/web/src/components/features/RecentItems.test.tsx
+++ b/web/src/components/features/RecentItems.test.tsx
@@ -1,0 +1,78 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../hooks/useRecentItems', () => ({
+	useRecentItems: vi.fn(),
+	useDeleteRecentItem: vi.fn(),
+	useClearRecentItems: vi.fn(),
+}));
+
+import {
+	useClearRecentItems,
+	useDeleteRecentItem,
+	useRecentItems,
+} from '../../hooks/useRecentItems';
+import { RecentItemsDropdown } from './RecentItems';
+
+function setItems(items: unknown[] | undefined, isLoading = false) {
+	vi.mocked(useRecentItems).mockReturnValue({
+		data: items,
+		isLoading,
+	} as never);
+	vi.mocked(useDeleteRecentItem).mockReturnValue({
+		mutateAsync: vi.fn(),
+	} as never);
+	vi.mocked(useClearRecentItems).mockReturnValue({
+		mutateAsync: vi.fn(),
+	} as never);
+}
+
+function withRouter(ui: React.ReactNode) {
+	return <MemoryRouter>{ui}</MemoryRouter>;
+}
+
+describe('RecentItemsDropdown', () => {
+	it('renders the trigger button', () => {
+		setItems([]);
+		render(withRouter(<RecentItemsDropdown />));
+		expect(screen.getByRole('button', { name: 'Recent Items' })).toBeDefined();
+	});
+
+	it('opens dropdown on click and shows empty state', () => {
+		setItems([]);
+		render(withRouter(<RecentItemsDropdown />));
+		fireEvent.click(screen.getByRole('button', { name: 'Recent Items' }));
+		expect(screen.getByText('No recent items')).toBeDefined();
+	});
+
+	it('renders grouped items by type', () => {
+		setItems([
+			{
+				id: '1',
+				item_type: 'agent',
+				item_name: 'web-prod-01',
+				page_path: '/agents/1',
+				viewed_at: new Date(Date.now() - 60_000).toISOString(),
+			},
+			{
+				id: '2',
+				item_type: 'repository',
+				item_name: 's3-backup',
+				page_path: '/repositories/2',
+				viewed_at: new Date().toISOString(),
+			},
+		]);
+		render(withRouter(<RecentItemsDropdown />));
+		fireEvent.click(screen.getByRole('button', { name: 'Recent Items' }));
+		expect(screen.getByText('Agents')).toBeDefined();
+		expect(screen.getByText('web-prod-01')).toBeDefined();
+		expect(screen.getByText('s3-backup')).toBeDefined();
+	});
+
+	it('disables trigger while loading', () => {
+		setItems(undefined, true);
+		render(withRouter(<RecentItemsDropdown />));
+		expect(screen.getByRole('button', { name: 'Recent Items' })).toBeDisabled();
+	});
+});

--- a/web/src/components/features/UpgradePrompt.test.tsx
+++ b/web/src/components/features/UpgradePrompt.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import { UpgradeLimitWarning, UpgradePrompt } from './UpgradePrompt';
+
+function withRouter(ui: React.ReactNode) {
+	return <MemoryRouter>{ui}</MemoryRouter>;
+}
+
+describe('UpgradePrompt', () => {
+	it('renders banner variant by default', () => {
+		render(withRouter(<UpgradePrompt feature="custom_branding" />));
+		expect(screen.getByText(/Unlock|requires/)).toBeDefined();
+	});
+
+	it('renders inline variant', () => {
+		render(
+			withRouter(<UpgradePrompt feature="custom_branding" variant="inline" />),
+		);
+		expect(screen.getByText(/requires/)).toBeDefined();
+	});
+
+	it('renders card variant with benefits', () => {
+		render(
+			withRouter(<UpgradePrompt feature="custom_branding" variant="card" />),
+		);
+		expect(screen.getByRole('heading')).toBeDefined();
+	});
+
+	it('renders modal variant', () => {
+		render(
+			withRouter(<UpgradePrompt feature="custom_branding" variant="modal" />),
+		);
+		expect(screen.getByRole('heading')).toBeDefined();
+	});
+
+	it('fires onDismiss when modal close clicked', () => {
+		const onDismiss = vi.fn();
+		render(
+			withRouter(
+				<UpgradePrompt
+					feature="custom_branding"
+					variant="modal"
+					onDismiss={onDismiss}
+				/>,
+			),
+		);
+		screen.getByRole('button', { name: 'Close' }).click();
+		expect(onDismiss).toHaveBeenCalledOnce();
+	});
+
+	it('renders unknown feature with fallback label', () => {
+		render(
+			withRouter(
+				<UpgradePrompt
+					feature={'completely_unknown' as 'custom_branding'}
+					variant="inline"
+				/>,
+			),
+		);
+		expect(screen.getByText(/Completely Unknown/)).toBeDefined();
+	});
+});
+
+describe('UpgradeLimitWarning', () => {
+	it('renders nothing when below 80% usage', () => {
+		const { container } = render(
+			withRouter(
+				<UpgradeLimitWarning type="agents" current={10} limit={100} />,
+			),
+		);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders amber warning when near limit (80-99%)', () => {
+		render(
+			withRouter(
+				<UpgradeLimitWarning type="agents" current={85} limit={100} />,
+			),
+		);
+		expect(screen.getByText(/Approaching/)).toBeDefined();
+	});
+
+	it('renders red warning when at limit (>=100%)', () => {
+		render(
+			withRouter(
+				<UpgradeLimitWarning type="agents" current={100} limit={100} />,
+			),
+		);
+		expect(screen.getByText(/limit reached/)).toBeDefined();
+	});
+
+	it('formats storage values in GB/TB', () => {
+		const oneGB = 1024 * 1024 * 1024;
+		render(
+			withRouter(
+				<UpgradeLimitWarning
+					type="storage"
+					current={oneGB * 80}
+					limit={oneGB * 100}
+				/>,
+			),
+		);
+		expect(screen.getByText(/80.0 GB/)).toBeDefined();
+	});
+});


### PR DESCRIPTION
## Summary
Smoke tests for the final 15 components. **Every component in src/components/ now has a *_test.tsx file.**

Tested: ActivityFeed, AgentLogViewer, BackupCalendar, BackupQueuePanel, ContainerHooksEditor, DockerRestoreWizard, DockerStackSelector, ExportImportModal, GlobalSearchBar, ImportAgentsWizard, ImportRepositoryWizard, MetadataEditor, MetadataSchemaManager, RecentItems, UpgradePrompt (+ UpgradeLimitWarning).

## Metrics
- vitest now **238** test files passing (was 223 after PR #277)
- biome clean (509 files)
- tsc --noEmit clean

## Test plan
- [x] vitest clean
- [x] biome clean
- [x] tsc --noEmit clean