### PR TITLE
Tests for Go middleware (limits/ipfilter/superuser) + web lib/upgrade

### DIFF
--- a/internal/api/middleware/ipfilter_test.go
+++ b/internal/api/middleware/ipfilter_test.go
@@ -1,0 +1,157 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/MacJediWizard/keldris/internal/models"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+)
+
+type stubIPFilterStore struct {
+	settings    *models.IPAllowlistSettings
+	allowlist   []*models.IPAllowlist
+	user        *models.User
+	settingsErr error
+	allowErr    error
+}
+
+func (s *stubIPFilterStore) GetOrCreateIPAllowlistSettings(_ context.Context, _ uuid.UUID) (*models.IPAllowlistSettings, error) {
+	if s.settingsErr != nil {
+		return nil, s.settingsErr
+	}
+	if s.settings != nil {
+		return s.settings, nil
+	}
+	return &models.IPAllowlistSettings{Enabled: false}, nil
+}
+
+func (s *stubIPFilterStore) ListEnabledIPAllowlistsByOrg(_ context.Context, _ uuid.UUID, _ models.IPAllowlistType) ([]*models.IPAllowlist, error) {
+	return s.allowlist, s.allowErr
+}
+
+func (s *stubIPFilterStore) CreateIPBlockedAttempt(_ context.Context, _ *models.IPBlockedAttempt) error {
+	return nil
+}
+
+func (s *stubIPFilterStore) GetUserByID(_ context.Context, _ uuid.UUID) (*models.User, error) {
+	return s.user, nil
+}
+
+func TestNewIPFilterCache(t *testing.T) {
+	cache := NewIPFilterCache(5 * time.Second)
+	if cache == nil {
+		t.Fatal("expected non-nil cache")
+	}
+}
+
+func TestNewIPFilter(t *testing.T) {
+	filter := NewIPFilter(&stubIPFilterStore{}, zerolog.Nop())
+	if filter == nil {
+		t.Fatal("expected non-nil filter")
+	}
+}
+
+func TestCheckIP_DisabledAllowsAll(t *testing.T) {
+	store := &stubIPFilterStore{settings: &models.IPAllowlistSettings{Enabled: false}}
+	filter := NewIPFilter(store, zerolog.Nop())
+
+	allowed, _ := filter.CheckIP(context.Background(), uuid.New(), "1.2.3.4", models.IPAllowlistTypeUI, false)
+	if !allowed {
+		t.Fatal("expected allowed when filtering disabled")
+	}
+}
+
+func TestCheckIP_StoreErrorFailsOpen(t *testing.T) {
+	store := &stubIPFilterStore{settingsErr: errors.New("db down")}
+	filter := NewIPFilter(store, zerolog.Nop())
+
+	allowed, _ := filter.CheckIP(context.Background(), uuid.New(), "1.2.3.4", models.IPAllowlistTypeUI, false)
+	if !allowed {
+		t.Fatal("expected allowed on store error (fail-open)")
+	}
+}
+
+func TestCheckIP_UINotEnforced(t *testing.T) {
+	store := &stubIPFilterStore{settings: &models.IPAllowlistSettings{Enabled: true, EnforceForUI: false}}
+	filter := NewIPFilter(store, zerolog.Nop())
+
+	allowed, _ := filter.CheckIP(context.Background(), uuid.New(), "1.2.3.4", models.IPAllowlistTypeUI, false)
+	if !allowed {
+		t.Fatal("expected allowed when UI not enforced")
+	}
+}
+
+func TestCheckIP_AdminBypass(t *testing.T) {
+	store := &stubIPFilterStore{
+		settings: &models.IPAllowlistSettings{
+			Enabled:          true,
+			EnforceForUI:     true,
+			AllowAdminBypass: true,
+		},
+	}
+	filter := NewIPFilter(store, zerolog.Nop())
+
+	allowed, _ := filter.CheckIP(context.Background(), uuid.New(), "1.2.3.4", models.IPAllowlistTypeUI, true)
+	if !allowed {
+		t.Fatal("expected admin bypass to allow")
+	}
+}
+
+func TestCheckIP_NoEntriesDenied(t *testing.T) {
+	store := &stubIPFilterStore{
+		settings:  &models.IPAllowlistSettings{Enabled: true, EnforceForUI: true},
+		allowlist: []*models.IPAllowlist{},
+	}
+	filter := NewIPFilter(store, zerolog.Nop())
+
+	allowed, reason := filter.CheckIP(context.Background(), uuid.New(), "1.2.3.4", models.IPAllowlistTypeUI, false)
+	if allowed {
+		t.Fatal("expected denied when no entries configured")
+	}
+	if reason == "" {
+		t.Fatal("expected reason to be set")
+	}
+}
+
+func TestCheckIP_AllowedByCIDR(t *testing.T) {
+	store := &stubIPFilterStore{
+		settings: &models.IPAllowlistSettings{Enabled: true, EnforceForUI: true},
+		allowlist: []*models.IPAllowlist{
+			{CIDR: "10.0.0.0/8", Type: models.IPAllowlistTypeUI},
+		},
+	}
+	filter := NewIPFilter(store, zerolog.Nop())
+
+	allowed, _ := filter.CheckIP(context.Background(), uuid.New(), "10.1.2.3", models.IPAllowlistTypeUI, false)
+	if !allowed {
+		t.Fatal("expected 10.1.2.3 allowed by 10.0.0.0/8")
+	}
+}
+
+func TestCheckIP_DeniedNotInCIDR(t *testing.T) {
+	store := &stubIPFilterStore{
+		settings: &models.IPAllowlistSettings{Enabled: true, EnforceForUI: true},
+		allowlist: []*models.IPAllowlist{
+			{CIDR: "10.0.0.0/8", Type: models.IPAllowlistTypeUI},
+		},
+	}
+	filter := NewIPFilter(store, zerolog.Nop())
+
+	allowed, reason := filter.CheckIP(context.Background(), uuid.New(), "192.168.1.1", models.IPAllowlistTypeUI, false)
+	if allowed {
+		t.Fatal("expected 192.168.1.1 denied")
+	}
+	if reason == "" {
+		t.Fatal("expected reason")
+	}
+}
+
+func TestInvalidateCache(t *testing.T) {
+	filter := NewIPFilter(&stubIPFilterStore{}, zerolog.Nop())
+	// Should not panic
+	filter.InvalidateCache(uuid.New())
+}

