### PR TITLE
Fix CI: remove unused tier field from mockLegalHoldStore

### DIFF
--- a/internal/api/handlers/legal_holds_test.go
+++ b/internal/api/handlers/legal_holds_test.go
@@ -21,7 +21,6 @@ type mockLegalHoldStore struct {
 	agent     *models.Agent
 	statusMap map[string]bool
 	onHold    bool
-	tier      license.Tier
 	err       error
 }
 


### PR DESCRIPTION
## Summary
Removes one unused struct field that was tripping staticcheck (U1000) on every CI run since PR #279.

```
internal/api/handlers/legal_holds_test.go:24:2: field tier is unused (U1000)
```

No behavior change.

## Test plan
- [x] `go test -race -short ./...` clean
- [x] `staticcheck ./...` clean
- [x] `go vet ./...` clean