--- a/internal/api/middleware/limits_test.go
+++ b/internal/api/middleware/limits_test.go
@@ -1,0 +1,159 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/MacJediWizard/keldris/internal/auth"
+	"github.com/MacJediWizard/keldris/internal/license"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+)
+
+type stubCounter struct {
+	agents, users, orgs int
+	err                 error
+}
+
+func (s *stubCounter) CountAgentsByOrgID(_ context.Context, _ uuid.UUID) (int, error) {
+	return s.agents, s.err
+}
+
+func (s *stubCounter) CountUsersByOrgID(_ context.Context, _ uuid.UUID) (int, error) {
+	return s.users, s.err
+}
+
+func (s *stubCounter) CountOrganizations(_ context.Context) (int, error) {
+	return s.orgs, s.err
+}
+
+func setupLimitRouter(counter ResourceCounter, resource string, user *auth.SessionUser, lic *license.License) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		if user != nil {
+			c.Set(string(UserContextKey), user)
+		}
+		if lic != nil {
+			c.Set(string(LicenseContextKey), lic)
+		}
+		c.Next()
+	})
+	r.POST("/x", LimitMiddleware(counter, resource, zerolog.Nop()), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+	return r
+}
+
+func TestLimitMiddleware_NoUserPasses(t *testing.T) {
+	counter := &stubCounter{agents: 999}
+	r := setupLimitRouter(counter, "agents", nil, license.FreeLicense())
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/x", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 when no user, got %d", w.Code)
+	}
+}
+
+func TestLimitMiddleware_UnlimitedPasses(t *testing.T) {
+	user := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: uuid.New()}
+	lic := &license.License{Tier: license.TierEnterprise, Limits: license.TierLimits{MaxAgents: -1}}
+	counter := &stubCounter{agents: 999999}
+	r := setupLimitRouter(counter, "agents", user, lic)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/x", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for unlimited, got %d", w.Code)
+	}
+}
+
+func TestLimitMiddleware_UnderLimitPasses(t *testing.T) {
+	user := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: uuid.New()}
+	lic := &license.License{Tier: license.TierFree, Limits: license.TierLimits{MaxAgents: 5}}
+	counter := &stubCounter{agents: 3}
+	r := setupLimitRouter(counter, "agents", user, lic)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/x", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 under limit, got %d", w.Code)
+	}
+}
+
+func TestLimitMiddleware_AtLimitBlocked(t *testing.T) {
+	user := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: uuid.New()}
+	lic := &license.License{Tier: license.TierFree, Limits: license.TierLimits{MaxAgents: 5}}
+	counter := &stubCounter{agents: 5}
+	r := setupLimitRouter(counter, "agents", user, lic)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/x", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusPaymentRequired {
+		t.Fatalf("expected 402 at limit, got %d", w.Code)
+	}
+}
+
+func TestLimitMiddleware_UsersResource(t *testing.T) {
+	user := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: uuid.New()}
+	lic := &license.License{Tier: license.TierFree, Limits: license.TierLimits{MaxUsers: 2}}
+	counter := &stubCounter{users: 2}
+	r := setupLimitRouter(counter, "users", user, lic)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/x", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusPaymentRequired {
+		t.Fatalf("expected 402 for users limit, got %d", w.Code)
+	}
+}
+
+func TestLimitMiddleware_OrganizationsResource(t *testing.T) {
+	user := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: uuid.New()}
+	lic := &license.License{Tier: license.TierFree, Limits: license.TierLimits{MaxOrgs: 1}}
+	counter := &stubCounter{orgs: 1}
+	r := setupLimitRouter(counter, "organizations", user, lic)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/x", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusPaymentRequired {
+		t.Fatalf("expected 402 for orgs limit, got %d", w.Code)
+	}
+}
+
+func TestLimitMiddleware_UnknownResourcePassesThrough(t *testing.T) {
+	user := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: uuid.New()}
+	lic := license.FreeLicense()
+	counter := &stubCounter{}
+	r := setupLimitRouter(counter, "unknown", user, lic)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/x", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for unknown resource, got %d", w.Code)
+	}
+}
+
+func TestLimitMiddleware_CounterErrorPassesThrough(t *testing.T) {
+	user := &auth.SessionUser{ID: uuid.New(), CurrentOrgID: uuid.New()}
+	lic := &license.License{Tier: license.TierFree, Limits: license.TierLimits{MaxAgents: 5}}
+	counter := &stubCounter{err: context.DeadlineExceeded}
+	r := setupLimitRouter(counter, "agents", user, lic)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/x", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 on counter error (fail-open), got %d", w.Code)
+	}
+}

--- a/internal/api/middleware/superuser_test.go
+++ b/internal/api/middleware/superuser_test.go
@@ -1,0 +1,167 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/MacJediWizard/keldris/internal/auth"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+)
+
+func injectUser(user *auth.SessionUser) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if user != nil {
+			c.Set(string(UserContextKey), user)
+		}
+		c.Next()
+	}
+}
+
+func TestSuperuserMiddleware_NoUser401(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/x", SuperuserMiddleware(nil, zerolog.Nop()), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/x", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestSuperuserMiddleware_NonSuperuser403(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(injectUser(&auth.SessionUser{ID: uuid.New()}))
+	r.GET("/x", SuperuserMiddleware(nil, zerolog.Nop()), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/x", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", w.Code)
+	}
+}
+
+func TestSuperuserMiddleware_SuperuserPasses(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(injectUser(&auth.SessionUser{ID: uuid.New(), IsSuperuser: true}))
+	r.GET("/x", SuperuserMiddleware(nil, zerolog.Nop()), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/x", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestRequireSuperuser_NoUser401(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/x", func(c *gin.Context) {
+		if RequireSuperuser(c) == nil {
+			return
+		}
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/x", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestRequireSuperuser_NonSuperuser403(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(injectUser(&auth.SessionUser{ID: uuid.New()}))
+	r.GET("/x", func(c *gin.Context) {
+		if RequireSuperuser(c) == nil {
+			return
+		}
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/x", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", w.Code)
+	}
+}
+
+func TestIsSuperuser_True(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(injectUser(&auth.SessionUser{ID: uuid.New(), IsSuperuser: true}))
+	r.GET("/x", func(c *gin.Context) {
+		if !IsSuperuser(c) {
+			c.Status(http.StatusForbidden)
+			return
+		}
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/x", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestIsImpersonating(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	t.Run("false when not impersonating", func(t *testing.T) {
+		r := gin.New()
+		r.Use(injectUser(&auth.SessionUser{ID: uuid.New()}))
+		r.GET("/x", func(c *gin.Context) {
+			if IsImpersonating(c) {
+				c.Status(http.StatusForbidden)
+				return
+			}
+			c.Status(http.StatusOK)
+		})
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/x", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200 when not impersonating, got %d", w.Code)
+		}
+	})
+
+	t.Run("true when ImpersonatingID is set", func(t *testing.T) {
+		r := gin.New()
+		impID := uuid.New()
+		r.Use(injectUser(&auth.SessionUser{ID: uuid.New(), ImpersonatingID: impID}))
+		r.GET("/x", func(c *gin.Context) {
+			if !IsImpersonating(c) {
+				c.Status(http.StatusForbidden)
+				return
+			}
+			c.Status(http.StatusOK)
+		})
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/x", nil)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200 when impersonating, got %d", w.Code)
+		}
+	})
+}

--- a/web/src/lib/upgrade.test.ts
+++ b/web/src/lib/upgrade.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import {
+	PLAN_NAMES,
+	PLAN_PRICING,
+	generateContactSalesLink,
+	generateUpgradeLink,
+	getNextPlan,
+	needsUpgrade,
+	requiresSales,
+} from './upgrade';
+
+describe('generateUpgradeLink', () => {
+	it('returns base path with no params', () => {
+		expect(generateUpgradeLink()).toBe('/organization/license');
+	});
+
+	it('includes feature param', () => {
+		expect(generateUpgradeLink({ feature: 'sso' })).toBe(
+			'/organization/license?feature=sso',
+		);
+	});
+
+	it('includes all params', () => {
+		const url = generateUpgradeLink({
+			feature: 'sso',
+			source: 'banner',
+			targetPlan: 'professional',
+		});
+		expect(url).toContain('feature=sso');
+		expect(url).toContain('source=banner');
+		expect(url).toContain('plan=professional');
+	});
+});
+
+describe('generateContactSalesLink', () => {
+	it('returns base path with no params', () => {
+		expect(generateContactSalesLink()).toBe('/organization/license');
+	});
+
+	it('maps feature to interest param', () => {
+		expect(generateContactSalesLink({ feature: 'sso' })).toBe(
+			'/organization/license?interest=sso',
+		);
+	});
+
+	it('includes source', () => {
+		const url = generateContactSalesLink({
+			feature: 'sso',
+			source: 'modal',
+		});
+		expect(url).toContain('interest=sso');
+		expect(url).toContain('source=modal');
+	});
+});
+
+describe('needsUpgrade', () => {
+	it('returns true when target is higher tier', () => {
+		expect(needsUpgrade('free', 'professional')).toBe(true);
+		expect(needsUpgrade('starter', 'enterprise')).toBe(true);
+	});
+
+	it('returns false when target is same or lower tier', () => {
+		expect(needsUpgrade('professional', 'free')).toBe(false);
+		expect(needsUpgrade('professional', 'professional')).toBe(false);
+	});
+});
+
+describe('getNextPlan', () => {
+	it('returns next tier in order', () => {
+		expect(getNextPlan('free')).toBe('starter');
+		expect(getNextPlan('starter')).toBe('professional');
+		expect(getNextPlan('professional')).toBe('enterprise');
+	});
+
+	it('returns null at top tier', () => {
+		expect(getNextPlan('enterprise')).toBeNull();
+	});
+});
+
+describe('requiresSales', () => {
+	it('returns true for enterprise only', () => {
+		expect(requiresSales('enterprise')).toBe(true);
+		expect(requiresSales('professional')).toBe(false);
+		expect(requiresSales('starter')).toBe(false);
+		expect(requiresSales('free')).toBe(false);
+	});
+});
+
+describe('PLAN_NAMES + PLAN_PRICING', () => {
+	it('PLAN_NAMES has entry for each tier', () => {
+		expect(PLAN_NAMES.free).toBe('Free');
+		expect(PLAN_NAMES.starter).toBe('Starter');
+		expect(PLAN_NAMES.professional).toBe('Professional');
+		expect(PLAN_NAMES.enterprise).toBe('Enterprise');
+	});
+
+	it('PLAN_PRICING enterprise tier says Contact Sales', () => {
+		expect(PLAN_PRICING.enterprise).toBe('Contact Sales');
+	});
+});


### PR DESCRIPTION
## Summary
Adds 4 new test files closing the remaining middleware + lib coverage gaps.

### Go middleware (3 new files)
- **limits_test.go** (8 tests): all branches of LimitMiddleware — no-user, unlimited tier, under-limit, at-limit 402, per-resource paths (agents/users/orgs), unknown-resource passthrough, counter-error fail-open.
- **ipfilter_test.go** (9 tests): NewIPFilterCache, NewIPFilter, CheckIP branches (disabled, store-error fail-open, UI not enforced, admin bypass, no entries denied, allowed by CIDR, denied not in CIDR), InvalidateCache.
- **superuser_test.go** (7 tests): SuperuserMiddleware (401/403/200), RequireSuperuser helper, IsSuperuser, IsImpersonating.

### Frontend
- **web/src/lib/upgrade.test.ts** (13 tests): generateUpgradeLink, generateContactSalesLink, needsUpgrade, getNextPlan, requiresSales, PLAN_NAMES/PRICING tables.

## Metrics
- vitest now **239** files passing
- go test ./internal/api/middleware/ clean
- biome + tsc clean

## Test plan
- [x] vitest clean
- [x] go test -short ./... clean
- [x] biome clean
- [x] tsc --noEmit clean